### PR TITLE
Fix Mollweide line wrapping

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -13,7 +13,7 @@
 // Only this file changed. Public API and all other files are untouched.
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
 
 export class DensityGridOverlay {
   /**
@@ -238,8 +238,10 @@ export class DensityGridOverlay {
       line.visible = true;
       const p1 = cell1.mollweideMesh.position.clone();
       const p2 = cell2.mollweideMesh.position.clone();
-      const [adj1, adj2] = adjustMollweideWrap(p1, p2);
-      lineM.geometry.setFromPoints([adj1, adj2]);
+      const segs = splitMollweideWrap(p1, p2);
+      const ptsM = [];
+      segs.forEach(([s, e]) => { ptsM.push(s, e); });
+      lineM.geometry.setFromPoints(ptsM);
       lineM.visible = true;
     });
 
@@ -262,8 +264,10 @@ export class DensityGridOverlay {
     this.adjacentLines.forEach(obj => {
       const p1 = obj.cell1.mollweideMesh.position.clone();
       const p2 = obj.cell2.mollweideMesh.position.clone();
-      const [a, b] = adjustMollweideWrap(p1, p2);
-      obj.lineM.geometry.setFromPoints([a, b]);
+      const segs = splitMollweideWrap(p1, p2);
+      const pts = [];
+      segs.forEach(([s, e]) => { pts.push(s, e); });
+      obj.lineM.geometry.setFromPoints(pts);
     });
   }
 
@@ -345,10 +349,10 @@ export class DensityGridOverlay {
         const dec2 = Math.asin(b.center.y / b.center.length());
         const pM1 = cachedRadToMollweide(ra1, dec1, 100, getMollweideLambda0());
         const pM2 = cachedRadToMollweide(ra2, dec2, 100, getMollweideLambda0());
-        if (Math.abs(pM1.x - pM2.x) > 200) {
-          if (pM1.x > pM2.x) pM1.x -= 400; else pM2.x -= 400;
-        }
-        const geomM = new THREE.BufferGeometry().setFromPoints([pM1, pM2]);
+        const segsM = splitMollweideWrap(pM1, pM2);
+        const pointsM = [];
+        segsM.forEach(([s, e]) => { pointsM.push(s, e); });
+        const geomM = new THREE.BufferGeometry().setFromPoints(pointsM);
 
         const mat = new THREE.LineBasicMaterial({
           vertexColors : true,
@@ -359,7 +363,7 @@ export class DensityGridOverlay {
 
         this.adjacentLines.push({
           line  : new THREE.Line(geom, mat),
-          lineM : new THREE.Line(geomM, mat.clone()),
+          lineM : new THREE.LineSegments(geomM, mat.clone()),
           cell1 : a,
           cell2 : b
         });

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
@@ -155,8 +155,10 @@ class IsolationGridOverlay {
           const colors = [];
           const posM1 = cell.mollweideMesh.position.clone();
           const posM2 = neighbor.mollweideMesh.position.clone();
-          const [adj1, adj2] = adjustMollweideWrap(posM1, posM2);
-          const geomM = new THREE.BufferGeometry().setFromPoints([adj1, adj2]);
+          const segsM = splitMollweideWrap(posM1, posM2);
+          const pointsM = [];
+          segsM.forEach(([s,e]) => { pointsM.push(s, e); });
+          const geomM = new THREE.BufferGeometry().setFromPoints(pointsM);
           const c1 = cell.tcMesh.material.color; // use cube color
           const c2 = neighbor.tcMesh.material.color;
           for (let i = 0; i < points.length; i++) {
@@ -185,7 +187,7 @@ class IsolationGridOverlay {
             opacity: 0.9,
             linewidth: 5
           });
-          const lineM = new THREE.Line(geomM, mollMat);
+          const lineM = new THREE.LineSegments(geomM, mollMat);
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });
@@ -246,7 +248,9 @@ class IsolationGridOverlay {
         const colors = [];
         const posM1 = cell1.mollweideMesh.position.clone();
         const posM2 = cell2.mollweideMesh.position.clone();
-        const [adj1, adj2] = adjustMollweideWrap(posM1, posM2);
+        const segs = splitMollweideWrap(posM1, posM2);
+        const ptsM = [];
+        segs.forEach(([s,e]) => { ptsM.push(s, e); });
         const c1 = cell1.tcMesh.material.color;
         const c2 = cell2.tcMesh.material.color;
         for (let i = 0; i < points.length; i++) {
@@ -265,7 +269,7 @@ class IsolationGridOverlay {
         const avgScale = (cell1.globeMesh.scale.x + cell2.globeMesh.scale.x) / 2;
         line.material.linewidth = avgScale;
         line.visible = true;
-        lineM.geometry.setFromPoints([adj1, adj2]);
+        lineM.geometry.setFromPoints(ptsM);
         lineM.visible = true;
       } else {
         line.visible = false;
@@ -305,8 +309,10 @@ class IsolationGridOverlay {
     this.adjacentLines.forEach(obj => {
       const p1 = obj.cell1.mollweideMesh.position.clone();
       const p2 = obj.cell2.mollweideMesh.position.clone();
-      const [a, b] = adjustMollweideWrap(p1, p2);
-      obj.lineM.geometry.setFromPoints([a, b]);
+      const segs = splitMollweideWrap(p1, p2);
+      const pts = [];
+      segs.forEach(([s,e]) => { pts.push(s, e); });
+      obj.lineM.geometry.setFromPoints(pts);
     });
   }
 

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -224,7 +224,7 @@ export function adjustMollweideWrap(p1, p2) {
 export function splitMollweideWrap(p1, p2) {
   const a = p1.clone();
   const b = p2.clone();
-  if (Math.abs(a.x - b.x) <= 200) {
+  if (Math.abs(a.x - b.x) < 200) {
     return [[a, b]];
   }
   let left = a, right = b;
@@ -249,7 +249,7 @@ export function splitMollweideWrap(p1, p2) {
   const ix = left.x + dx * t;
   const iy = left.y + dy * t;
   const edgeLeft = new THREE.Vector3(ix, iy, 0);
-  const edgeRight = new THREE.Vector3(ix + 400, iy, 0);
+  const edgeRight = new THREE.Vector3(-ix, iy, 0);
   if (!swapped) {
     return [ [left.clone(), edgeLeft], [edgeRight, right.clone()] ];
   } else {


### PR DESCRIPTION
## Summary
- use `splitMollweideWrap` when drawing density grid connections
- update isolation filter neighbour lines to split on map boundaries

## Testing
- `node -e "import('./filters/densityFilter.js').then(()=>console.log('density ok')).catch(err=>console.error(err));" && node -e "import('./filters/isolationFilter.js').then(()=>console.log('isolation ok')).catch(err=>console.error(err));" (fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)`

------
https://chatgpt.com/codex/tasks/task_e_6846b91a45d8832abf8514381238a0d1