### PR TITLE
Add Mollweide map wrap and filter support

### DIFF
--- a/cameraControls.js
+++ b/cameraControls.js
@@ -269,9 +269,11 @@ export class ThreeDControls {
  * Provides pan and zoom controls for 2D maps using an OrthographicCamera.
  */
 export class TwoDControls {
-    constructor(camera, domElement) {
+    constructor(camera, domElement, panCallback = null) {
         this.camera = camera;
         this.domElement = domElement;
+
+        this.panCallback = panCallback;
 
         this.isPanning = false;
         this.lastPos = { x: 0, y: 0 };
@@ -308,6 +310,7 @@ export class TwoDControls {
         const scale = this.getScale();
         this.camera.position.x -= dx * scale.x;
         this.camera.position.y += dy * scale.y;
+        if (this.panCallback) this.panCallback(dx * scale.x, dy * scale.y);
     }
 
     onMouseDown(event) {

--- a/cameraControls.js
+++ b/cameraControls.js
@@ -259,6 +259,7 @@ export class ThreeDControls {
         this.domElement.removeEventListener('touchmove', this.onTouchMove, false);
         this.domElement.removeEventListener('touchend', this.onTouchEnd, false);
         this.domElement.removeEventListener('touchcancel', this.onTouchEnd, false);
+        this.domElement.removeEventListener('contextmenu', this.contextMenuHandler);
     }
 }
 
@@ -269,15 +270,18 @@ export class ThreeDControls {
  * Provides pan and zoom controls for 2D maps using an OrthographicCamera.
  */
 export class TwoDControls {
-    constructor(camera, domElement, panCallback = null, panCamera = true) {
+    constructor(camera, domElement, options = {}) {
         this.camera = camera;
         this.domElement = domElement;
 
-        this.panCallback = panCallback;
-        this.panCamera = panCamera;
+        this.leftCallback = options.leftCallback || null;
+        this.rightCallback = options.rightCallback || null;
+        this.panCameraLeft = options.panCameraLeft !== undefined ? options.panCameraLeft : true;
+        this.panCameraRight = options.panCameraRight !== undefined ? options.panCameraRight : false;
 
         this.isPanning = false;
         this.lastPos = { x: 0, y: 0 };
+        this.button = 0;
         this.isPinching = false;
         this.touchStartDistance = 0;
 
@@ -293,6 +297,8 @@ export class TwoDControls {
         domElement.addEventListener('mousemove', this.onMouseMove, false);
         domElement.addEventListener('mouseup', this.onMouseUp, false);
         domElement.addEventListener('wheel', this.onWheel, false);
+        this.contextMenuHandler = (e) => e.preventDefault();
+        domElement.addEventListener('contextmenu', this.contextMenuHandler);
 
         domElement.addEventListener('touchstart', this.onTouchStart, false);
         domElement.addEventListener('touchmove', this.onTouchMove, false);
@@ -307,17 +313,27 @@ export class TwoDControls {
         };
     }
 
-    pan(dx, dy) {
+    pan(dx, dy, button = 0) {
         const scale = this.getScale();
-        if (this.panCamera) {
-            this.camera.position.x -= dx * scale.x;
-            this.camera.position.y += dy * scale.y;
+        if (button === 2) {
+            if (this.panCameraRight) {
+                this.camera.position.x -= dx * scale.x;
+                this.camera.position.y += dy * scale.y;
+            }
+            if (this.rightCallback) this.rightCallback(dx, dy);
+        } else {
+            if (this.panCameraLeft) {
+                this.camera.position.x -= dx * scale.x;
+                this.camera.position.y += dy * scale.y;
+            }
+            if (this.leftCallback) this.leftCallback(dx, dy);
         }
-        if (this.panCallback) this.panCallback(dx, dy);
     }
 
     onMouseDown(event) {
         this.isPanning = true;
+        this.button = event.button;
+        if (this.button === 2) event.preventDefault();
         this.lastPos = { x: event.clientX, y: event.clientY };
     }
 
@@ -325,12 +341,13 @@ export class TwoDControls {
         if (!this.isPanning) return;
         const dx = event.clientX - this.lastPos.x;
         const dy = event.clientY - this.lastPos.y;
-        this.pan(dx, dy);
+        this.pan(dx, dy, this.button);
         this.lastPos = { x: event.clientX, y: event.clientY };
     }
 
     onMouseUp() {
         this.isPanning = false;
+        this.button = 0;
     }
 
     onWheel(event) {
@@ -369,7 +386,7 @@ export class TwoDControls {
             const touch = event.touches[0];
             const dx = touch.clientX - this.lastPos.x;
             const dy = touch.clientY - this.lastPos.y;
-            this.pan(dx, dy);
+            this.pan(dx, dy, 0);
             this.lastPos = { x: touch.clientX, y: touch.clientY };
         }
     }
@@ -389,6 +406,7 @@ export class TwoDControls {
         this.domElement.removeEventListener('touchmove', this.onTouchMove, false);
         this.domElement.removeEventListener('touchend', this.onTouchEnd, false);
         this.domElement.removeEventListener('touchcancel', this.onTouchEnd, false);
+        this.domElement.removeEventListener('contextmenu', this.contextMenuHandler);
     }
 }
 

--- a/cameraControls.js
+++ b/cameraControls.js
@@ -269,11 +269,12 @@ export class ThreeDControls {
  * Provides pan and zoom controls for 2D maps using an OrthographicCamera.
  */
 export class TwoDControls {
-    constructor(camera, domElement, panCallback = null) {
+    constructor(camera, domElement, panCallback = null, panCamera = true) {
         this.camera = camera;
         this.domElement = domElement;
 
         this.panCallback = panCallback;
+        this.panCamera = panCamera;
 
         this.isPanning = false;
         this.lastPos = { x: 0, y: 0 };
@@ -308,9 +309,11 @@ export class TwoDControls {
 
     pan(dx, dy) {
         const scale = this.getScale();
-        this.camera.position.x -= dx * scale.x;
-        this.camera.position.y += dy * scale.y;
-        if (this.panCallback) this.panCallback(dx * scale.x, dy * scale.y);
+        if (this.panCamera) {
+            this.camera.position.x -= dx * scale.x;
+            this.camera.position.y += dy * scale.y;
+        }
+        if (this.panCallback) this.panCallback(dx, dy);
     }
 
     onMouseDown(event) {

--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -21,7 +21,7 @@ async function loadCloudData(cloudFileUrl) {
  * is drawn as a series of small segments following the great‑circle path on a sphere.
  * @param {Array} cloudData - Array of star objects from the cloud file.
  * @param {Array} completeStarList - Complete array of star objects.
- * @param {string} mapType - Either 'TrueCoordinates' or 'Globe'.
+ * @param {string} mapType - Either 'TrueCoordinates', 'Globe', or 'Mollweide'.
  * @param {THREE.Color} cloudColor - Unique color for the cloud overlay.
  * @returns {THREE.LineSegments|null} - A THREE.LineSegments object representing the cloud overlay, or null if too few points.
  */
@@ -38,8 +38,10 @@ export async function createCloudOverlay(cloudData, completeStarList, mapType, c
       let pos = null;
       if (mapType === 'TrueCoordinates') {
         if (star.truePosition) pos = star.truePosition;
-      } else {
+      } else if (mapType === 'Globe') {
         if (star.spherePosition) pos = star.spherePosition;
+      } else {
+        if (star.mollweidePosition) pos = star.mollweidePosition;
       }
       if (pos) {
         cloudStars.push({ star, pos });
@@ -78,8 +80,13 @@ export async function createCloudOverlay(cloudData, completeStarList, mapType, c
         }
       } else {
         // For non-globe maps, simply connect p1 and p2.
-        vertices.push(p1.x, p1.y, p1.z);
-        vertices.push(p2.x, p2.y, p2.z);
+        const v1 = p1.clone();
+        const v2 = p2.clone();
+        if (mapType === 'Mollweide' && Math.abs(v1.x - v2.x) > 200) {
+          if (v1.x > v2.x) v1.x -= 400; else v2.x -= 400;
+        }
+        vertices.push(v1.x, v1.y, v1.z);
+        vertices.push(v2.x, v2.y, v2.z);
       }
     }
   }
@@ -135,7 +142,7 @@ function getCloudNameFromFileUrl(fileUrl) {
  * Each cloud is rendered with a unique color.
  * @param {Array} completeStarList - Complete array of star objects.
  * @param {THREE.Scene} scene - The scene to add the cloud overlays.
- * @param {string} mapType - 'TrueCoordinates' or 'Globe'.
+ * @param {string} mapType - 'TrueCoordinates', 'Globe', or 'Mollweide'.
  * @param {Array} cloudDataFiles - Array of file URLs for cloud data.
  */
 export async function updateCloudsOverlay(completeStarList, scene, mapType, cloudDataFiles) {

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -1,6 +1,7 @@
 // filters/connectionsFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { adjustMollweideWrap } from '../utils/geometryUtils.js';
 
 /**
  * Helper: Returns a THREE.Vector3 for a star’s position.
@@ -80,12 +81,12 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
       posA = starA.spherePosition;
       posB = starB.spherePosition;
     } else if (mapType === 'Mollweide') {
-      posA = starA.mollweidePosition.clone();
-      posB = starB.mollweidePosition.clone();
-      if (Math.abs(posA.x - posB.x) > 200) {
-        if (posA.x > posB.x) posA.x -= 400;
-        else posB.x -= 400;
-      }
+      const [a, b] = adjustMollweideWrap(
+        starA.mollweidePosition,
+        starB.mollweidePosition
+      );
+      posA = a;
+      posB = b;
     } else {
       posA = getPosition(starA);
       posB = getPosition(starB);
@@ -139,12 +140,12 @@ export function createConnectionLines(stars, pairs, mapType) {
       posB = new THREE.Vector3(starB.spherePosition.x, starB.spherePosition.y, starB.spherePosition.z);
     } else if (mapType === 'Mollweide') {
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
-      posA = new THREE.Vector3(starA.mollweidePosition.x, starA.mollweidePosition.y, starA.mollweidePosition.z);
-      posB = new THREE.Vector3(starB.mollweidePosition.x, starB.mollweidePosition.y, starB.mollweidePosition.z);
-      if (Math.abs(posA.x - posB.x) > 200) {
-        if (posA.x > posB.x) posA.x -= 400;
-        else posB.x -= 400;
-      }
+      const [a, b] = adjustMollweideWrap(
+        starA.mollweidePosition,
+        starB.mollweidePosition
+      );
+      posA = a.clone();
+      posB = b.clone();
     } else {
       // Use the computed truePosition if available
       posA = getPosition(starA).clone();

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -80,8 +80,12 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
       posA = starA.spherePosition;
       posB = starB.spherePosition;
     } else if (mapType === 'Mollweide') {
-      posA = starA.mollweidePosition;
-      posB = starB.mollweidePosition;
+      posA = starA.mollweidePosition.clone();
+      posB = starB.mollweidePosition.clone();
+      if (Math.abs(posA.x - posB.x) > 200) {
+        if (posA.x > posB.x) posA.x -= 400;
+        else posB.x -= 400;
+      }
     } else {
       posA = getPosition(starA);
       posB = getPosition(starB);
@@ -137,6 +141,10 @@ export function createConnectionLines(stars, pairs, mapType) {
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
       posA = new THREE.Vector3(starA.mollweidePosition.x, starA.mollweidePosition.y, starA.mollweidePosition.z);
       posB = new THREE.Vector3(starB.mollweidePosition.x, starB.mollweidePosition.y, starB.mollweidePosition.z);
+      if (Math.abs(posA.x - posB.x) > 200) {
+        if (posA.x > posB.x) posA.x -= 400;
+        else posB.x -= 400;
+      }
     } else {
       // Use the computed truePosition if available
       posA = getPosition(starA).clone();

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -121,6 +121,59 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
   return mergedLines;
 }
 
+export function createMollweideConnectionSegments(pairs) {
+  const segCount = pairs.length * 2; // up to 2 segments per pair
+  const positions = new Float32Array(segCount * 2 * 3);
+  const colors = new Float32Array(segCount * 2 * 3);
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  const material = new THREE.LineBasicMaterial({
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.5,
+    linewidth: 1
+  });
+  const lineSegs = new THREE.LineSegments(geometry, material);
+  lineSegs.userData.pairs = pairs;
+  updateMollweideConnectionSegments(lineSegs);
+  return lineSegs;
+}
+
+export function updateMollweideConnectionSegments(lineSegs) {
+  const pairs = lineSegs.userData.pairs || [];
+  const posAttr = lineSegs.geometry.getAttribute('position');
+  const colorAttr = lineSegs.geometry.getAttribute('color');
+  let idx = 0;
+  pairs.forEach(pair => {
+    const segs = splitMollweideWrap(
+      pair.starA.mollweidePosition,
+      pair.starB.mollweidePosition
+    );
+    const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
+    const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
+    for (let i = 0; i < 2; i++) {
+      if (i < segs.length) {
+        const s = segs[i][0];
+        const e = segs[i][1];
+        posAttr.array[idx] = s.x; posAttr.array[idx+1] = s.y; posAttr.array[idx+2] = s.z;
+        posAttr.array[idx+3] = e.x; posAttr.array[idx+4] = e.y; posAttr.array[idx+5] = e.z;
+        colorAttr.array[idx] = cA.r; colorAttr.array[idx+1] = cA.g; colorAttr.array[idx+2] = cA.b;
+        colorAttr.array[idx+3] = cB.r; colorAttr.array[idx+4] = cB.g; colorAttr.array[idx+5] = cB.b;
+      } else {
+        posAttr.array[idx] = posAttr.array[idx+1] = posAttr.array[idx+2] = 0;
+        posAttr.array[idx+3] = posAttr.array[idx+4] = posAttr.array[idx+5] = 0;
+        colorAttr.array[idx] = colorAttr.array[idx+1] = colorAttr.array[idx+2] = 0;
+        colorAttr.array[idx+3] = colorAttr.array[idx+4] = colorAttr.array[idx+5] = 0;
+      }
+      idx += 6;
+    }
+  });
+  posAttr.needsUpdate = true;
+  colorAttr.needsUpdate = true;
+  lineSegs.computeLineDistances();
+}
+
 /**
  * Creates individual connection line objects between star pairs.
  *

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -1,7 +1,7 @@
 // filters/connectionsFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { adjustMollweideWrap, splitMollweideWrap } from '../utils/geometryUtils.js';
 
 /**
  * Helper: Returns a THREE.Vector3 for a star’s position.
@@ -77,29 +77,33 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
   connectionObjs.forEach(pair => {
     const { starA, starB } = pair;
     let posA, posB;
+    const c1 = new THREE.Color(starA.displayColor || '#ffffff');
+    const c2 = new THREE.Color(starB.displayColor || '#ffffff');
     if (mapType === 'Globe') {
       posA = starA.spherePosition;
       posB = starB.spherePosition;
     } else if (mapType === 'Mollweide') {
-      const [a, b] = adjustMollweideWrap(
+      const segments = splitMollweideWrap(
         starA.mollweidePosition,
         starB.mollweidePosition
       );
-      posA = a;
-      posB = b;
+      segments.forEach(([s1, s2]) => {
+        positions.push(s1.x, s1.y, s1.z, s2.x, s2.y, s2.z);
+        const cA = new THREE.Color(starA.displayColor || '#ffffff');
+        const cB = new THREE.Color(starB.displayColor || '#ffffff');
+        colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
+      });
+      return; // continue to next pair
     } else {
       posA = getPosition(starA);
       posB = getPosition(starB);
     }
-    
     positions.push(posA.x, posA.y, posA.z);
     positions.push(posB.x, posB.y, posB.z);
-    
-    // Set each vertex's color from the star's displayColor.
+
     const cA = new THREE.Color(starA.displayColor || '#ffffff');
     const cB = new THREE.Color(starB.displayColor || '#ffffff');
-    colors.push(cA.r, cA.g, cA.b);
-    colors.push(cB.r, cB.g, cB.b);
+    colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
   });
   
   const geometry = new THREE.BufferGeometry();
@@ -134,26 +138,37 @@ export function createConnectionLines(stars, pairs, mapType) {
   pairs.forEach(pair => {
     const { starA, starB, distance } = pair;
     let posA, posB;
+    const c1 = new THREE.Color(starA.displayColor || '#ffffff');
+    const c2 = new THREE.Color(starB.displayColor || '#ffffff');
     if (mapType === 'Globe') {
       if (!starA.spherePosition || !starB.spherePosition) return;
       posA = new THREE.Vector3(starA.spherePosition.x, starA.spherePosition.y, starA.spherePosition.z);
       posB = new THREE.Vector3(starB.spherePosition.x, starB.spherePosition.y, starB.spherePosition.z);
     } else if (mapType === 'Mollweide') {
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
-      const [a, b] = adjustMollweideWrap(
+      const segments = splitMollweideWrap(
         starA.mollweidePosition,
         starB.mollweidePosition
       );
-      posA = a.clone();
-      posB = b.clone();
+      segments.forEach(([s1, s2]) => {
+        const points = [s1, s2];
+        const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
+        const materialLine = new THREE.LineBasicMaterial({
+          color: c1.clone().lerp(c2, 0.5),
+          transparent: true,
+          opacity: THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)),
+          linewidth: THREE.MathUtils.lerp(5, 1, distance / (largestPairDistance || distance))
+        });
+        const line = new THREE.Line(geometryLine, materialLine);
+        lines.push(line);
+      });
+      return;
     } else {
       // Use the computed truePosition if available
       posA = getPosition(starA).clone();
       posB = getPosition(starB).clone();
     }
     
-    const c1 = new THREE.Color(starA.displayColor || '#ffffff');
-    const c2 = new THREE.Color(starB.displayColor || '#ffffff');
     const gradientColor = c1.clone().lerp(c2, 0.5);
     
     const normDist = distance / (largestPairDistance || distance);
@@ -168,7 +183,7 @@ export function createConnectionLines(stars, pairs, mapType) {
     } else {
       points = [posA, posB];
     }
-    
+
     const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
     const materialLine = new THREE.LineBasicMaterial({
       color: gradientColor,

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,7 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -108,6 +108,26 @@ export function createConstellationBoundariesForGlobe() {
   return lines;
 }
 
+export function createConstellationBoundariesForMollweide() {
+  const lines = [];
+  const R = 100;
+  boundaryData.forEach(b => {
+    const p1 = cachedRadToMollweide(b.ra1, b.dec1, R, 0);
+    const p2 = cachedRadToMollweide(b.ra2, b.dec2, R, 0);
+    const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
+    const material = new THREE.LineDashedMaterial({
+      color: 0x888888,
+      dashSize: 2,
+      gapSize: 1,
+      linewidth: 1
+    });
+    const line = new THREE.Line(geometry, material);
+    line.computeLineDistances();
+    lines.push(line);
+  });
+  return lines;
+}
+
 /**
  * Creates constellation label meshes for the Globe.
  * The labels are rendered using a custom shader material so that they are double-sided
@@ -173,6 +193,71 @@ export function createConstellationLabelsForGlobe() {
     labels.push(label);
   });
   return labels;
+}
+
+export function createConstellationLabelsForMollweide() {
+  const labels = [];
+  const R = 100;
+  centerData.forEach(c => {
+    const p = cachedRadToMollweide(c.ra, c.dec, R, 0);
+    const baseFontSize = 300;
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.font = `${baseFontSize}px Arial`;
+    const textWidth = ctx.measureText(c.name).width;
+    canvas.width = textWidth + 20;
+    canvas.height = baseFontSize * 1.2;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.font = `${baseFontSize}px Arial`;
+    ctx.fillStyle = '#888888';
+    ctx.fillText(c.name, 10, baseFontSize);
+    const texture = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.5 });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(canvas.width / 100, canvas.height / 100, 1);
+    sprite.position.copy(p);
+    labels.push(sprite);
+  });
+  return labels;
+}
+
+export function createConstellationOverlayForMollweide() {
+  const boundaries = getConstellationBoundaries();
+  const groups = {};
+  boundaries.forEach(seg => {
+    const key1 = seg.const1 ? seg.const1.toUpperCase() : null;
+    const key2 = seg.const2 ? seg.const2.toUpperCase() : null;
+    if (key1) {
+      if (!groups[key1]) groups[key1] = [];
+      groups[key1].push(seg);
+    }
+    if (key2 && key2 !== key1) {
+      if (!groups[key2]) groups[key2] = [];
+      groups[key2].push(seg);
+    }
+  });
+  const colorMapping = computeConstellationColorMapping();
+  const overlays = [];
+  for (const constellation in groups) {
+    const segs = groups[constellation];
+    const points = [];
+    segs.forEach(seg => {
+      points.push(cachedRadToMollweide(seg.ra1, seg.dec1, 100, 0));
+      points.push(cachedRadToMollweide(seg.ra2, seg.dec2, 100, 0));
+    });
+    const shape = new THREE.Shape(points.map(p => new THREE.Vector2(p.x, p.y)));
+    const geometry = new THREE.ShapeGeometry(shape);
+    const material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(colorMapping[constellation]),
+      opacity: 0.15,
+      transparent: true,
+      side: THREE.DoubleSide,
+      depthWrite: false
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    overlays.push(mesh);
+  }
+  return overlays;
 }
 
 /**

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,7 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -113,13 +113,9 @@ export function createConstellationBoundariesForMollweide() {
   const R = 100;
   const lambda0 = getMollweideLambda0();
   boundaryData.forEach(b => {
-    const p1 = cachedRadToMollweide(b.ra1, b.dec1, R, lambda0);
-    const p2 = cachedRadToMollweide(b.ra2, b.dec2, R, lambda0);
-    const pos1 = p1.clone();
-    const pos2 = p2.clone();
-    if (Math.abs(pos1.x - pos2.x) > 200) {
-      if (pos1.x > pos2.x) pos1.x -= 400; else pos2.x -= 400;
-    }
+    const raw1 = cachedRadToMollweide(b.ra1, b.dec1, R, lambda0);
+    const raw2 = cachedRadToMollweide(b.ra2, b.dec2, R, lambda0);
+    const [pos1, pos2] = adjustMollweideWrap(raw1, raw2);
     const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
     const material = new THREE.LineDashedMaterial({
       color: 0x888888,

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -109,27 +109,59 @@ export function createConstellationBoundariesForGlobe() {
 }
 
 export function createConstellationBoundariesForMollweide() {
-  const lines = [];
   const R = 100;
-  const lambda0 = getMollweideLambda0();
-  boundaryData.forEach(b => {
-    const raw1 = cachedRadToMollweide(b.ra1, b.dec1, R, lambda0);
-    const raw2 = cachedRadToMollweide(b.ra2, b.dec2, R, lambda0);
-    const segments = splitMollweideWrap(raw1, raw2);
-    segments.forEach(([p1, p2]) => {
-      const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
-      const material = new THREE.LineDashedMaterial({
-        color: 0x888888,
-        dashSize: 2,
-        gapSize: 1,
-        linewidth: 1
-      });
-      const line = new THREE.Line(geometry, material);
-      line.computeLineDistances();
-      lines.push(line);
-    });
+  const material = new THREE.LineDashedMaterial({
+    color: 0x888888,
+    dashSize: 2,
+    gapSize: 1,
+    linewidth: 1
   });
-  return lines;
+  const maxSegments = boundaryData.length * 2; // each boundary can wrap
+  const positions = new Float32Array(maxSegments * 2 * 3); // 2 vertices per segment
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const lineSegs = new THREE.LineSegments(geometry, material);
+  lineSegs.computeLineDistances();
+  lineSegs.userData.boundaryData = boundaryData;
+  lineSegs.userData.R = R;
+  updateConstellationBoundariesForMollweide(lineSegs);
+  return [lineSegs];
+}
+
+export function updateConstellationBoundariesForMollweide(lineSegs) {
+  const R = lineSegs.userData.R || 100;
+  const lambda0 = getMollweideLambda0();
+  const data = lineSegs.userData.boundaryData || [];
+  const posAttr = lineSegs.geometry.getAttribute('position');
+  const array = posAttr.array;
+  let idx = 0;
+  data.forEach(seg => {
+    const p1 = cachedRadToMollweide(seg.ra1, seg.dec1, R, lambda0);
+    const p2 = cachedRadToMollweide(seg.ra2, seg.dec2, R, lambda0);
+    const segments = splitMollweideWrap(p1, p2);
+    for (let i = 0; i < 2; i++) {
+      if (i < segments.length) {
+        const s = segments[i][0];
+        const e = segments[i][1];
+        array[idx++] = s.x;
+        array[idx++] = s.y;
+        array[idx++] = 0;
+        array[idx++] = e.x;
+        array[idx++] = e.y;
+        array[idx++] = 0;
+      } else {
+        // degenerate segment
+        array[idx++] = 0;
+        array[idx++] = 0;
+        array[idx++] = 0;
+        array[idx++] = 0;
+        array[idx++] = 0;
+        array[idx++] = 0;
+      }
+    }
+  });
+  posAttr.needsUpdate = true;
+  lineSegs.computeLineDistances();
 }
 
 /**

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,7 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -111,10 +111,16 @@ export function createConstellationBoundariesForGlobe() {
 export function createConstellationBoundariesForMollweide() {
   const lines = [];
   const R = 100;
+  const lambda0 = getMollweideLambda0();
   boundaryData.forEach(b => {
-    const p1 = cachedRadToMollweide(b.ra1, b.dec1, R, 0);
-    const p2 = cachedRadToMollweide(b.ra2, b.dec2, R, 0);
-    const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
+    const p1 = cachedRadToMollweide(b.ra1, b.dec1, R, lambda0);
+    const p2 = cachedRadToMollweide(b.ra2, b.dec2, R, lambda0);
+    const pos1 = p1.clone();
+    const pos2 = p2.clone();
+    if (Math.abs(pos1.x - pos2.x) > 200) {
+      if (pos1.x > pos2.x) pos1.x -= 400; else pos2.x -= 400;
+    }
+    const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
     const material = new THREE.LineDashedMaterial({
       color: 0x888888,
       dashSize: 2,
@@ -198,8 +204,9 @@ export function createConstellationLabelsForGlobe() {
 export function createConstellationLabelsForMollweide() {
   const labels = [];
   const R = 100;
+  const lambda0 = getMollweideLambda0();
   centerData.forEach(c => {
-    const p = cachedRadToMollweide(c.ra, c.dec, R, 0);
+    const p = cachedRadToMollweide(c.ra, c.dec, R, lambda0);
     const baseFontSize = 300;
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
@@ -224,6 +231,7 @@ export function createConstellationLabelsForMollweide() {
 export function createConstellationOverlayForMollweide() {
   const boundaries = getConstellationBoundaries();
   const groups = {};
+  const lambda0 = getMollweideLambda0();
   boundaries.forEach(seg => {
     const key1 = seg.const1 ? seg.const1.toUpperCase() : null;
     const key2 = seg.const2 ? seg.const2.toUpperCase() : null;
@@ -242,8 +250,13 @@ export function createConstellationOverlayForMollweide() {
     const segs = groups[constellation];
     const points = [];
     segs.forEach(seg => {
-      points.push(cachedRadToMollweide(seg.ra1, seg.dec1, 100, 0));
-      points.push(cachedRadToMollweide(seg.ra2, seg.dec2, 100, 0));
+      const p1 = cachedRadToMollweide(seg.ra1, seg.dec1, 100, lambda0);
+      const p2 = cachedRadToMollweide(seg.ra2, seg.dec2, 100, lambda0);
+      if (Math.abs(p1.x - p2.x) > 200) {
+        if (p1.x > p2.x) p1.x -= 400; else p2.x -= 400;
+      }
+      points.push(p1);
+      points.push(p2);
     });
     const shape = new THREE.Shape(points.map(p => new THREE.Vector2(p.x, p.y)));
     const geometry = new THREE.ShapeGeometry(shape);

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,7 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap, splitMollweideWrap } from '../utils/geometryUtils.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -115,17 +115,19 @@ export function createConstellationBoundariesForMollweide() {
   boundaryData.forEach(b => {
     const raw1 = cachedRadToMollweide(b.ra1, b.dec1, R, lambda0);
     const raw2 = cachedRadToMollweide(b.ra2, b.dec2, R, lambda0);
-    const [pos1, pos2] = adjustMollweideWrap(raw1, raw2);
-    const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
-    const material = new THREE.LineDashedMaterial({
-      color: 0x888888,
-      dashSize: 2,
-      gapSize: 1,
-      linewidth: 1
+    const segments = splitMollweideWrap(raw1, raw2);
+    segments.forEach(([p1, p2]) => {
+      const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
+      const material = new THREE.LineDashedMaterial({
+        color: 0x888888,
+        dashSize: 2,
+        gapSize: 1,
+        linewidth: 1
+      });
+      const line = new THREE.Line(geometry, material);
+      line.computeLineDistances();
+      lines.push(line);
     });
-    const line = new THREE.Line(geometry, material);
-    line.computeLineDistances();
-    lines.push(line);
   });
   return lines;
 }

--- a/filters/constellationOverlayFilter.js
+++ b/filters/constellationOverlayFilter.js
@@ -1,6 +1,6 @@
 // filters/constellationOverlayFilter.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { cachedRadToSphere, cachedRadToMollweide, getGreatCirclePoints, subdivideGeometry } from '../utils/geometryUtils.js';
+import { cachedRadToSphere, cachedRadToMollweide, getGreatCirclePoints, subdivideGeometry, getMollweideLambda0 } from '../utils/geometryUtils.js';
 import { getConstellationBoundaries } from './constellationFilter.js';
 
 const R = 100;
@@ -116,6 +116,7 @@ export function createConstellationOverlayForGlobe() {
     }
   });
   
+  const lambda0 = getMollweideLambda0();
   const colorMapping = computeConstellationColorMapping();
   const overlays = [];
   
@@ -252,7 +253,7 @@ export function createConstellationOverlayForMollweide() {
         endpoint === 0 ? seg.ra1 : seg.ra2,
         endpoint === 0 ? seg.dec1 : seg.dec2,
         R,
-        0
+        lambda0
       ).clone();
       if (base) {
         if (Math.abs(p.x - base.x) > 200) {

--- a/filters/constellationOverlayFilter.js
+++ b/filters/constellationOverlayFilter.js
@@ -1,6 +1,6 @@
 // filters/constellationOverlayFilter.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { cachedRadToSphere, cachedRadToMollweide, getGreatCirclePoints, subdivideGeometry, getMollweideLambda0 } from '../utils/geometryUtils.js';
+import { cachedRadToSphere, cachedRadToMollweide, getGreatCirclePoints, subdivideGeometry, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
 import { getConstellationBoundaries } from './constellationFilter.js';
 
 const R = 100;
@@ -249,18 +249,15 @@ export function createConstellationOverlayForMollweide() {
     const ordered = [];
     const used = new Array(segs.length).fill(false);
     const convert = (seg, endpoint, base = null) => {
-      const p = cachedRadToMollweide(
+      const raw = cachedRadToMollweide(
         endpoint === 0 ? seg.ra1 : seg.ra2,
         endpoint === 0 ? seg.dec1 : seg.dec2,
         R,
         lambda0
-      ).clone();
-      if (base) {
-        if (Math.abs(p.x - base.x) > 200) {
-          p.x += p.x > base.x ? -400 : 400;
-        }
-      }
-      return p;
+      );
+      if (!base) return raw.clone();
+      const [adj] = adjustMollweideWrap(raw, base);
+      return adj;
     };
 
     let currentPoint = convert(segs[0], 0);

--- a/filters/constellationOverlayFilter.js
+++ b/filters/constellationOverlayFilter.js
@@ -239,6 +239,7 @@ export function createConstellationOverlayForMollweide() {
     }
   });
 
+  const lambda0 = getMollweideLambda0();
   const colorMapping = computeConstellationColorMapping();
   const overlays = [];
 

--- a/filters/constellationOverlayFilter.js
+++ b/filters/constellationOverlayFilter.js
@@ -1,6 +1,6 @@
 // filters/constellationOverlayFilter.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { cachedRadToSphere, getGreatCirclePoints, subdivideGeometry } from '../utils/geometryUtils.js';
+import { cachedRadToSphere, cachedRadToMollweide, getGreatCirclePoints, subdivideGeometry } from '../utils/geometryUtils.js';
 import { getConstellationBoundaries } from './constellationFilter.js';
 
 const R = 100;
@@ -219,5 +219,102 @@ export function createConstellationOverlayForGlobe() {
     mesh.userData.constellation = constellation;
     overlays.push(mesh);
   }
+  return overlays;
+}
+
+export function createConstellationOverlayForMollweide() {
+  const boundaries = getConstellationBoundaries();
+  const groups = {};
+  boundaries.forEach(seg => {
+    if (seg.const1) {
+      const key = seg.const1.toUpperCase();
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(seg);
+    }
+    if (seg.const2 && seg.const2.toUpperCase() !== (seg.const1 ? seg.const1.toUpperCase() : '')) {
+      const key = seg.const2.toUpperCase();
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(seg);
+    }
+  });
+
+  const colorMapping = computeConstellationColorMapping();
+  const overlays = [];
+
+  for (const constellation in groups) {
+    const segs = groups[constellation];
+    if (segs.length === 0) continue;
+
+    const ordered = [];
+    const used = new Array(segs.length).fill(false);
+    const convert = (seg, endpoint, base = null) => {
+      const p = cachedRadToMollweide(
+        endpoint === 0 ? seg.ra1 : seg.ra2,
+        endpoint === 0 ? seg.dec1 : seg.dec2,
+        R,
+        0
+      ).clone();
+      if (base) {
+        if (Math.abs(p.x - base.x) > 200) {
+          p.x += p.x > base.x ? -400 : 400;
+        }
+      }
+      return p;
+    };
+
+    let currentPoint = convert(segs[0], 0);
+    ordered.push(currentPoint.clone());
+    used[0] = true;
+    let currentEnd = convert(segs[0], 1, currentPoint);
+    ordered.push(currentEnd.clone());
+    let changed = true;
+    let iteration = 0;
+    while (changed && iteration < segs.length) {
+      changed = false;
+      for (let i = 0; i < segs.length; i++) {
+        if (used[i]) continue;
+        const seg = segs[i];
+        const p0 = convert(seg, 0, currentEnd);
+        const p1 = convert(seg, 1, currentEnd);
+        if (p0.distanceTo(currentEnd) < TOLERANCE) {
+          ordered.push(p1.clone());
+          currentEnd = p1.clone();
+          used[i] = true;
+          changed = true;
+        } else if (p1.distanceTo(currentEnd) < TOLERANCE) {
+          ordered.push(p0.clone());
+          currentEnd = p0.clone();
+          used[i] = true;
+          changed = true;
+        }
+      }
+      iteration++;
+    }
+
+    if (ordered.length < 3) continue;
+    if (ordered[0].distanceTo(ordered[ordered.length - 1]) > TOLERANCE) continue;
+    if (ordered[0].distanceTo(ordered[ordered.length - 1]) < TOLERANCE) {
+      ordered.pop();
+    }
+
+    const shape = new THREE.Shape();
+    shape.moveTo(ordered[0].x, ordered[0].y);
+    for (let i = 1; i < ordered.length; i++) {
+      shape.lineTo(ordered[i].x, ordered[i].y);
+    }
+    const geometry = new THREE.ShapeGeometry(shape);
+    const material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(colorMapping[constellation]),
+      opacity: 0.15,
+      transparent: true,
+      side: THREE.DoubleSide,
+      depthWrite: false
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.renderOrder = 1;
+    mesh.userData.constellation = constellation;
+    overlays.push(mesh);
+  }
+
   return overlays;
 }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -13,7 +13,7 @@
 // Only this file changed. Public API and all other files are untouched.
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
 
 export class DensityGridOverlay {
   /**
@@ -122,9 +122,9 @@ export class DensityGridOverlay {
         const ra = Math.atan2(-center.z, -center.x);
         const dec = Math.asin(center.y / r);
         const p = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
-        const obj = new THREE.Object3D();
-        obj.position.copy(p);
-        return obj;
+        const mesh = new THREE.Mesh(new THREE.PlaneGeometry(size, size), material.clone());
+        mesh.position.copy(p);
+        return mesh;
       })(),
       center    : center,
       bbox      : cell.bbox,
@@ -238,10 +238,8 @@ export class DensityGridOverlay {
       line.visible = true;
       const p1 = cell1.mollweideMesh.position.clone();
       const p2 = cell2.mollweideMesh.position.clone();
-      if (Math.abs(p1.x - p2.x) > 200) {
-        if (p1.x > p2.x) p1.x -= 400; else p2.x -= 400;
-      }
-      lineM.geometry.setFromPoints([p1, p2]);
+      const [adj1, adj2] = adjustMollweideWrap(p1, p2);
+      lineM.geometry.setFromPoints([adj1, adj2]);
       lineM.visible = true;
     });
 

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -252,6 +252,21 @@ export class DensityGridOverlay {
     this.adjacentLines.forEach(o => { sceneGlobe.add(o.line); sceneMoll.add(o.lineM); });
   }
 
+  refreshMollweide(lambda0 = getMollweideLambda0()) {
+    this.cubesData.forEach(cell => {
+      const ra = Math.atan2(-cell.center.z, -cell.center.x);
+      const dec = Math.asin(cell.center.y / cell.center.length());
+      const p = cachedRadToMollweide(ra, dec, 100, lambda0);
+      cell.mollweideMesh.position.copy(p);
+    });
+    this.adjacentLines.forEach(obj => {
+      const p1 = obj.cell1.mollweideMesh.position.clone();
+      const p2 = obj.cell2.mollweideMesh.position.clone();
+      const [a, b] = adjustMollweideWrap(p1, p2);
+      obj.lineM.geometry.setFromPoints([a, b]);
+    });
+  }
+
   /* ───────────────────────────── HELPERS ─────────────────────────────── */
 
   /** Axis-aligned bounding box of an array of Vector3s. */

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -13,7 +13,7 @@
 // Only this file changed. Public API and all other files are untouched.
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
 
 export class DensityGridOverlay {
   /**
@@ -121,7 +121,7 @@ export class DensityGridOverlay {
       mollweideMesh : (() => {
         const ra = Math.atan2(-center.z, -center.x);
         const dec = Math.asin(center.y / r);
-        const p = cachedRadToMollweide(ra, dec, 100, 0);
+        const p = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
         const obj = new THREE.Object3D();
         obj.position.copy(p);
         return obj;
@@ -330,8 +330,8 @@ export class DensityGridOverlay {
         const dec1 = Math.asin(a.center.y / a.center.length());
         const ra2 = Math.atan2(-b.center.z, -b.center.x);
         const dec2 = Math.asin(b.center.y / b.center.length());
-        const pM1 = cachedRadToMollweide(ra1, dec1, 100, 0);
-        const pM2 = cachedRadToMollweide(ra2, dec2, 100, 0);
+        const pM1 = cachedRadToMollweide(ra1, dec1, 100, getMollweideLambda0());
+        const pM2 = cachedRadToMollweide(ra2, dec2, 100, getMollweideLambda0());
         if (Math.abs(pM1.x - pM2.x) > 200) {
           if (pM1.x > pM2.x) pM1.x -= 400; else pM2.x -= 400;
         }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -13,7 +13,7 @@
 // Only this file changed. Public API and all other files are untouched.
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
 
 export class DensityGridOverlay {
   /**
@@ -118,6 +118,14 @@ export class DensityGridOverlay {
     this.cubesData.push({
       tcMesh    : cubeTC,
       globeMesh : plane,
+      mollweideMesh : (() => {
+        const ra = Math.atan2(-center.z, -center.x);
+        const dec = Math.asin(center.y / r);
+        const p = cachedRadToMollweide(ra, dec, 100, 0);
+        const obj = new THREE.Object3D();
+        obj.position.copy(p);
+        return obj;
+      })(),
       center    : center,
       bbox      : cell.bbox,
       count     : cell.count,
@@ -133,13 +141,17 @@ export class DensityGridOverlay {
   /**
    * Re-apply threshold & update visibility.  
    * Re-creates grid each call (same as original design). */
-  update(stars, sceneTC, sceneGlobe) {
+  update(stars, sceneTC, sceneGlobe, sceneMoll) {
     /* remove previous meshes from scenes */
     this.cubesData.forEach(c => {
       c.tcMesh.parent?.remove(c.tcMesh);
       c.globeMesh.parent?.remove(c.globeMesh);
+      c.mollweideMesh.parent?.remove(c.mollweideMesh);
     });
-    this.adjacentLines.forEach(o => o.line.parent?.remove(o.line));
+    this.adjacentLines.forEach(o => {
+      o.line.parent?.remove(o.line);
+      o.lineM?.parent?.remove(o.lineM);
+    });
 
     /* rebuild grid */
     this.createGrid(stars);
@@ -184,18 +196,21 @@ export class DensityGridOverlay {
 
       cell.tcMesh.visible   = cell.active;
       cell.globeMesh.visible = cell.active;
+      cell.mollweideMesh.visible = cell.active;
 
       /* globe square scale = distance-based (unchanged) */
       const ratio = Math.min(1, cell.center.length() / this.maxDistance);
       const scl   = THREE.MathUtils.lerp(20, 0.1, ratio);
       cell.globeMesh.scale.set(scl, scl, 1);
+      cell.mollweideMesh.scale.set(scl, scl, 1);
     });
 
     /* neighbour lines: only between visible cells + colour gradient */
     this.adjacentLines.forEach(obj => {
-      const { line, cell1, cell2 } = obj;
+      const { line, lineM, cell1, cell2 } = obj;
       if (!(cell1.active && cell2.active)) {
         line.visible = false;
+        lineM.visible = false;
         return;
       }
       const pts  = getGreatCirclePoints(cell1.globeMesh.position,
@@ -221,14 +236,22 @@ export class DensityGridOverlay {
       line.geometry.attributes.position.needsUpdate = true;
       line.geometry.attributes.color.needsUpdate    = true;
       line.visible = true;
+      const p1 = cell1.mollweideMesh.position.clone();
+      const p2 = cell2.mollweideMesh.position.clone();
+      if (Math.abs(p1.x - p2.x) > 200) {
+        if (p1.x > p2.x) p1.x -= 400; else p2.x -= 400;
+      }
+      lineM.geometry.setFromPoints([p1, p2]);
+      lineM.visible = true;
     });
 
     /* push meshes back into scenes */
     this.cubesData.forEach(c => {
       sceneTC.add(c.tcMesh);
       sceneGlobe.add(c.globeMesh);
+      sceneMoll.add(c.mollweideMesh);
     });
-    this.adjacentLines.forEach(o => sceneGlobe.add(o.line));
+    this.adjacentLines.forEach(o => { sceneGlobe.add(o.line); sceneMoll.add(o.lineM); });
   }
 
   /* ───────────────────────────── HELPERS ─────────────────────────────── */
@@ -303,6 +326,16 @@ export class DensityGridOverlay {
           new THREE.Float32BufferAttribute(pos, 3));
         geom.setAttribute('color',
           new THREE.Float32BufferAttribute(col, 3));
+        const ra1 = Math.atan2(-a.center.z, -a.center.x);
+        const dec1 = Math.asin(a.center.y / a.center.length());
+        const ra2 = Math.atan2(-b.center.z, -b.center.x);
+        const dec2 = Math.asin(b.center.y / b.center.length());
+        const pM1 = cachedRadToMollweide(ra1, dec1, 100, 0);
+        const pM2 = cachedRadToMollweide(ra2, dec2, 100, 0);
+        if (Math.abs(pM1.x - pM2.x) > 200) {
+          if (pM1.x > pM2.x) pM1.x -= 400; else pM2.x -= 400;
+        }
+        const geomM = new THREE.BufferGeometry().setFromPoints([pM1, pM2]);
 
         const mat = new THREE.LineBasicMaterial({
           vertexColors : true,
@@ -313,6 +346,7 @@ export class DensityGridOverlay {
 
         this.adjacentLines.push({
           line  : new THREE.Line(geom, mat),
+          lineM : new THREE.Line(geomM, mat.clone()),
           cell1 : a,
           cell2 : b
         });
@@ -334,7 +368,7 @@ export function initDensityFilter(minDistance, maxDistance,
 }
 
 export function updateDensityFilter(starArray, overlay,
-                                    sceneTC, sceneGlobe) {
+                                    sceneTC, sceneGlobe, sceneMoll) {
   if (!overlay) return;
-  overlay.update(starArray, sceneTC, sceneGlobe);
+  overlay.update(starArray, sceneTC, sceneGlobe, sceneMoll);
 }

--- a/filters/index.js
+++ b/filters/index.js
@@ -10,6 +10,7 @@ import { applyStellarClassLogic, generateStellarClassFilters as scGenerate } fro
 import { loadConstellationBoundaries, loadConstellationCenters } from './constellationFilter.js';
 import { applyGlobeSurfaceFilter } from './globeSurfaceFilter.js';
 import { createConstellationOverlayForGlobe } from './constellationOverlayFilter.js';
+import { createConstellationOverlayForMollweide } from './constellationOverlayFilter.js';
 import { applyDistanceFilter } from './distanceFilter.js';
 
 // Import the new Isolation and Density Filter modules.
@@ -245,10 +246,16 @@ export function applyFilters(allStars) {
           if (window.globeMap.scene.children.includes(cell.globeMesh)) {
             window.globeMap.scene.remove(cell.globeMesh);
           }
+          if (window.mollweideMap.scene.children.includes(cell.mollweideMesh)) {
+            window.mollweideMap.scene.remove(cell.mollweideMesh);
+          }
         });
         isolationOverlay.adjacentLines.forEach(obj => {
           if (window.globeMap.scene.children.includes(obj.line)) {
             window.globeMap.scene.remove(obj.line);
+          }
+          if (window.mollweideMap.scene.children.includes(obj.lineM)) {
+            window.mollweideMap.scene.remove(obj.lineM);
           }
         });
       }
@@ -257,20 +264,24 @@ export function applyFilters(allStars) {
       isolationOverlay.cubesData.forEach(cell => {
         window.trueCoordinatesMap.scene.add(cell.tcMesh);
         window.globeMap.scene.add(cell.globeMesh);
+        window.mollweideMap.scene.add(cell.mollweideMesh);
       });
       isolationOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.add(obj.line);
+        window.mollweideMap.scene.add(obj.lineM);
       });
     }
-    updateIsolationFilter(allStars, isolationOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene);
+    updateIsolationFilter(allStars, isolationOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene, window.mollweideMap.scene);
   } else {
     if (isolationOverlay) {
       isolationOverlay.cubesData.forEach(cell => {
         window.trueCoordinatesMap.scene.remove(cell.tcMesh);
         window.globeMap.scene.remove(cell.globeMesh);
+        window.mollweideMap.scene.remove(cell.mollweideMesh);
       });
       isolationOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.remove(obj.line);
+        window.mollweideMap.scene.remove(obj.lineM);
       });
       isolationOverlay = null;
     }
@@ -290,28 +301,35 @@ export function applyFilters(allStars) {
         densityOverlay.cubesData.forEach(cell => {
           window.trueCoordinatesMap.scene.remove(cell.tcMesh);
           window.globeMap.scene.remove(cell.globeMesh);
+          window.mollweideMap.scene.remove(cell.mollweideMesh);
         });
         densityOverlay.adjacentLines.forEach(obj => {
           window.globeMap.scene.remove(obj.line);
+          window.mollweideMap.scene.remove(obj.lineM);
         });
       }
       densityOverlay = initDensityFilter(filters.minDistance, filters.maxDistance, allStars, densityThreshold);
       densityOverlay.cubesData.forEach(cell => {
         window.trueCoordinatesMap.scene.add(cell.tcMesh);
+        window.globeMap.scene.add(cell.globeMesh);
+        window.mollweideMap.scene.add(cell.mollweideMesh);
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.add(obj.line);
+        window.mollweideMap.scene.add(obj.lineM);
       });
     }
-    updateDensityFilter(allStars, densityOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene);
+    updateDensityFilter(allStars, densityOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene, window.mollweideMap.scene);
   } else {
     if (densityOverlay) {
       densityOverlay.cubesData.forEach(cell => {
         window.trueCoordinatesMap.scene.remove(cell.tcMesh);
         window.globeMap.scene.remove(cell.globeMesh);
+        window.mollweideMap.scene.remove(cell.mollweideMesh);
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.remove(obj.line);
+        window.mollweideMap.scene.remove(obj.lineM);
       });
       densityOverlay = null;
     }

--- a/filters/index.js
+++ b/filters/index.js
@@ -10,7 +10,6 @@ import { applyStellarClassLogic, generateStellarClassFilters as scGenerate } fro
 import { loadConstellationBoundaries, loadConstellationCenters } from './constellationFilter.js';
 import { applyGlobeSurfaceFilter } from './globeSurfaceFilter.js';
 import { createConstellationOverlayForGlobe } from './constellationOverlayFilter.js';
-import { createConstellationOverlayForMollweide } from './constellationOverlayFilter.js';
 import { applyDistanceFilter } from './distanceFilter.js';
 
 // Import the new Isolation and Density Filter modules.

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -265,11 +265,28 @@ class IsolationGridOverlay {
         sceneGlobe.add(cell.globeMesh);
         sceneMoll.add(cell.mollweideMesh);
       });
-      this.adjacentLines.forEach(obj => {
-        sceneGlobe.add(obj.line);
-        sceneMoll.add(obj.lineM);
-      });
+    this.adjacentLines.forEach(obj => {
+      sceneGlobe.add(obj.line);
+      sceneMoll.add(obj.lineM);
+    });
     }
+  }
+
+  refreshMollweide(lambda0 = getMollweideLambda0()) {
+    this.cubesData.forEach(cell => {
+      const lambda = minimalRADifference(cell.raRad - lambda0);
+      cell.mollweideMesh.position.set(
+        cell.mollXFactor * lambda,
+        cell.mollY,
+        0
+      );
+    });
+    this.adjacentLines.forEach(obj => {
+      const p1 = obj.cell1.mollweideMesh.position.clone();
+      const p2 = obj.cell2.mollweideMesh.position.clone();
+      const [a, b] = adjustMollweideWrap(p1, p2);
+      obj.lineM.geometry.setFromPoints([a, b]);
+    });
   }
 
   async assignConstellationsToCells() {

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -50,13 +50,13 @@ class IsolationGridOverlay {
           const cubeTC = new THREE.Mesh(geometry, material);
           cubeTC.position.copy(posTC);
 
-          // Create plane meshes for Globe and Mollweide projections
-          const planeGeom = new THREE.PlaneGeometry(this.gridSize, this.gridSize);
-          const squareGlobe = new THREE.Mesh(planeGeom, material.clone());
-          const squareMoll = new THREE.Mesh(planeGeom.clone(), material.clone());
+          // Create placeholder objects for Globe and Mollweide projections
+          const squareGlobe = new THREE.Object3D();
+          const squareMoll = new THREE.Object3D();
           let projectedPos;
           if (distFromCenter < 1e-6) {
             projectedPos = new THREE.Vector3(0, 0, 0);
+            squareMoll.position.set(0, 0, 0);
           } else {
             const ra = Math.atan2(-posTC.z, -posTC.x);
             const dec = Math.asin(posTC.y / distFromCenter);
@@ -70,7 +70,6 @@ class IsolationGridOverlay {
             squareMoll.position.copy(projMoll);
           }
           squareGlobe.position.copy(projectedPos);
-          squareGlobe.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), projectedPos.clone().normalize());
 
           const cell = {
             tcMesh: cubeTC,
@@ -100,11 +99,6 @@ class IsolationGridOverlay {
       return d >= Math.max(0, this.minDistance - 10) && d <= this.maxDistance + 10;
     });
     this.cubesData.forEach(cell => {
-      const r = cell.tcPos.length();
-      const ra = Math.atan2(-cell.tcPos.z, -cell.tcPos.x);
-      const dec = Math.asin(cell.tcPos.y / r);
-      const posM = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
-      cell.mollweideMesh.position.copy(posM);
       computeCellDistances(cell, extendedStars);
     });
     this.computeAdjacentLines();

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -3,6 +3,7 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
 import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
 // IsolationGridOverlay encapsulates the uniform grid logic for the Isolation Filter.
@@ -54,12 +55,14 @@ class IsolationGridOverlay {
           const squareGlobe = new THREE.Object3D();
           const squareMoll = new THREE.Object3D();
           let projectedPos;
+          let ra, dec;
           if (distFromCenter < 1e-6) {
             projectedPos = new THREE.Vector3(0, 0, 0);
             squareMoll.position.set(0, 0, 0);
+            ra = 0; dec = 0;
           } else {
-            const ra = Math.atan2(-posTC.z, -posTC.x);
-            const dec = Math.asin(posTC.y / distFromCenter);
+            ra = Math.atan2(-posTC.z, -posTC.x);
+            dec = Math.asin(posTC.y / distFromCenter);
             const radius = 100;
             projectedPos = new THREE.Vector3(
               -radius * Math.cos(dec) * Math.cos(ra),
@@ -69,6 +72,17 @@ class IsolationGridOverlay {
             const projMoll = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
             squareMoll.position.copy(projMoll);
           }
+          let theta = dec;
+          for (let i = 0; i < 10; i++) {
+            const delta = (2 * theta + Math.sin(2 * theta) - Math.PI * Math.sin(dec)) /
+              (2 + 2 * Math.cos(2 * theta));
+            theta -= delta;
+            if (Math.abs(delta) < 1e-10) break;
+          }
+          const cosT = Math.cos(theta);
+          const sinT = Math.sin(theta);
+          const mollXFactor = (2 * 100 / Math.PI) * cosT;
+          const mollY = 100 * sinT;
           squareGlobe.position.copy(projectedPos);
 
           const cell = {
@@ -81,13 +95,13 @@ class IsolationGridOverlay {
               iy: Math.round(y / this.gridSize),
               iz: Math.round(z / this.gridSize)
             },
-            active: false
+            active: false,
+            raRad: ra,
+            decRad: dec,
+            mollXFactor: mollXFactor,
+            mollY: mollY
           };
 
-          const cellRa = ((posTC.x + halfExt) / (2 * halfExt)) * 360;
-          const cellDec = ((posTC.y + halfExt) / (2 * halfExt)) * 180 - 90;
-          cell.ra = cellRa;
-          cell.dec = cellDec;
           cell.id = this.cubesData.length;
           this.cubesData.push(cell);
         }
@@ -200,6 +214,12 @@ class IsolationGridOverlay {
       cell.globeMesh.scale.set(scale, scale, 1);
       cell.mollweideMesh.visible = cell.active;
       cell.mollweideMesh.scale.set(scale, scale, 1);
+      const lambda = minimalRADifference(cell.raRad - getMollweideLambda0());
+      cell.mollweideMesh.position.set(
+        cell.mollXFactor * lambda,
+        cell.mollY,
+        0
+      );
     });
 
     // Update the adjacent lines.

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
 // IsolationGridOverlay encapsulates the uniform grid logic for the Isolation Filter.
@@ -66,7 +66,7 @@ class IsolationGridOverlay {
                radius * Math.sin(dec),
               -radius * Math.cos(dec) * Math.sin(ra)
             );
-            const projMoll = cachedRadToMollweide(ra, dec, 100, 0);
+            const projMoll = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
             squareMoll.position.copy(projMoll);
           }
           squareGlobe.position.copy(projectedPos);

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
 // IsolationGridOverlay encapsulates the uniform grid logic for the Isolation Filter.
@@ -50,10 +50,10 @@ class IsolationGridOverlay {
           const cubeTC = new THREE.Mesh(geometry, material);
           cubeTC.position.copy(posTC);
 
-          // Instead of a square mesh on the globe, create a dummy Object3D
-          // that will hold the projected position.
-          const squareGlobe = new THREE.Object3D();
-          const squareMoll = new THREE.Object3D();
+          // Create plane meshes for Globe and Mollweide projections
+          const planeGeom = new THREE.PlaneGeometry(this.gridSize, this.gridSize);
+          const squareGlobe = new THREE.Mesh(planeGeom, material.clone());
+          const squareMoll = new THREE.Mesh(planeGeom.clone(), material.clone());
           let projectedPos;
           if (distFromCenter < 1e-6) {
             projectedPos = new THREE.Vector3(0, 0, 0);
@@ -70,7 +70,7 @@ class IsolationGridOverlay {
             squareMoll.position.copy(projMoll);
           }
           squareGlobe.position.copy(projectedPos);
-          // (No geometry or material is set for squareGlobe.)
+          squareGlobe.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), projectedPos.clone().normalize());
 
           const cell = {
             tcMesh: cubeTC,
@@ -100,6 +100,11 @@ class IsolationGridOverlay {
       return d >= Math.max(0, this.minDistance - 10) && d <= this.maxDistance + 10;
     });
     this.cubesData.forEach(cell => {
+      const r = cell.tcPos.length();
+      const ra = Math.atan2(-cell.tcPos.z, -cell.tcPos.x);
+      const dec = Math.asin(cell.tcPos.y / r);
+      const posM = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
+      cell.mollweideMesh.position.copy(posM);
       computeCellDistances(cell, extendedStars);
     });
     this.computeAdjacentLines();
@@ -133,10 +138,8 @@ class IsolationGridOverlay {
           const colors = [];
           const posM1 = cell.mollweideMesh.position.clone();
           const posM2 = neighbor.mollweideMesh.position.clone();
-          if (Math.abs(posM1.x - posM2.x) > 200) {
-            if (posM1.x > posM2.x) posM1.x -= 400; else posM2.x -= 400;
-          }
-          const geomM = new THREE.BufferGeometry().setFromPoints([posM1, posM2]);
+          const [adj1, adj2] = adjustMollweideWrap(posM1, posM2);
+          const geomM = new THREE.BufferGeometry().setFromPoints([adj1, adj2]);
           const c1 = cell.tcMesh.material.color; // use cube color
           const c2 = neighbor.tcMesh.material.color;
           for (let i = 0; i < points.length; i++) {
@@ -214,9 +217,7 @@ class IsolationGridOverlay {
         const colors = [];
         const posM1 = cell1.mollweideMesh.position.clone();
         const posM2 = cell2.mollweideMesh.position.clone();
-        if (Math.abs(posM1.x - posM2.x) > 200) {
-          if (posM1.x > posM2.x) posM1.x -= 400; else posM2.x -= 400;
-        }
+        const [adj1, adj2] = adjustMollweideWrap(posM1, posM2);
         const c1 = cell1.tcMesh.material.color;
         const c2 = cell2.tcMesh.material.color;
         for (let i = 0; i < points.length; i++) {
@@ -235,7 +236,7 @@ class IsolationGridOverlay {
         const avgScale = (cell1.globeMesh.scale.x + cell2.globeMesh.scale.x) / 2;
         line.material.linewidth = avgScale;
         line.visible = true;
-        lineM.geometry.setFromPoints([posM1, posM2]);
+        lineM.geometry.setFromPoints([adj1, adj2]);
         lineM.visible = true;
       } else {
         line.visible = false;

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -51,9 +51,11 @@ class IsolationGridOverlay {
           const cubeTC = new THREE.Mesh(geometry, material);
           cubeTC.position.copy(posTC);
 
-          // Create placeholder objects for Globe and Mollweide projections
-          const squareGlobe = new THREE.Object3D();
-          const squareMoll = new THREE.Object3D();
+          const planeGeom = new THREE.PlaneGeometry(this.gridSize, this.gridSize);
+          const planeMat = material.clone();
+          planeMat.side = THREE.DoubleSide;
+          const squareGlobe = new THREE.Mesh(planeGeom, planeMat.clone());
+          const squareMoll = new THREE.Mesh(planeGeom.clone(), planeMat.clone());
           let projectedPos;
           let ra, dec;
           if (distFromCenter < 1e-6) {
@@ -84,6 +86,13 @@ class IsolationGridOverlay {
           const mollXFactor = (2 * 100 / Math.PI) * cosT;
           const mollY = 100 * sinT;
           squareGlobe.position.copy(projectedPos);
+          const nrm = projectedPos.clone().normalize();
+          let right = new THREE.Vector3().crossVectors(new THREE.Vector3(0,1,0), nrm);
+          if (right.lengthSq() < 1e-6) right.set(1,0,0);
+          right.normalize();
+          const upVec = new THREE.Vector3().crossVectors(nrm, right).normalize();
+          const mat4 = new THREE.Matrix4().makeBasis(right, upVec, nrm);
+          squareGlobe.setRotationFromMatrix(mat4);
 
           const cell = {
             tcMesh: cubeTC,

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide } from '../utils/geometryUtils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
 // IsolationGridOverlay encapsulates the uniform grid logic for the Isolation Filter.
@@ -21,6 +21,7 @@ class IsolationGridOverlay {
     this.regionClusters = [];
     this.regionLabelsGroupTC = new THREE.Group();
     this.regionLabelsGroupGlobe = new THREE.Group();
+    this.regionLabelsGroupMoll = new THREE.Group();
   }
 
   createGrid(stars) {
@@ -52,6 +53,7 @@ class IsolationGridOverlay {
           // Instead of a square mesh on the globe, create a dummy Object3D
           // that will hold the projected position.
           const squareGlobe = new THREE.Object3D();
+          const squareMoll = new THREE.Object3D();
           let projectedPos;
           if (distFromCenter < 1e-6) {
             projectedPos = new THREE.Vector3(0, 0, 0);
@@ -64,6 +66,8 @@ class IsolationGridOverlay {
                radius * Math.sin(dec),
               -radius * Math.cos(dec) * Math.sin(ra)
             );
+            const projMoll = cachedRadToMollweide(ra, dec, 100, 0);
+            squareMoll.position.copy(projMoll);
           }
           squareGlobe.position.copy(projectedPos);
           // (No geometry or material is set for squareGlobe.)
@@ -71,6 +75,7 @@ class IsolationGridOverlay {
           const cell = {
             tcMesh: cubeTC,
             globeMesh: squareGlobe,
+            mollweideMesh: squareMoll,
             tcPos: posTC,
             grid: {
               ix: Math.round(x / this.gridSize),
@@ -126,6 +131,12 @@ class IsolationGridOverlay {
           const points = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 16);
           const positions = [];
           const colors = [];
+          const posM1 = cell.mollweideMesh.position.clone();
+          const posM2 = neighbor.mollweideMesh.position.clone();
+          if (Math.abs(posM1.x - posM2.x) > 200) {
+            if (posM1.x > posM2.x) posM1.x -= 400; else posM2.x -= 400;
+          }
+          const geomM = new THREE.BufferGeometry().setFromPoints([posM1, posM2]);
           const c1 = cell.tcMesh.material.color; // use cube color
           const c2 = neighbor.tcMesh.material.color;
           for (let i = 0; i < points.length; i++) {
@@ -148,14 +159,15 @@ class IsolationGridOverlay {
           });
           const line = new THREE.Line(geom, mat);
           line.renderOrder = 1;
-          this.adjacentLines.push({ line, cell1: cell, cell2: neighbor });
+          const lineM = new THREE.Line(geomM, mat.clone());
+          this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });
     });
   }
 
-  // Updated update() method now accepts sceneTC and sceneGlobe to re-add new meshes.
-  update(stars, sceneTC, sceneGlobe) {
+  // Updated update() method now accepts sceneTC, sceneGlobe, and sceneMoll to re-add new meshes.
+  update(stars, sceneTC, sceneGlobe, sceneMoll) {
     // Safely obtain slider values: if not found, use defaults.
     const isolationSlider = document.getElementById('isolation-slider');
     const toleranceSlider = document.getElementById('isolation-tolerance-slider');
@@ -189,15 +201,22 @@ class IsolationGridOverlay {
       cell.globeMesh.visible = cell.active;
       const scale = THREE.MathUtils.lerp(20.0, 0.1, ratio);
       cell.globeMesh.scale.set(scale, scale, 1);
+      cell.mollweideMesh.visible = cell.active;
+      cell.mollweideMesh.scale.set(scale, scale, 1);
     });
 
     // Update the adjacent lines.
     this.adjacentLines.forEach(obj => {
-      const { line, cell1, cell2 } = obj;
+      const { line, lineM, cell1, cell2 } = obj;
       if (cell1.globeMesh.visible && cell2.globeMesh.visible) {
         const points = getGreatCirclePoints(cell1.globeMesh.position, cell2.globeMesh.position, 100, 16);
         const positions = [];
         const colors = [];
+        const posM1 = cell1.mollweideMesh.position.clone();
+        const posM2 = cell2.mollweideMesh.position.clone();
+        if (Math.abs(posM1.x - posM2.x) > 200) {
+          if (posM1.x > posM2.x) posM1.x -= 400; else posM2.x -= 400;
+        }
         const c1 = cell1.tcMesh.material.color;
         const c2 = cell2.tcMesh.material.color;
         for (let i = 0; i < points.length; i++) {
@@ -216,19 +235,24 @@ class IsolationGridOverlay {
         const avgScale = (cell1.globeMesh.scale.x + cell2.globeMesh.scale.x) / 2;
         line.material.linewidth = avgScale;
         line.visible = true;
+        lineM.geometry.setFromPoints([posM1, posM2]);
+        lineM.visible = true;
       } else {
         line.visible = false;
+        lineM.visible = false;
       }
     });
 
     // Re‑add the new cell meshes to the scenes.
-    if (sceneTC && sceneGlobe) {
+    if (sceneTC && sceneGlobe && sceneMoll) {
       this.cubesData.forEach(cell => {
         sceneTC.add(cell.tcMesh);
         sceneGlobe.add(cell.globeMesh);
+        sceneMoll.add(cell.mollweideMesh);
       });
       this.adjacentLines.forEach(obj => {
         sceneGlobe.add(obj.line);
+        sceneMoll.add(obj.lineM);
       });
     }
   }
@@ -352,8 +376,8 @@ export function initIsolationFilter(minDistance, maxDistance, starArray, gridSiz
   return overlay;
 }
 
-export function updateIsolationFilter(starArray, overlay, sceneTC, sceneGlobe) {
+export function updateIsolationFilter(starArray, overlay, sceneTC, sceneGlobe, sceneMoll) {
   if (!overlay) return;
-  overlay.update(starArray, sceneTC, sceneGlobe);
+  overlay.update(starArray, sceneTC, sceneGlobe, sceneMoll);
 }
 

--- a/script.js
+++ b/script.js
@@ -209,7 +209,16 @@ function debounce(func, wait) {
   };
 }
 
-const debouncedUpdateMollweideView = debounce(updateMollweideView, 16);
+let pendingMollweideUpdate = false;
+function scheduleMollweideUpdate() {
+  if (!pendingMollweideUpdate) {
+    pendingMollweideUpdate = true;
+    requestAnimationFrame(() => {
+      pendingMollweideUpdate = false;
+      updateMollweideView();
+    });
+  }
+}
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
@@ -404,7 +413,7 @@ class MapManager {
         const twoPi = Math.PI * 2;
         lambda0 = ((lambda0 % twoPi) + twoPi) % twoPi;
         setMollweideLambda0(lambda0);
-        debouncedUpdateMollweideView();
+        scheduleMollweideUpdate();
       }, false);
       const border = createMollweideBorder(100);
       this.scene.add(border);
@@ -630,8 +639,8 @@ function updateSelectedStarHighlight() {
 }
 
 function updateMollweideView() {
-  if (!cachedStars) return;
-  cachedStars.forEach(star => {
+  if (!currentFilteredStars || currentFilteredStars.length === 0) return;
+  currentFilteredStars.forEach(star => {
     updateMollweidePosition(star);
   });
 
@@ -659,12 +668,14 @@ function updateMollweideView() {
     updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudFiles);
   }
   if (enableIsolationFilterFlag && isolationOverlay) {
-    updateIsolationFilter(cachedStars, isolationOverlay, trueCoordinatesMap.scene,
-      globeMap.scene, mollweideMap.scene);
+    if (typeof isolationOverlay.refreshMollweide === 'function') {
+      isolationOverlay.refreshMollweide();
+    }
   }
   if (enableDensityFilterFlag && densityOverlay) {
-    updateDensityFilter(cachedStars, densityOverlay, trueCoordinatesMap.scene,
-      globeMap.scene, mollweideMap.scene);
+    if (typeof densityOverlay.refreshMollweide === 'function') {
+      densityOverlay.refreshMollweide();
+    }
   }
 }
 window.updateMollweideView = updateMollweideView;

--- a/script.js
+++ b/script.js
@@ -91,6 +91,7 @@ function projectStarMollweide(star) {
 }
 
 function precalcMollweideData(star) {
+  const R = 100;
   let ra, dec;
   if (star.RA_in_radian !== undefined && star.DEC_in_radian !== undefined) {
     ra = star.RA_in_radian;
@@ -208,7 +209,7 @@ function debounce(func, wait) {
   };
 }
 
-const debouncedUpdateMollweideView = debounce(updateMollweideView, 1);
+const debouncedUpdateMollweideView = debounce(updateMollweideView, 16);
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
@@ -262,7 +263,8 @@ async function buildAndApplyFilters() {
   trueCoordinatesMap.labelManager.refreshLabels(currentFilteredStars);
   globeMap.updateMap(currentGlobeFilteredStars, currentGlobeConnections);
   globeMap.labelManager.refreshLabels(currentGlobeFilteredStars);
-  mollweideMap.updateMap(currentFilteredStars, currentConnections);
+  mollweideMap.updateStarPositions(currentFilteredStars);
+  mollweideMap.updateConnections(currentFilteredStars, currentConnections);
   mollweideMap.labelManager.refreshLabels(currentFilteredStars);
 
   removeConstellationObjectsFromGlobe();
@@ -418,33 +420,42 @@ class MapManager {
   }
 
   addStars(stars) {
-    while (this.starGroup.children.length > 0) {
-      const child = this.starGroup.children[0];
-      this.starGroup.remove(child);
-      if (child.geometry) child.geometry.dispose();
-      if (child.material) child.material.dispose();
-    }
     const count = stars.length;
-    if (count === 0) return;
-    const baseGeometry = new THREE.SphereGeometry(1, 12, 12);
-    const vertexCount = baseGeometry.attributes.position.count;
-    const dummyColors = new Float32Array(vertexCount * 3);
-    for (let i = 0; i < vertexCount; i++) {
-      dummyColors[i * 3] = 1;
-      dummyColors[i * 3 + 1] = 1;
-      dummyColors[i * 3 + 2] = 1;
+    if (!this.instancedMesh || this.instancedMesh.count !== count) {
+      while (this.starGroup.children.length > 0) {
+        const child = this.starGroup.children[0];
+        this.starGroup.remove(child);
+        if (child.geometry) child.geometry.dispose();
+        if (child.material) child.material.dispose();
+      }
+      if (count === 0) return;
+      const baseGeometry = new THREE.SphereGeometry(1, 12, 12);
+      const vertexCount = baseGeometry.attributes.position.count;
+      const dummyColors = new Float32Array(vertexCount * 3);
+      for (let i = 0; i < vertexCount; i++) {
+        dummyColors[i * 3] = 1;
+        dummyColors[i * 3 + 1] = 1;
+        dummyColors[i * 3 + 2] = 1;
+      }
+      baseGeometry.setAttribute('color', new THREE.BufferAttribute(dummyColors, 3));
+      const material = new THREE.MeshBasicMaterial({
+        color: 0xffffff,
+        transparent: true,
+        opacity: 1.0,
+        vertexColors: true
+      });
+      this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
+      this.instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);
+      this.starGroup.add(this.instancedMesh);
     }
-    baseGeometry.setAttribute('color', new THREE.BufferAttribute(dummyColors, 3));
-    const material = new THREE.MeshBasicMaterial({
-      color: 0xffffff,
-      transparent: true,
-      opacity: 1.0,
-      vertexColors: true
-    });
-    const instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
+    this.updateStarPositions(stars);
+  }
+
+  updateStarPositions(stars) {
+    if (!this.instancedMesh) return;
     const dummy = new THREE.Object3D();
-    const colors = new Float32Array(count * 3);
-    for (let i = 0; i < count; i++) {
+    const colors = this.instancedMesh.instanceColor.array;
+    for (let i = 0; i < stars.length; i++) {
       const star = stars[i];
       let pos;
       if (this.mapType === 'TrueCoordinates') {
@@ -459,15 +470,14 @@ class MapManager {
       dummy.position.copy(pos);
       dummy.scale.set(scale, scale, scale);
       dummy.updateMatrix();
-      instancedMesh.setMatrixAt(i, dummy.matrix);
+      this.instancedMesh.setMatrixAt(i, dummy.matrix);
       const color = new THREE.Color(star.displayColor || '#ffffff');
       colors[i * 3] = color.r;
       colors[i * 3 + 1] = color.g;
       colors[i * 3 + 2] = color.b;
     }
-    instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(colors, 3);
-    instancedMesh.instanceColor.needsUpdate = true;
-    this.starGroup.add(instancedMesh);
+    this.instancedMesh.instanceMatrix.needsUpdate = true;
+    this.instancedMesh.instanceColor.needsUpdate = true;
     this.starObjects = stars;
   }
 

--- a/script.js
+++ b/script.js
@@ -408,13 +408,17 @@ class MapManager {
     const pt = new THREE.PointLight(0xffffff, 1);
     this.scene.add(pt);
     if (mapType === 'Mollweide') {
-      this.controls = new TwoDControls(this.camera, this.renderer.domElement, (dx) => {
-        let lambda0 = getMollweideLambda0() - dx * 0.002;
-        const twoPi = Math.PI * 2;
-        lambda0 = ((lambda0 % twoPi) + twoPi) % twoPi;
-        setMollweideLambda0(lambda0);
-        scheduleMollweideUpdate();
-      }, false);
+      this.controls = new TwoDControls(this.camera, this.renderer.domElement, {
+        rightCallback: (dx) => {
+          let lambda0 = getMollweideLambda0() - dx * 0.002;
+          const twoPi = Math.PI * 2;
+          lambda0 = ((lambda0 % twoPi) + twoPi) % twoPi;
+          setMollweideLambda0(lambda0);
+          scheduleMollweideUpdate();
+        },
+        panCameraLeft: true,
+        panCameraRight: false
+      });
       const border = createMollweideBorder(100);
       this.scene.add(border);
     } else {

--- a/script.js
+++ b/script.js
@@ -2,7 +2,8 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines } from './filters/connectionsFilter.js';
-import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe } from './filters/constellationFilter.js';
+import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
+import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
 import { applyGlobeSurfaceFilter } from './filters/globeSurfaceFilter.js';
@@ -27,6 +28,9 @@ let mollweideMap;
 let constellationLinesGlobe = [];
 let constellationLabelsGlobe = [];
 let constellationOverlayGlobe = [];
+let constellationLinesMoll = [];
+let constellationLabelsMoll = [];
+let constellationOverlayMoll = [];
 let globeSurfaceSphere = null;
 let isolationOverlay = null;
 let densityOverlay = null;
@@ -204,15 +208,23 @@ async function buildAndApplyFilters() {
   if (showConstellationBoundaries) {
     constellationLinesGlobe = createConstellationBoundariesForGlobe();
     constellationLinesGlobe.forEach(ln => globeMap.scene.add(ln));
+    constellationLinesMoll = createConstellationBoundariesForMollweide();
+    constellationLinesMoll.forEach(ln => mollweideMap.scene.add(ln));
   }
   if (showConstellationNames) {
     constellationLabelsGlobe = createConstellationLabelsForGlobe();
     constellationLabelsGlobe.forEach(lbl => globeMap.scene.add(lbl));
+    constellationLabelsMoll = createConstellationLabelsForMollweide();
+    constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
   }
   if (showConstellationOverlay) {
     const constellationOverlay = createConstellationOverlayForGlobe();
     constellationOverlay.forEach(mesh => {
       window.globeMap.scene.add(mesh);
+    });
+    constellationOverlayMoll = createConstellationOverlayForMollweide();
+    constellationOverlayMoll.forEach(mesh => {
+      mollweideMap.scene.add(mesh);
     });
   }
 
@@ -224,6 +236,7 @@ async function buildAndApplyFilters() {
     // Use the complete star list (cachedStars) so that the clouds overlay ignores the distance filter.
     updateCloudsOverlay(cachedStars, trueCoordinatesMap.scene, 'TrueCoordinates', cloudDataFiles);
     updateCloudsOverlay(cachedStars, globeMap.scene, 'Globe', cloudDataFiles);
+    updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudDataFiles);
   }
 
   applyGlobeSurface(globeOpaqueSurface);
@@ -238,6 +251,14 @@ function removeConstellationObjectsFromGlobe() {
     constellationLabelsGlobe.forEach(lbl => globeMap.scene.remove(lbl));
   }
   constellationLabelsGlobe = [];
+  if (constellationLinesMoll && constellationLinesMoll.length > 0) {
+    constellationLinesMoll.forEach(l => mollweideMap.scene.remove(l));
+  }
+  constellationLinesMoll = [];
+  if (constellationLabelsMoll && constellationLabelsMoll.length > 0) {
+    constellationLabelsMoll.forEach(lbl => mollweideMap.scene.remove(lbl));
+  }
+  constellationLabelsMoll = [];
 }
 
 function removeConstellationOverlayObjectsFromGlobe() {
@@ -245,6 +266,10 @@ function removeConstellationOverlayObjectsFromGlobe() {
     constellationOverlayGlobe.forEach(mesh => globeMap.scene.remove(mesh));
   }
   constellationOverlayGlobe = [];
+  if (constellationOverlayMoll && constellationOverlayMoll.length > 0) {
+    constellationOverlayMoll.forEach(mesh => mollweideMap.scene.remove(mesh));
+  }
+  constellationOverlayMoll = [];
 }
 
 function applyGlobeSurface(isOpaque) {

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
-import { createConnectionLines, mergeConnectionLines } from './filters/connectionsFilter.js';
+import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
@@ -500,11 +500,24 @@ class MapManager {
     if (this.mapType === 'Globe') {
       const linesArray = createConnectionLines(stars, connectionObjs, 'Globe');
       linesArray.forEach(line => this.connectionGroup.add(line));
+    } else if (this.mapType === 'Mollweide') {
+      const merged = createMollweideConnectionSegments(connectionObjs);
+      this.connectionGroup.add(merged);
     } else {
       const merged = mergeConnectionLines(connectionObjs, this.mapType);
       this.connectionGroup.add(merged);
     }
     this.scene.add(this.connectionGroup);
+  }
+
+  updateConnectionPositions(stars, connectionObjs) {
+    if (!this.connectionGroup) return;
+    if (this.mapType === 'Mollweide') {
+      const segs = this.connectionGroup.children[0];
+      if (segs) updateMollweideConnectionSegments(segs);
+    } else {
+      this.updateConnections(stars, connectionObjs);
+    }
   }
 
   updateMap(stars, connectionObjs) {
@@ -644,7 +657,8 @@ function updateMollweideView() {
     updateMollweidePosition(star);
   });
 
-  mollweideMap.updateMap(currentFilteredStars, currentConnections);
+  mollweideMap.updateStarPositions(currentFilteredStars);
+  mollweideMap.updateConnectionPositions(currentFilteredStars, currentConnections);
   mollweideMap.labelManager.refreshLabels(currentFilteredStars);
 
   if (showConstellationBoundariesFlag) {

--- a/script.js
+++ b/script.js
@@ -34,6 +34,12 @@ let constellationOverlayMoll = [];
 let globeSurfaceSphere = null;
 let isolationOverlay = null;
 let densityOverlay = null;
+let showConstellationBoundariesFlag = false;
+let showConstellationNamesFlag = false;
+let showConstellationOverlayFlag = false;
+let enableIsolationFilterFlag = false;
+let enableDensityFilterFlag = false;
+let showCloudsFlag = false;
 
 function getStarTruePosition(star) {
   const R = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
@@ -168,7 +174,7 @@ function debounce(func, wait) {
   };
 }
 
-const debouncedUpdateMollweideView = debounce(updateMollweideView, 100);
+const debouncedUpdateMollweideView = debounce(updateMollweideView, 50);
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
@@ -196,6 +202,13 @@ async function buildAndApplyFilters() {
     densityGridSize,
     showClouds
   } = filters;
+
+  showConstellationBoundariesFlag = showConstellationBoundaries;
+  showConstellationNamesFlag = showConstellationNames;
+  showConstellationOverlayFlag = showConstellationOverlay;
+  enableIsolationFilterFlag = enableIsolationFilter;
+  enableDensityFilterFlag = enableDensityFilter;
+  showCloudsFlag = showClouds;
 
   currentFilteredStars = filteredStars;
   currentConnections = connections;
@@ -576,7 +589,38 @@ function updateMollweideView() {
   cachedStars.forEach(star => {
     star.mollweidePosition = projectStarMollweide(star);
   });
-  buildAndApplyFilters();
+
+  mollweideMap.updateMap(currentFilteredStars, currentConnections);
+  mollweideMap.labelManager.refreshLabels(currentFilteredStars);
+
+  if (showConstellationBoundariesFlag) {
+    constellationLinesMoll.forEach(l => mollweideMap.scene.remove(l));
+    constellationLinesMoll = createConstellationBoundariesForMollweide();
+    constellationLinesMoll.forEach(l => mollweideMap.scene.add(l));
+  }
+  if (showConstellationNamesFlag) {
+    constellationLabelsMoll.forEach(lbl => mollweideMap.scene.remove(lbl));
+    constellationLabelsMoll = createConstellationLabelsForMollweide();
+    constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
+  }
+  if (showConstellationOverlayFlag) {
+    constellationOverlayMoll.forEach(mesh => mollweideMap.scene.remove(mesh));
+    constellationOverlayMoll = createConstellationOverlayForMollweide();
+    constellationOverlayMoll.forEach(mesh => mollweideMap.scene.add(mesh));
+  }
+  if (showCloudsFlag) {
+    const form = document.getElementById('filters-form');
+    const cloudFiles = new FormData(form).getAll('dust-clouds');
+    updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudFiles);
+  }
+  if (enableIsolationFilterFlag && isolationOverlay) {
+    updateIsolationFilter(cachedStars, isolationOverlay, trueCoordinatesMap.scene,
+      globeMap.scene, mollweideMap.scene);
+  }
+  if (enableDensityFilterFlag && densityOverlay) {
+    updateDensityFilter(cachedStars, densityOverlay, trueCoordinatesMap.scene,
+      globeMap.scene, mollweideMap.scene);
+  }
 }
 window.updateMollweideView = updateMollweideView;
 

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct impo
 import { ThreeDControls, TwoDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
 import { showTooltip, hideTooltip } from './tooltips.js';
-import { cachedRadToSphere, cachedRadToMollweide, degToRad } from './utils/geometryUtils.js';
+import { cachedRadToSphere, cachedRadToMollweide, degToRad, setMollweideLambda0, getMollweideLambda0 } from './utils/geometryUtils.js';
 
 let cachedStars = null;
 let currentFilteredStars = [];
@@ -80,7 +80,7 @@ function projectStarMollweide(star) {
     ra = 0;
     dec = 0;
   }
-  return cachedRadToMollweide(ra, dec, R, 0);
+  return cachedRadToMollweide(ra, dec, R);
 }
 
 function createGlobeGrid(R = 100, options = {}) {
@@ -118,6 +118,19 @@ function createGlobeGrid(R = 100, options = {}) {
     gridGroup.add(line);
   }
   return gridGroup;
+}
+
+function createMollweideBorder(R = 100) {
+  const points = [];
+  for (let i = 0; i <= 64; i++) {
+    const theta = (i / 64) * 2 * Math.PI;
+    const x = 2 * R * Math.cos(theta);
+    const y = R * Math.sin(theta);
+    points.push(new THREE.Vector3(x, y, 0));
+  }
+  const geom = new THREE.BufferGeometry().setFromPoints(points);
+  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  return new THREE.LineLoop(geom, mat);
 }
 
 async function loadStarData() {
@@ -334,7 +347,13 @@ class MapManager {
     const pt = new THREE.PointLight(0xffffff, 1);
     this.scene.add(pt);
     if (mapType === 'Mollweide') {
-      this.controls = new TwoDControls(this.camera, this.renderer.domElement);
+      this.controls = new TwoDControls(this.camera, this.renderer.domElement, (dx) => {
+        const lambda0 = getMollweideLambda0() + dx * 0.005;
+        setMollweideLambda0(lambda0);
+        if (window.updateMollweideView) window.updateMollweideView();
+      });
+      const border = createMollweideBorder(100);
+      this.scene.add(border);
     } else {
       this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
     }
@@ -547,6 +566,15 @@ function updateSelectedStarHighlight() {
   selectedHighlightMollweide.position.copy(posMoll);
   mollweideMap.scene.add(selectedHighlightMollweide);
 }
+
+function updateMollweideView() {
+  if (!cachedStars) return;
+  cachedStars.forEach(star => {
+    star.mollweidePosition = projectStarMollweide(star);
+  });
+  buildAndApplyFilters();
+}
+window.updateMollweideView = updateMollweideView;
 
 async function main() {
   const loader = document.getElementById('loader');

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ import { ThreeDControls, TwoDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
 import { showTooltip, hideTooltip } from './tooltips.js';
 import { cachedRadToSphere, cachedRadToMollweide, degToRad, setMollweideLambda0, getMollweideLambda0 } from './utils/geometryUtils.js';
+import { minimalRADifference } from './utils.js';
 
 let cachedStars = null;
 let currentFilteredStars = [];
@@ -87,6 +88,39 @@ function projectStarMollweide(star) {
     dec = 0;
   }
   return cachedRadToMollweide(ra, dec, R);
+}
+
+function precalcMollweideData(star) {
+  let ra, dec;
+  if (star.RA_in_radian !== undefined && star.DEC_in_radian !== undefined) {
+    ra = star.RA_in_radian;
+    dec = star.DEC_in_radian;
+  } else if (star.RA_in_degrees !== undefined && star.DEC_in_degrees !== undefined) {
+    ra = degToRad(star.RA_in_degrees);
+    dec = degToRad(star.DEC_in_degrees);
+  } else {
+    ra = 0;
+    dec = 0;
+  }
+  star.raRad = ra;
+  star.decRad = dec;
+  let theta = dec;
+  for (let i = 0; i < 10; i++) {
+    const delta = (2 * theta + Math.sin(2 * theta) - Math.PI * Math.sin(dec)) /
+      (2 + 2 * Math.cos(2 * theta));
+    theta -= delta;
+    if (Math.abs(delta) < 1e-10) break;
+  }
+  const cosT = Math.cos(theta);
+  const sinT = Math.sin(theta);
+  star.mollXFactor = (2 * R / Math.PI) * cosT;
+  star.mollY = R * sinT;
+}
+
+function updateMollweidePosition(star) {
+  const lambda = minimalRADifference(star.raRad - getMollweideLambda0());
+  if (!star.mollweidePosition) star.mollweidePosition = new THREE.Vector3();
+  star.mollweidePosition.set(star.mollXFactor * lambda, star.mollY, 0);
 }
 
 function createGlobeGrid(R = 100, options = {}) {
@@ -174,7 +208,7 @@ function debounce(func, wait) {
   };
 }
 
-const debouncedUpdateMollweideView = debounce(updateMollweideView, 10);
+const debouncedUpdateMollweideView = debounce(updateMollweideView, 1);
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
@@ -220,7 +254,8 @@ async function buildAndApplyFilters() {
   });
   currentFilteredStars.forEach(star => {
     star.truePosition = getStarTruePosition(star);
-    star.mollweidePosition = projectStarMollweide(star);
+    precalcMollweideData(star);
+    updateMollweidePosition(star);
   });
 
   trueCoordinatesMap.updateMap(currentFilteredStars, currentConnections);
@@ -587,7 +622,7 @@ function updateSelectedStarHighlight() {
 function updateMollweideView() {
   if (!cachedStars) return;
   cachedStars.forEach(star => {
-    star.mollweidePosition = projectStarMollweide(star);
+    updateMollweidePosition(star);
   });
 
   mollweideMap.updateMap(currentFilteredStars, currentConnections);
@@ -645,7 +680,8 @@ async function main() {
     cachedStars.forEach(star => {
       star.spherePosition = projectStarGlobe(star);
       star.truePosition = getStarTruePosition(star);
-      star.mollweidePosition = projectStarMollweide(star);
+      precalcMollweideData(star);
+      updateMollweidePosition(star);
     });
     const globeGrid = createGlobeGrid(100, { color: 0x444444, opacity: 0.2, lineWidth: 1 });
     globeMap.scene.add(globeGrid);

--- a/script.js
+++ b/script.js
@@ -168,6 +168,8 @@ function debounce(func, wait) {
   };
 }
 
+const debouncedUpdateMollweideView = debounce(updateMollweideView, 100);
+
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
   const filters = applyFilters(cachedStars);
@@ -348,10 +350,12 @@ class MapManager {
     this.scene.add(pt);
     if (mapType === 'Mollweide') {
       this.controls = new TwoDControls(this.camera, this.renderer.domElement, (dx) => {
-        const lambda0 = getMollweideLambda0() + dx * 0.005;
+        let lambda0 = getMollweideLambda0() - dx * 0.002;
+        const twoPi = Math.PI * 2;
+        lambda0 = ((lambda0 % twoPi) + twoPi) % twoPi;
         setMollweideLambda0(lambda0);
-        if (window.updateMollweideView) window.updateMollweideView();
-      });
+        debouncedUpdateMollweideView();
+      }, false);
       const border = createMollweideBorder(100);
       this.scene.add(border);
     } else {

--- a/script.js
+++ b/script.js
@@ -174,7 +174,7 @@ function debounce(func, wait) {
   };
 }
 
-const debouncedUpdateMollweideView = debounce(updateMollweideView, 50);
+const debouncedUpdateMollweideView = debounce(updateMollweideView, 10);
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines } from './filters/connectionsFilter.js';
-import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
+import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
@@ -648,9 +648,12 @@ function updateMollweideView() {
   mollweideMap.labelManager.refreshLabels(currentFilteredStars);
 
   if (showConstellationBoundariesFlag) {
-    constellationLinesMoll.forEach(l => mollweideMap.scene.remove(l));
-    constellationLinesMoll = createConstellationBoundariesForMollweide();
-    constellationLinesMoll.forEach(l => mollweideMap.scene.add(l));
+    if (constellationLinesMoll.length === 0) {
+      constellationLinesMoll = createConstellationBoundariesForMollweide();
+      constellationLinesMoll.forEach(l => mollweideMap.scene.add(l));
+    } else {
+      constellationLinesMoll.forEach(l => updateConstellationBoundariesForMollweide(l));
+    }
   }
   if (showConstellationNamesFlag) {
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.remove(lbl));

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -206,9 +206,15 @@ export function adjustMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
   if (Math.abs(a.x - b.x) > 200) {
-    if (a.x > b.x) a.x -= 400; else b.x -= 400;
+    if (a.x > b.x) {
+      b.x += 400;
+    } else {
+      a.x += 400;
+    }
   }
-  a.x = THREE.MathUtils.clamp(a.x, -200, 200);
-  b.x = THREE.MathUtils.clamp(b.x, -200, 200);
+  if (a.x > 200) a.x -= 400;
+  if (a.x < -200) a.x += 400;
+  if (b.x > 200) b.x -= 400;
+  if (b.x < -200) b.x += 400;
   return [a, b];
 }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -205,13 +205,14 @@ export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda
 export function adjustMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
-  if (Math.abs(a.x - b.x) > 200) {
-    if (a.x < b.x) {
-      a.x += 400;
-    } else {
-      b.x += 400;
-    }
-  }
+  // shift points horizontally so their separation stays within the map
+  while (a.x - b.x > 200) a.x -= 400;
+  while (b.x - a.x > 200) b.x -= 400;
+  // keep coordinates inside [-200, 200]
+  while (a.x > 200) a.x -= 400;
+  while (a.x < -200) a.x += 400;
+  while (b.x > 200) b.x -= 400;
+  while (b.x < -200) b.x += 400;
   return [a, b];
 }
 
@@ -223,49 +224,35 @@ export function adjustMollweideWrap(p1, p2) {
 export function splitMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
-  const dx = b.x - a.x;
-  const dy = b.y - a.y;
-  const ellipse = (x, y) => (x * x) / (200 * 200) + (y * y) / (100 * 100);
-
-  // If both points are inside the ellipse and the x-distance is less than
-  // the wrap threshold, return the original segment.
-  if (Math.abs(dx) < 200 && ellipse(a.x, a.y) <= 1 && ellipse(b.x, b.y) <= 1) {
+  if (Math.abs(a.x - b.x) <= 200) {
     return [[a, b]];
   }
+  let left = a, right = b;
+  let swapped = false;
+  if (left.x > right.x) { left = b; right = a; swapped = true; }
 
-  // Compute intersection of the line with the ellipse boundary. We solve for t
-  // on the parametric line a + t*(b-a) such that the point lies on the ellipse.
+  const shifted = right.clone();
+  shifted.x -= 400;
+
+  const dx = shifted.x - left.x;
+  const dy = shifted.y - left.y;
   const A = (dx * dx) / (200 * 200) + (dy * dy) / (100 * 100);
-  const B = 2 * (a.x * dx / (200 * 200) + a.y * dy / (100 * 100));
-  const C = ellipse(a.x, a.y) - 1;
+  const B = 2 * (left.x * dx / (200 * 200) + left.y * dy / (100 * 100));
+  const C = (left.x * left.x) / (200 * 200) + (left.y * left.y) / (100 * 100) - 1;
   const disc = B * B - 4 * A * C;
-  if (disc < 0) {
-    return [[a, b]];
-  }
+  if (disc < 0) return [[a, b]];
   const sqrtDisc = Math.sqrt(disc);
   const t1 = (-B - sqrtDisc) / (2 * A);
   const t2 = (-B + sqrtDisc) / (2 * A);
-  const ts = [t1, t2].filter(t => t >= 0 && t <= 1).sort((x, y) => x - y);
-  if (ts.length === 0) {
-    return [[a, b]];
-  }
-  const t = ts[0];
-  const ix = a.x + dx * t;
-  const iy = a.y + dy * t;
-  const edge = new THREE.Vector3(ix, iy, 0);
-  const wrapped = edge.clone();
-  if (a.x < b.x) {
-    wrapped.x -= 400;
+  const t = (t1 >= 0 && t1 <= 1) ? t1 : (t2 >= 0 && t2 <= 1 ? t2 : null);
+  if (t === null) return [[a, b]];
+  const ix = left.x + dx * t;
+  const iy = left.y + dy * t;
+  const edgeLeft = new THREE.Vector3(ix, iy, 0);
+  const edgeRight = new THREE.Vector3(ix + 400, iy, 0);
+  if (!swapped) {
+    return [ [left.clone(), edgeLeft], [edgeRight, right.clone()] ];
   } else {
-    wrapped.x += 400;
+    return [ [left.clone(), edgeLeft], [edgeRight, right.clone()] ];
   }
-  // Second point also needs to be shifted so the wrapped segment continues
-  // from the opposite edge.
-  const end = b.clone();
-  if (a.x < b.x) {
-    end.x -= 400;
-  } else {
-    end.x += 400;
-  }
-  return [ [a, edge], [wrapped, end] ];
 }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -225,17 +225,18 @@ export function splitMollweideWrap(p1, p2) {
   const b = p2.clone();
   const dx = b.x - a.x;
   const dy = b.y - a.y;
-  // Check if the segment crosses the wrap boundary by testing the
-  // difference in x as well as whether the points lie within the ellipse.
   const ellipse = (x, y) => (x * x) / (200 * 200) + (y * y) / (100 * 100);
+
+  // If both points are inside the ellipse and the x-distance is less than
+  // the wrap threshold, return the original segment.
   if (Math.abs(dx) < 200 && ellipse(a.x, a.y) <= 1 && ellipse(b.x, b.y) <= 1) {
     return [[a, b]];
   }
 
-  // Solve line/ellipse intersection for the first intersection point.
+  // Compute intersection of the line with the ellipse boundary. We solve for t
+  // on the parametric line a + t*(b-a) such that the point lies on the ellipse.
   const A = (dx * dx) / (200 * 200) + (dy * dy) / (100 * 100);
-  const B =
-    2 * (a.x * dx / (200 * 200) + a.y * dy / (100 * 100));
+  const B = 2 * (a.x * dx / (200 * 200) + a.y * dy / (100 * 100));
   const C = ellipse(a.x, a.y) - 1;
   const disc = B * B - 4 * A * C;
   if (disc < 0) {
@@ -244,9 +245,7 @@ export function splitMollweideWrap(p1, p2) {
   const sqrtDisc = Math.sqrt(disc);
   const t1 = (-B - sqrtDisc) / (2 * A);
   const t2 = (-B + sqrtDisc) / (2 * A);
-  const ts = [t1, t2]
-    .filter(t => t >= 0 && t <= 1)
-    .sort((x, y) => x - y);
+  const ts = [t1, t2].filter(t => t >= 0 && t <= 1).sort((x, y) => x - y);
   if (ts.length === 0) {
     return [[a, b]];
   }
@@ -260,7 +259,13 @@ export function splitMollweideWrap(p1, p2) {
   } else {
     wrapped.x += 400;
   }
-  const seg1 = [a, edge];
-  const seg2 = [wrapped, b];
-  return [seg1, seg2];
+  // Second point also needs to be shifted so the wrapped segment continues
+  // from the opposite edge.
+  const end = b.clone();
+  if (a.x < b.x) {
+    end.x -= 400;
+  } else {
+    end.x += 400;
+  }
+  return [ [a, edge], [wrapped, end] ];
 }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -223,20 +223,44 @@ export function adjustMollweideWrap(p1, p2) {
 export function splitMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
-  if (Math.abs(a.x - b.x) <= 200) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  // Check if the segment crosses the wrap boundary by testing the
+  // difference in x as well as whether the points lie within the ellipse.
+  const ellipse = (x, y) => (x * x) / (200 * 200) + (y * y) / (100 * 100);
+  if (Math.abs(dx) < 200 && ellipse(a.x, a.y) <= 1 && ellipse(b.x, b.y) <= 1) {
     return [[a, b]];
   }
-  if (a.x < b.x) {
-    const t = (-200 - a.x) / (b.x - a.x);
-    const yEdge = a.y + t * (b.y - a.y);
-    const seg1 = [a, new THREE.Vector3(-200, yEdge, 0)];
-    const seg2 = [new THREE.Vector3(200, yEdge, 0), b];
-    return [seg1, seg2];
-  } else {
-    const t = (200 - a.x) / (b.x - a.x);
-    const yEdge = a.y + t * (b.y - a.y);
-    const seg1 = [a, new THREE.Vector3(200, yEdge, 0)];
-    const seg2 = [new THREE.Vector3(-200, yEdge, 0), b];
-    return [seg1, seg2];
+
+  // Solve line/ellipse intersection for the first intersection point.
+  const A = (dx * dx) / (200 * 200) + (dy * dy) / (100 * 100);
+  const B =
+    2 * (a.x * dx / (200 * 200) + a.y * dy / (100 * 100));
+  const C = ellipse(a.x, a.y) - 1;
+  const disc = B * B - 4 * A * C;
+  if (disc < 0) {
+    return [[a, b]];
   }
+  const sqrtDisc = Math.sqrt(disc);
+  const t1 = (-B - sqrtDisc) / (2 * A);
+  const t2 = (-B + sqrtDisc) / (2 * A);
+  const ts = [t1, t2]
+    .filter(t => t >= 0 && t <= 1)
+    .sort((x, y) => x - y);
+  if (ts.length === 0) {
+    return [[a, b]];
+  }
+  const t = ts[0];
+  const ix = a.x + dx * t;
+  const iy = a.y + dy * t;
+  const edge = new THREE.Vector3(ix, iy, 0);
+  const wrapped = edge.clone();
+  if (a.x < b.x) {
+    wrapped.x -= 400;
+  } else {
+    wrapped.x += 400;
+  }
+  const seg1 = [a, edge];
+  const seg2 = [wrapped, b];
+  return [seg1, seg2];
 }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -2,6 +2,17 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { minimalRADifference } from '../utils.js';
 
+// Global central meridian for Mollweide projection
+let mollweideLambda0 = 0;
+
+export function setMollweideLambda0(lambda0) {
+  mollweideLambda0 = lambda0;
+}
+
+export function getMollweideLambda0() {
+  return mollweideLambda0;
+}
+
 /**
  * Converts RA and DEC (in radians) to a THREE.Vector3 on a sphere of radius R.
  */
@@ -158,7 +169,7 @@ export function cachedRadToSphere(ra, dec, R) {
  * @param {number} [lambda0=0] - Central meridian in radians.
  * @returns {THREE.Vector3}
  */
-export function radToMollweide(ra, dec, R = 100, lambda0 = 0) {
+export function radToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda0) {
   const lambda = minimalRADifference(ra - lambda0);
   const phi = dec;
   let theta = phi;
@@ -174,7 +185,7 @@ export function radToMollweide(ra, dec, R = 100, lambda0 = 0) {
 }
 
 const radToMollweideCache = new Map();
-export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = 0) {
+export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda0) {
   const key = `${ra}_${dec}_${R}_${lambda0}`;
   if (radToMollweideCache.has(key)) {
     return radToMollweideCache.get(key).clone();

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -206,15 +206,37 @@ export function adjustMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
   if (Math.abs(a.x - b.x) > 200) {
-    if (a.x > b.x) {
-      b.x += 400;
-    } else {
+    if (a.x < b.x) {
       a.x += 400;
+    } else {
+      b.x += 400;
     }
   }
-  if (a.x > 200) a.x -= 400;
-  if (a.x < -200) a.x += 400;
-  if (b.x > 200) b.x -= 400;
-  if (b.x < -200) b.x += 400;
   return [a, b];
+}
+
+/**
+ * Splits a Mollweide segment at the map boundary if needed so that
+ * wrapped lines appear on the opposite side instead of bleeding out.
+ * Returns an array of [start, end] pairs.
+ */
+export function splitMollweideWrap(p1, p2) {
+  const a = p1.clone();
+  const b = p2.clone();
+  if (Math.abs(a.x - b.x) <= 200) {
+    return [[a, b]];
+  }
+  if (a.x < b.x) {
+    const t = (-200 - a.x) / (b.x - a.x);
+    const yEdge = a.y + t * (b.y - a.y);
+    const seg1 = [a, new THREE.Vector3(-200, yEdge, 0)];
+    const seg2 = [new THREE.Vector3(200, yEdge, 0), b];
+    return [seg1, seg2];
+  } else {
+    const t = (200 - a.x) / (b.x - a.x);
+    const yEdge = a.y + t * (b.y - a.y);
+    const seg1 = [a, new THREE.Vector3(200, yEdge, 0)];
+    const seg2 = [new THREE.Vector3(-200, yEdge, 0), b];
+    return [seg1, seg2];
+  }
 }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -194,3 +194,21 @@ export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda
   radToMollweideCache.set(key, vec.clone());
   return vec;
 }
+
+/**
+ * Adjusts a pair of Mollweide points so the connecting line wraps inside the
+ * standard [-200, 200] x-range. Returns the adjusted clones.
+ * @param {THREE.Vector3} p1
+ * @param {THREE.Vector3} p2
+ * @returns {[THREE.Vector3, THREE.Vector3]}
+ */
+export function adjustMollweideWrap(p1, p2) {
+  const a = p1.clone();
+  const b = p2.clone();
+  if (Math.abs(a.x - b.x) > 200) {
+    if (a.x > b.x) a.x -= 400; else b.x -= 400;
+  }
+  a.x = THREE.MathUtils.clamp(a.x, -200, 200);
+  b.x = THREE.MathUtils.clamp(b.x, -200, 200);
+  return [a, b];
+}


### PR DESCRIPTION
## Summary
- implement RA wrap handling for Mollweide connections and clouds
- allow clouds, isolation and density filters to project on Mollweide
- add Mollweide constellation labels, boundaries and overlay
- integrate new Mollweide features into filter pipeline and viewer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845dace3518832ab7f75732cc8c32b5