### PR TITLE
Fix Mollweide map to be 2D

### DIFF
--- a/cameraControls.js
+++ b/cameraControls.js
@@ -261,3 +261,128 @@ export class ThreeDControls {
         this.domElement.removeEventListener('touchcancel', this.onTouchEnd, false);
     }
 }
+
+/* ----------------------------
+   TwoDControls Class
+   ---------------------------- */
+/**
+ * Provides pan and zoom controls for 2D maps using an OrthographicCamera.
+ */
+export class TwoDControls {
+    constructor(camera, domElement) {
+        this.camera = camera;
+        this.domElement = domElement;
+
+        this.isPanning = false;
+        this.lastPos = { x: 0, y: 0 };
+        this.isPinching = false;
+        this.touchStartDistance = 0;
+
+        this.onMouseDown = this.onMouseDown.bind(this);
+        this.onMouseMove = this.onMouseMove.bind(this);
+        this.onMouseUp = this.onMouseUp.bind(this);
+        this.onWheel = this.onWheel.bind(this);
+        this.onTouchStart = this.onTouchStart.bind(this);
+        this.onTouchMove = this.onTouchMove.bind(this);
+        this.onTouchEnd = this.onTouchEnd.bind(this);
+
+        domElement.addEventListener('mousedown', this.onMouseDown, false);
+        domElement.addEventListener('mousemove', this.onMouseMove, false);
+        domElement.addEventListener('mouseup', this.onMouseUp, false);
+        domElement.addEventListener('wheel', this.onWheel, false);
+
+        domElement.addEventListener('touchstart', this.onTouchStart, false);
+        domElement.addEventListener('touchmove', this.onTouchMove, false);
+        domElement.addEventListener('touchend', this.onTouchEnd, false);
+        domElement.addEventListener('touchcancel', this.onTouchEnd, false);
+    }
+
+    getScale() {
+        return {
+            x: (this.camera.right - this.camera.left) / this.domElement.clientWidth,
+            y: (this.camera.top - this.camera.bottom) / this.domElement.clientHeight
+        };
+    }
+
+    pan(dx, dy) {
+        const scale = this.getScale();
+        this.camera.position.x -= dx * scale.x;
+        this.camera.position.y += dy * scale.y;
+    }
+
+    onMouseDown(event) {
+        this.isPanning = true;
+        this.lastPos = { x: event.clientX, y: event.clientY };
+    }
+
+    onMouseMove(event) {
+        if (!this.isPanning) return;
+        const dx = event.clientX - this.lastPos.x;
+        const dy = event.clientY - this.lastPos.y;
+        this.pan(dx, dy);
+        this.lastPos = { x: event.clientX, y: event.clientY };
+    }
+
+    onMouseUp() {
+        this.isPanning = false;
+    }
+
+    onWheel(event) {
+        event.preventDefault();
+        const zoomFactor = event.deltaY < 0 ? 1.1 : 0.9;
+        this.camera.zoom *= zoomFactor;
+        this.camera.updateProjectionMatrix();
+    }
+
+    getTouchDistance(t1, t2) {
+        const dx = t2.clientX - t1.clientX;
+        const dy = t2.clientY - t1.clientY;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    onTouchStart(event) {
+        if (event.touches.length === 1) {
+            this.isPanning = true;
+            this.lastPos = { x: event.touches[0].clientX, y: event.touches[0].clientY };
+        } else if (event.touches.length === 2) {
+            this.isPinching = true;
+            this.touchStartDistance = this.getTouchDistance(event.touches[0], event.touches[1]);
+        }
+    }
+
+    onTouchMove(event) {
+        event.preventDefault();
+        if (this.isPinching && event.touches.length === 2) {
+            const currentDistance = this.getTouchDistance(event.touches[0], event.touches[1]);
+            const delta = currentDistance - this.touchStartDistance;
+            const zoomFactor = 1 + delta / 200;
+            this.camera.zoom *= zoomFactor;
+            this.camera.updateProjectionMatrix();
+            this.touchStartDistance = currentDistance;
+        } else if (this.isPanning && event.touches.length === 1) {
+            const touch = event.touches[0];
+            const dx = touch.clientX - this.lastPos.x;
+            const dy = touch.clientY - this.lastPos.y;
+            this.pan(dx, dy);
+            this.lastPos = { x: touch.clientX, y: touch.clientY };
+        }
+    }
+
+    onTouchEnd() {
+        this.isPanning = false;
+        this.isPinching = false;
+    }
+
+    dispose() {
+        this.domElement.removeEventListener('mousedown', this.onMouseDown, false);
+        this.domElement.removeEventListener('mousemove', this.onMouseMove, false);
+        this.domElement.removeEventListener('mouseup', this.onMouseUp, false);
+        this.domElement.removeEventListener('wheel', this.onWheel, false);
+
+        this.domElement.removeEventListener('touchstart', this.onTouchStart, false);
+        this.domElement.removeEventListener('touchmove', this.onTouchMove, false);
+        this.domElement.removeEventListener('touchend', this.onTouchEnd, false);
+        this.domElement.removeEventListener('touchcancel', this.onTouchEnd, false);
+    }
+}
+

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ import { initIsolationFilter, updateIsolationFilter } from './filters/isolationF
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
 import { applyGlobeSurfaceFilter } from './filters/globeSurfaceFilter.js';
 import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct import
-import { ThreeDControls } from './cameraControls.js';
+import { ThreeDControls, TwoDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
 import { showTooltip, hideTooltip } from './tooltips.js';
 import { cachedRadToSphere, cachedRadToMollweide, degToRad } from './utils/geometryUtils.js';
@@ -278,25 +278,41 @@ class MapManager {
     });
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
-    this.camera = new THREE.PerspectiveCamera(
-      75,
-      this.canvas.clientWidth / this.canvas.clientHeight,
-      0.1,
-      10000
-    );
-    if (mapType === 'TrueCoordinates') {
-      this.camera.position.set(0, 0, 70);
-    } else if (mapType === 'Globe') {
-      this.camera.position.set(0, 0, 200);
+    if (mapType === 'Mollweide') {
+      const aspect = this.canvas.clientWidth / this.canvas.clientHeight;
+      this.frustumSize = 200;
+      this.camera = new THREE.OrthographicCamera(
+        (-this.frustumSize * aspect) / 2,
+        (this.frustumSize * aspect) / 2,
+        this.frustumSize / 2,
+        -this.frustumSize / 2,
+        -1000,
+        1000
+      );
+      this.camera.position.set(0, 0, 10);
     } else {
-      this.camera.position.set(0, 0, 200);
+      this.camera = new THREE.PerspectiveCamera(
+        75,
+        this.canvas.clientWidth / this.canvas.clientHeight,
+        0.1,
+        10000
+      );
+      if (mapType === 'TrueCoordinates') {
+        this.camera.position.set(0, 0, 70);
+      } else {
+        this.camera.position.set(0, 0, 200);
+      }
     }
     this.scene.add(this.camera);
     const amb = new THREE.AmbientLight(0xffffff, 0.5);
     this.scene.add(amb);
     const pt = new THREE.PointLight(0xffffff, 1);
     this.scene.add(pt);
-    this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
+    if (mapType === 'Mollweide') {
+      this.controls = new TwoDControls(this.camera, this.renderer.domElement);
+    } else {
+      this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
+    }
     this.labelManager = new LabelManager(mapType, this.scene);
     this.starGroup = new THREE.Group();
     this.scene.add(this.starGroup);
@@ -384,7 +400,15 @@ class MapManager {
   onResize() {
     const w = this.canvas.clientWidth;
     const h = this.canvas.clientHeight;
-    this.camera.aspect = w / h;
+    if (this.camera.isOrthographicCamera) {
+      const aspect = w / h;
+      this.camera.left = (-this.frustumSize * aspect) / 2;
+      this.camera.right = (this.frustumSize * aspect) / 2;
+      this.camera.top = this.frustumSize / 2;
+      this.camera.bottom = -this.frustumSize / 2;
+    } else {
+      this.camera.aspect = w / h;
+    }
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(w, h);
   }


### PR DESCRIPTION
## Summary
- add `TwoDControls` for 2D pan and zoom
- create orthographic camera for the Mollweide map
- use the 2D controls and handle resizing for the orthographic projection

## Testing
- `node --check cameraControls.js`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6845d7d72148832abf64199eb0dd97a2