### PR TITLE
Fix Mollweide line routing

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -1,7 +1,9 @@
 // filters/connectionsFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { adjustMollweideWrap, splitMollweideWrap } from '../utils/geometryUtils.js';
+import { adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
+
+const GC_SEGMENTS = 32;
 
 /**
  * Helper: Returns a THREE.Vector3 for a star’s position.
@@ -122,7 +124,7 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
 }
 
 export function createMollweideConnectionSegments(pairs) {
-  const segCount = pairs.length * 2; // up to 2 segments per pair
+  const segCount = pairs.length * GC_SEGMENTS * 2; // each GC segment may wrap
   const positions = new Float32Array(segCount * 2 * 3);
   const colors = new Float32Array(segCount * 2 * 3);
   const geometry = new THREE.BufferGeometry();
@@ -135,40 +137,47 @@ export function createMollweideConnectionSegments(pairs) {
     linewidth: 1
   });
   const lineSegs = new THREE.LineSegments(geometry, material);
-  lineSegs.userData.pairs = pairs;
+  lineSegs.userData = { pairs, segments: GC_SEGMENTS };
   updateMollweideConnectionSegments(lineSegs);
   return lineSegs;
 }
 
 export function updateMollweideConnectionSegments(lineSegs) {
   const pairs = lineSegs.userData.pairs || [];
+  const segsCount = lineSegs.userData.segments || GC_SEGMENTS;
   const posAttr = lineSegs.geometry.getAttribute('position');
   const colorAttr = lineSegs.geometry.getAttribute('color');
   let idx = 0;
   pairs.forEach(pair => {
-    const segs = splitMollweideWrap(
-      pair.starA.mollweidePosition,
-      pair.starB.mollweidePosition
-    );
+    const p1 = pair.starA.spherePosition;
+    const p2 = pair.starB.spherePosition;
+    if (!p1 || !p2) return;
+    const pts = greatCircleToMollweide(p1, p2, 100, segsCount, getMollweideLambda0());
     const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
     const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
-    for (let i = 0; i < 2; i++) {
-      if (i < segs.length) {
-        const s = segs[i][0];
-        const e = segs[i][1];
+    for (let j = 0; j < pts.length - 1; j++) {
+      const segs = splitMollweideWrap(pts[j], pts[j + 1]);
+      segs.forEach(([s, e]) => {
+        if (idx + 6 > posAttr.array.length) return;
         posAttr.array[idx] = s.x; posAttr.array[idx+1] = s.y; posAttr.array[idx+2] = s.z;
         posAttr.array[idx+3] = e.x; posAttr.array[idx+4] = e.y; posAttr.array[idx+5] = e.z;
-        colorAttr.array[idx] = cA.r; colorAttr.array[idx+1] = cA.g; colorAttr.array[idx+2] = cA.b;
-        colorAttr.array[idx+3] = cB.r; colorAttr.array[idx+4] = cB.g; colorAttr.array[idx+5] = cB.b;
-      } else {
-        posAttr.array[idx] = posAttr.array[idx+1] = posAttr.array[idx+2] = 0;
-        posAttr.array[idx+3] = posAttr.array[idx+4] = posAttr.array[idx+5] = 0;
-        colorAttr.array[idx] = colorAttr.array[idx+1] = colorAttr.array[idx+2] = 0;
-        colorAttr.array[idx+3] = colorAttr.array[idx+4] = colorAttr.array[idx+5] = 0;
-      }
-      idx += 6;
+        const t1 = j / (pts.length - 1);
+        const t2 = (j + 1) / (pts.length - 1);
+        colorAttr.array[idx]   = THREE.MathUtils.lerp(cA.r, cB.r, t1);
+        colorAttr.array[idx+1] = THREE.MathUtils.lerp(cA.g, cB.g, t1);
+        colorAttr.array[idx+2] = THREE.MathUtils.lerp(cA.b, cB.b, t1);
+        colorAttr.array[idx+3] = THREE.MathUtils.lerp(cA.r, cB.r, t2);
+        colorAttr.array[idx+4] = THREE.MathUtils.lerp(cA.g, cB.g, t2);
+        colorAttr.array[idx+5] = THREE.MathUtils.lerp(cA.b, cB.b, t2);
+        idx += 6;
+      });
     }
   });
+  // zero out remaining
+  for (; idx < posAttr.array.length; idx++) {
+    posAttr.array[idx] = 0;
+    colorAttr.array[idx] = 0;
+  }
   posAttr.needsUpdate = true;
   colorAttr.needsUpdate = true;
   lineSegs.computeLineDistances();

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,7 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap, splitMollweideWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide } from '../utils/geometryUtils.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -116,7 +116,7 @@ export function createConstellationBoundariesForMollweide() {
     gapSize: 1,
     linewidth: 1
   });
-  const maxSegments = boundaryData.length * 2; // each boundary can wrap
+  const maxSegments = boundaryData.length * 32; // 16 segments per boundary, each may wrap
   const positions = new Float32Array(maxSegments * 2 * 3); // 2 vertices per segment
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
@@ -136,30 +136,25 @@ export function updateConstellationBoundariesForMollweide(lineSegs) {
   const array = posAttr.array;
   let idx = 0;
   data.forEach(seg => {
-    const p1 = cachedRadToMollweide(seg.ra1, seg.dec1, R, lambda0);
-    const p2 = cachedRadToMollweide(seg.ra2, seg.dec2, R, lambda0);
-    const segments = splitMollweideWrap(p1, p2);
-    for (let i = 0; i < 2; i++) {
-      if (i < segments.length) {
-        const s = segments[i][0];
-        const e = segments[i][1];
-        array[idx++] = s.x;
-        array[idx++] = s.y;
-        array[idx++] = 0;
-        array[idx++] = e.x;
-        array[idx++] = e.y;
-        array[idx++] = 0;
-      } else {
-        // degenerate segment
-        array[idx++] = 0;
-        array[idx++] = 0;
-        array[idx++] = 0;
-        array[idx++] = 0;
-        array[idx++] = 0;
-        array[idx++] = 0;
+    const pStart = radToSphere(seg.ra1, seg.dec1, R);
+    const pEnd   = radToSphere(seg.ra2, seg.dec2, R);
+    const arcPts  = greatCircleToMollweide(pStart, pEnd, R, 16, lambda0);
+    for (let j = 0; j < arcPts.length - 1; j++) {
+      const splits = splitMollweideWrap(arcPts[j], arcPts[j + 1]);
+      for (let s = 0; s < 2; s++) {
+        if (s < splits.length) {
+          const a = splits[s][0];
+          const b = splits[s][1];
+          array[idx++] = a.x; array[idx++] = a.y; array[idx++] = 0;
+          array[idx++] = b.x; array[idx++] = b.y; array[idx++] = 0;
+        } else {
+          array[idx++] = 0; array[idx++] = 0; array[idx++] = 0;
+          array[idx++] = 0; array[idx++] = 0; array[idx++] = 0;
+        }
       }
     }
   });
+  for (; idx < array.length; idx++) array[idx] = 0;
   posAttr.needsUpdate = true;
   lineSegs.computeLineDistances();
 }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -13,7 +13,7 @@
 // Only this file changed. Public API and all other files are untouched.
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
 
 export class DensityGridOverlay {
   /**
@@ -236,11 +236,16 @@ export class DensityGridOverlay {
       line.geometry.attributes.position.needsUpdate = true;
       line.geometry.attributes.color.needsUpdate    = true;
       line.visible = true;
-      const p1 = cell1.mollweideMesh.position.clone();
-      const p2 = cell2.mollweideMesh.position.clone();
-      const segs = splitMollweideWrap(p1, p2);
+      const mollPts = getGreatCirclePoints(cell1.globeMesh.position,
+                             cell2.globeMesh.position, 100, 16).map(v => {
+                               const { ra, dec } = vectorToRaDecRad(v, 100);
+                               return radToMollweide(ra, dec, 100, getMollweideLambda0());
+                             });
       const ptsM = [];
-      segs.forEach(([s, e]) => { ptsM.push(s, e); });
+      for (let mi = 0; mi < mollPts.length - 1; mi++) {
+        const segs = splitMollweideWrap(mollPts[mi], mollPts[mi + 1]);
+        segs.forEach(([s, e]) => { ptsM.push(s, e); });
+      }
       lineM.geometry.setFromPoints(ptsM);
       lineM.visible = true;
     });
@@ -262,11 +267,16 @@ export class DensityGridOverlay {
       cell.mollweideMesh.position.copy(p);
     });
     this.adjacentLines.forEach(obj => {
-      const p1 = obj.cell1.mollweideMesh.position.clone();
-      const p2 = obj.cell2.mollweideMesh.position.clone();
-      const segs = splitMollweideWrap(p1, p2);
+      const arc = getGreatCirclePoints(obj.cell1.globeMesh.position,
+                       obj.cell2.globeMesh.position, 100, 16).map(v => {
+                         const { ra, dec } = vectorToRaDecRad(v, 100);
+                         return radToMollweide(ra, dec, 100, lambda0);
+                       });
       const pts = [];
-      segs.forEach(([s, e]) => { pts.push(s, e); });
+      for (let i = 0; i < arc.length - 1; i++) {
+        const segs = splitMollweideWrap(arc[i], arc[i + 1]);
+        segs.forEach(([s, e]) => { pts.push(s, e); });
+      }
       obj.lineM.geometry.setFromPoints(pts);
     });
   }
@@ -343,15 +353,15 @@ export class DensityGridOverlay {
           new THREE.Float32BufferAttribute(pos, 3));
         geom.setAttribute('color',
           new THREE.Float32BufferAttribute(col, 3));
-        const ra1 = Math.atan2(-a.center.z, -a.center.x);
-        const dec1 = Math.asin(a.center.y / a.center.length());
-        const ra2 = Math.atan2(-b.center.z, -b.center.x);
-        const dec2 = Math.asin(b.center.y / b.center.length());
-        const pM1 = cachedRadToMollweide(ra1, dec1, 100, getMollweideLambda0());
-        const pM2 = cachedRadToMollweide(ra2, dec2, 100, getMollweideLambda0());
-        const segsM = splitMollweideWrap(pM1, pM2);
+        const arcM = pts.map(v => {
+          const { ra, dec } = vectorToRaDecRad(v, 100);
+          return radToMollweide(ra, dec, 100, getMollweideLambda0());
+        });
         const pointsM = [];
-        segsM.forEach(([s, e]) => { pointsM.push(s, e); });
+        for (let k = 0; k < arcM.length - 1; k++) {
+          const segsM = splitMollweideWrap(arcM[k], arcM[k + 1]);
+          segsM.forEach(([s, e]) => { pointsM.push(s, e); });
+        }
         const geomM = new THREE.BufferGeometry().setFromPoints(pointsM);
 
         const mat = new THREE.LineBasicMaterial({

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
@@ -153,11 +153,16 @@ class IsolationGridOverlay {
           const points = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 16);
           const positions = [];
           const colors = [];
-          const posM1 = cell.mollweideMesh.position.clone();
-          const posM2 = neighbor.mollweideMesh.position.clone();
-          const segsM = splitMollweideWrap(posM1, posM2);
+          const mollPts = getGreatCirclePoints(cell.globeMesh.position,
+            neighbor.globeMesh.position, 100, 16).map(v => {
+              const { ra, dec } = vectorToRaDecRad(v, 100);
+              return radToMollweide(ra, dec, 100, getMollweideLambda0());
+            });
           const pointsM = [];
-          segsM.forEach(([s,e]) => { pointsM.push(s, e); });
+          for (let m = 0; m < mollPts.length - 1; m++) {
+            const segsM = splitMollweideWrap(mollPts[m], mollPts[m + 1]);
+            segsM.forEach(([s,e]) => { pointsM.push(s, e); });
+          }
           const geomM = new THREE.BufferGeometry().setFromPoints(pointsM);
           const c1 = cell.tcMesh.material.color; // use cube color
           const c2 = neighbor.tcMesh.material.color;
@@ -246,11 +251,16 @@ class IsolationGridOverlay {
         const points = getGreatCirclePoints(cell1.globeMesh.position, cell2.globeMesh.position, 100, 16);
         const positions = [];
         const colors = [];
-        const posM1 = cell1.mollweideMesh.position.clone();
-        const posM2 = cell2.mollweideMesh.position.clone();
-        const segs = splitMollweideWrap(posM1, posM2);
+        const mollPoints = getGreatCirclePoints(cell1.globeMesh.position,
+          cell2.globeMesh.position, 100, 16).map(v => {
+            const { ra, dec } = vectorToRaDecRad(v, 100);
+            return radToMollweide(ra, dec, 100, getMollweideLambda0());
+          });
         const ptsM = [];
-        segs.forEach(([s,e]) => { ptsM.push(s, e); });
+        for (let mi = 0; mi < mollPoints.length - 1; mi++) {
+          const segs = splitMollweideWrap(mollPoints[mi], mollPoints[mi + 1]);
+          segs.forEach(([s,e]) => { ptsM.push(s, e); });
+        }
         const c1 = cell1.tcMesh.material.color;
         const c2 = cell2.tcMesh.material.color;
         for (let i = 0; i < points.length; i++) {
@@ -307,11 +317,16 @@ class IsolationGridOverlay {
       );
     });
     this.adjacentLines.forEach(obj => {
-      const p1 = obj.cell1.mollweideMesh.position.clone();
-      const p2 = obj.cell2.mollweideMesh.position.clone();
-      const segs = splitMollweideWrap(p1, p2);
+      const gcPts = getGreatCirclePoints(obj.cell1.globeMesh.position,
+        obj.cell2.globeMesh.position, 100, 16).map(v => {
+          const { ra, dec } = vectorToRaDecRad(v, 100);
+          return radToMollweide(ra, dec, 100, lambda0);
+        });
       const pts = [];
-      segs.forEach(([s,e]) => { pts.push(s, e); });
+      for (let i = 0; i < gcPts.length - 1; i++) {
+        const segs = splitMollweideWrap(gcPts[i], gcPts[i + 1]);
+        segs.forEach(([s,e]) => { pts.push(s, e); });
+      }
       obj.lineM.geometry.setFromPoints(pts);
     });
   }

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -146,6 +146,19 @@ export function vectorToRaDec(vector, R = 100) {
 }
 
 /**
+ * Converts a sphere coordinate to RA/DEC in **radians**.
+ * @param {THREE.Vector3} vector - The vector position.
+ * @param {number} [R=100] - The sphere radius.
+ * @returns {{ra:number, dec:number}} - RA and DEC in radians.
+ */
+export function vectorToRaDecRad(vector, R = 100) {
+  const dec = Math.asin(vector.y / R);
+  let ra = Math.atan2(-vector.z, -vector.x);
+  if (ra < 0) ra += 2 * Math.PI;
+  return { ra, dec };
+}
+
+/**
  * Caching mechanism for converting RA/DEC to sphere coordinates.
  * Returns a THREE.Vector3 corresponding to the inputs.
  */
@@ -255,4 +268,22 @@ export function splitMollweideWrap(p1, p2) {
   } else {
     return [ [left.clone(), edgeLeft], [edgeRight, right.clone()] ];
   }
+}
+
+/**
+ * Generates Mollweide coordinates for the great-circle arc between two
+ * 3D positions on the celestial sphere.
+ * @param {THREE.Vector3} p1 - Start vector on the sphere.
+ * @param {THREE.Vector3} p2 - End vector on the sphere.
+ * @param {number} [R=100] - Sphere radius.
+ * @param {number} [segments=32] - Number of segments along the arc.
+ * @param {number} [lambda0=mollweideLambda0] - Central meridian for projection.
+ * @returns {THREE.Vector3[]} Array of Mollweide coordinates along the arc.
+ */
+export function greatCircleToMollweide(p1, p2, R = 100, segments = 32, lambda0 = mollweideLambda0) {
+  const gcPoints = getGreatCirclePoints(p1, p2, R, segments);
+  return gcPoints.map(v => {
+    const { ra, dec } = vectorToRaDecRad(v, R);
+    return radToMollweide(ra, dec, R, lambda0);
+  });
 }


### PR DESCRIPTION
## Summary
- compute RA/DEC from vectors and add great‑circle projection utilities
- draw Mollweide connection lines using great‑circle arcs
- update isolation and density filters to project their lines via the great circle
- update constellation boundaries to follow great‑circle routes

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6846c0b36f0c832aaff2a8d35761731d