### PR TITLE
Add Mollweide projection view

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -69,15 +69,23 @@ export function computeConnectionPairs(stars, maxDistance) {
  * @param {Array} connectionObjs - Array of connection objects.
  * @returns {THREE.LineSegments} - The merged connection lines.
  */
-export function mergeConnectionLines(connectionObjs) {
+export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates') {
   const positions = [];
   const colors = [];
-  
+
   connectionObjs.forEach(pair => {
     const { starA, starB } = pair;
-    
-    const posA = getPosition(starA);
-    const posB = getPosition(starB);
+    let posA, posB;
+    if (mapType === 'Globe') {
+      posA = starA.spherePosition;
+      posB = starB.spherePosition;
+    } else if (mapType === 'Mollweide') {
+      posA = starA.mollweidePosition;
+      posB = starB.mollweidePosition;
+    } else {
+      posA = getPosition(starA);
+      posB = getPosition(starB);
+    }
     
     positions.push(posA.x, posA.y, posA.z);
     positions.push(posB.x, posB.y, posB.z);
@@ -125,6 +133,10 @@ export function createConnectionLines(stars, pairs, mapType) {
       if (!starA.spherePosition || !starB.spherePosition) return;
       posA = new THREE.Vector3(starA.spherePosition.x, starA.spherePosition.y, starA.spherePosition.z);
       posB = new THREE.Vector3(starB.spherePosition.x, starB.spherePosition.y, starB.spherePosition.z);
+    } else if (mapType === 'Mollweide') {
+      if (!starA.mollweidePosition || !starB.mollweidePosition) return;
+      posA = new THREE.Vector3(starA.mollweidePosition.x, starA.mollweidePosition.y, starA.mollweidePosition.z);
+      posB = new THREE.Vector3(starB.mollweidePosition.x, starB.mollweidePosition.y, starB.mollweidePosition.z);
     } else {
       // Use the computed truePosition if available
       posA = getPosition(starA).clone();

--- a/index.html
+++ b/index.html
@@ -187,6 +187,11 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
         <canvas id="sphereMap"></canvas>
       </div>
+      <div class="map-container">
+        <h2>Mollweide Map</h2>
+        <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
+        <canvas id="mollweideMap"></canvas>
+      </div>
     </section>
   </div>
 

--- a/labelManager.js
+++ b/labelManager.js
@@ -158,10 +158,12 @@ export class LabelManager {
     // Update positions:
     // For TrueCoordinates map, use star.truePosition if available.
     const starPos = (this.mapType === 'TrueCoordinates')
-      ? (star.truePosition 
+      ? (star.truePosition
           ? new THREE.Vector3(star.truePosition.x, star.truePosition.y, star.truePosition.z)
           : new THREE.Vector3(star.x_coordinate, star.y_coordinate, star.z_coordinate))
-      : new THREE.Vector3(star.spherePosition.x, star.spherePosition.y, star.spherePosition.z);
+      : (this.mapType === 'Globe'
+          ? new THREE.Vector3(star.spherePosition.x, star.spherePosition.y, star.spherePosition.z)
+          : new THREE.Vector3(star.mollweidePosition.x, star.mollweidePosition.y, star.mollweidePosition.z));
 
     const offset = this.computeLabelOffset(star, starPos);
     const labelPos = starPos.clone().add(offset);
@@ -189,7 +191,7 @@ export class LabelManager {
    * Simple helper to compute label offset from star position, so the label doesn't overlap the star mesh.
    */
   computeLabelOffset(star, starPos) {
-    if (this.mapType === 'TrueCoordinates') {
+    if (this.mapType === 'TrueCoordinates' || this.mapType === 'Mollweide') {
       // Small offset in X and Y
       return new THREE.Vector3(1, 1, 0).multiplyScalar(
         THREE.MathUtils.clamp(star.displaySize / 2, 0.5, 1.5)

--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@ import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct impo
 import { ThreeDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
 import { showTooltip, hideTooltip } from './tooltips.js';
-import { cachedRadToSphere, degToRad } from './utils/geometryUtils.js';
+import { cachedRadToSphere, cachedRadToMollweide, degToRad } from './utils/geometryUtils.js';
 
 let cachedStars = null;
 let currentFilteredStars = [];
@@ -20,8 +20,10 @@ let currentGlobeConnections = [];
 let selectedStarData = null;
 let selectedHighlightTrue = null;
 let selectedHighlightGlobe = null;
+let selectedHighlightMollweide = null;
 let trueCoordinatesMap;
 let globeMap;
+let mollweideMap;
 let constellationLinesGlobe = [];
 let constellationLabelsGlobe = [];
 let constellationOverlayGlobe = [];
@@ -59,6 +61,22 @@ function projectStarGlobe(star) {
     dec = 0;
   }
   return cachedRadToSphere(ra, dec, R);
+}
+
+function projectStarMollweide(star) {
+  const R = 100;
+  let ra, dec;
+  if (star.RA_in_radian !== undefined && star.DEC_in_radian !== undefined) {
+    ra = star.RA_in_radian;
+    dec = star.DEC_in_radian;
+  } else if (star.RA_in_degrees !== undefined && star.DEC_in_degrees !== undefined) {
+    ra = degToRad(star.RA_in_degrees);
+    dec = degToRad(star.DEC_in_degrees);
+  } else {
+    ra = 0;
+    dec = 0;
+  }
+  return cachedRadToMollweide(ra, dec, R, 0);
 }
 
 function createGlobeGrid(R = 100, options = {}) {
@@ -170,12 +188,15 @@ async function buildAndApplyFilters() {
   });
   currentFilteredStars.forEach(star => {
     star.truePosition = getStarTruePosition(star);
+    star.mollweidePosition = projectStarMollweide(star);
   });
 
   trueCoordinatesMap.updateMap(currentFilteredStars, currentConnections);
   trueCoordinatesMap.labelManager.refreshLabels(currentFilteredStars);
   globeMap.updateMap(currentGlobeFilteredStars, currentGlobeConnections);
   globeMap.labelManager.refreshLabels(currentGlobeFilteredStars);
+  mollweideMap.updateMap(currentFilteredStars, currentConnections);
+  mollweideMap.labelManager.refreshLabels(currentFilteredStars);
 
   removeConstellationObjectsFromGlobe();
   removeConstellationOverlayObjectsFromGlobe();
@@ -265,6 +286,8 @@ class MapManager {
     );
     if (mapType === 'TrueCoordinates') {
       this.camera.position.set(0, 0, 70);
+    } else if (mapType === 'Globe') {
+      this.camera.position.set(0, 0, 200);
     } else {
       this.camera.position.set(0, 0, 200);
     }
@@ -314,8 +337,10 @@ class MapManager {
       let pos;
       if (this.mapType === 'TrueCoordinates') {
         pos = star.truePosition ? star.truePosition.clone() : new THREE.Vector3(star.x_coordinate, star.y_coordinate, star.z_coordinate);
-      } else {
+      } else if (this.mapType === 'Globe') {
         pos = star.spherePosition ? star.spherePosition.clone() : new THREE.Vector3(0, 0, 0);
+      } else {
+        pos = star.mollweidePosition ? star.mollweidePosition.clone() : new THREE.Vector3(0, 0, 0);
       }
       const size = star.displaySize !== undefined ? star.displaySize : 1;
       const scale = size * 0.2;
@@ -345,7 +370,7 @@ class MapManager {
       const linesArray = createConnectionLines(stars, connectionObjs, 'Globe');
       linesArray.forEach(line => this.connectionGroup.add(line));
     } else {
-      const merged = mergeConnectionLines(connectionObjs);
+      const merged = mergeConnectionLines(connectionObjs, this.mapType);
       this.connectionGroup.add(merged);
     }
     this.scene.add(this.connectionGroup);
@@ -444,6 +469,10 @@ function updateSelectedStarHighlight() {
     globeMap.scene.remove(selectedHighlightGlobe);
     selectedHighlightGlobe = null;
   }
+  if (selectedHighlightMollweide) {
+    mollweideMap.scene.remove(selectedHighlightMollweide);
+    selectedHighlightMollweide = null;
+  }
   if (!selectedStarData) return;
   let posTrue = selectedStarData.truePosition ? selectedStarData.truePosition : new THREE.Vector3(selectedStarData.x_coordinate, selectedStarData.y_coordinate, selectedStarData.z_coordinate);
   let radius = (selectedStarData.displaySize || 2) * 0.2 * 1.2;
@@ -460,6 +489,14 @@ function updateSelectedStarHighlight() {
   selectedHighlightGlobe = new THREE.Mesh(highlightGeomGlobe, highlightMatGlobe);
   selectedHighlightGlobe.position.copy(posGlobe);
   globeMap.scene.add(selectedHighlightGlobe);
+
+  let posMoll = selectedStarData.mollweidePosition ? selectedStarData.mollweidePosition : projectStarMollweide(selectedStarData);
+  let radiusMoll = (selectedStarData.displaySize || 2) * 0.2 * 1.2;
+  const highlightGeomMoll = new THREE.SphereGeometry(radiusMoll, 16, 16);
+  const highlightMatMoll = new THREE.MeshBasicMaterial({ color: 0xffff00, wireframe: true });
+  selectedHighlightMollweide = new THREE.Mesh(highlightGeomMoll, highlightMatMoll);
+  selectedHighlightMollweide.position.copy(posMoll);
+  mollweideMap.scene.add(selectedHighlightMollweide);
 }
 
 async function main() {
@@ -476,17 +513,21 @@ async function main() {
     }
     trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });
     globeMap = new MapManager({ canvasId: 'sphereMap', mapType: 'Globe' });
+    mollweideMap = new MapManager({ canvasId: 'mollweideMap', mapType: 'Mollweide' });
     window.trueCoordinatesMap = trueCoordinatesMap;
     window.globeMap = globeMap;
+    window.mollweideMap = mollweideMap;
     cachedStars.forEach(star => {
       star.spherePosition = projectStarGlobe(star);
       star.truePosition = getStarTruePosition(star);
+      star.mollweidePosition = projectStarMollweide(star);
     });
     const globeGrid = createGlobeGrid(100, { color: 0x444444, opacity: 0.2, lineWidth: 1 });
     globeMap.scene.add(globeGrid);
     buildAndApplyFilters();
     initStarInteractions(trueCoordinatesMap);
     initStarInteractions(globeMap);
+    initStarInteractions(mollweideMap);
     loader.classList.add('hidden');
   } catch (err) {
     console.error('Error initializing starmap:', err);

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -1,5 +1,6 @@
 // utils/geometryUtils.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { minimalRADifference } from '../utils.js';
 
 /**
  * Converts RA and DEC (in radians) to a THREE.Vector3 on a sphere of radius R.
@@ -146,5 +147,39 @@ export function cachedRadToSphere(ra, dec, R) {
   }
   const vec = radToSphere(ra, dec, R);
   radToSphereCache.set(key, vec.clone());
+  return vec;
+}
+
+/**
+ * Converts RA and DEC (in radians) to Mollweide projection coordinates.
+ * @param {number} ra
+ * @param {number} dec
+ * @param {number} [R=100]
+ * @param {number} [lambda0=0] - Central meridian in radians.
+ * @returns {THREE.Vector3}
+ */
+export function radToMollweide(ra, dec, R = 100, lambda0 = 0) {
+  const lambda = minimalRADifference(ra - lambda0);
+  const phi = dec;
+  let theta = phi;
+  for (let i = 0; i < 10; i++) {
+    const delta = (2 * theta + Math.sin(2 * theta) - Math.PI * Math.sin(phi)) /
+      (2 + 2 * Math.cos(2 * theta));
+    theta -= delta;
+    if (Math.abs(delta) < 1e-10) break;
+  }
+  const x = (2 * R / Math.PI) * lambda * Math.cos(theta);
+  const y = R * Math.sin(theta);
+  return new THREE.Vector3(x, y, 0);
+}
+
+const radToMollweideCache = new Map();
+export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = 0) {
+  const key = `${ra}_${dec}_${R}_${lambda0}`;
+  if (radToMollweideCache.has(key)) {
+    return radToMollweideCache.get(key).clone();
+  }
+  const vec = radToMollweide(ra, dec, R, lambda0);
+  radToMollweideCache.set(key, vec.clone());
   return vec;
 }


### PR DESCRIPTION
## Summary
- implement Mollweide projection math in `utils/geometryUtils.js`
- render a new Mollweide map alongside the existing maps
- support Mollweide positions and interactions in `script.js`
- allow labels and connection lines to work with the new map
- update HTML layout for the new canvas

## Testing
- `node --check script.js`
- `node --check labelManager.js`
- `node --check filters/connectionsFilter.js`

------
https://chatgpt.com/codex/tasks/task_e_6845c05ee058832a82ed897bc7331c7d