### PR TITLE
Improve Mollweide boundary wrapping

### DIFF
--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -197,6 +197,26 @@ export function radToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda0) {
   return new THREE.Vector3(x, y, 0);
 }
 
+/**
+ * Converts RA and DEC (in radians) to Mollweide projection coordinates without
+ * wrapping the longitude difference into the [-π, π] range. This is useful when
+ * generating continuous paths that may legitimately span more than 180° in RA.
+ */
+export function radToMollweideRaw(ra, dec, R = 100, lambda0 = mollweideLambda0) {
+  const lambda = ra - lambda0; // no minimalRADifference
+  const phi = dec;
+  let theta = phi;
+  for (let i = 0; i < 10; i++) {
+    const delta = (2 * theta + Math.sin(2 * theta) - Math.PI * Math.sin(phi)) /
+      (2 + 2 * Math.cos(2 * theta));
+    theta -= delta;
+    if (Math.abs(delta) < 1e-10) break;
+  }
+  const x = (2 * R / Math.PI) * lambda * Math.cos(theta);
+  const y = R * Math.sin(theta);
+  return new THREE.Vector3(x, y, 0);
+}
+
 const radToMollweideCache = new Map();
 export function cachedRadToMollweide(ra, dec, R = 100, lambda0 = mollweideLambda0) {
   const key = `${ra}_${dec}_${R}_${lambda0}`;
@@ -282,8 +302,19 @@ export function splitMollweideWrap(p1, p2) {
  */
 export function greatCircleToMollweide(p1, p2, R = 100, segments = 32, lambda0 = mollweideLambda0) {
   const gcPoints = getGreatCirclePoints(p1, p2, R, segments);
-  return gcPoints.map(v => {
+  const result = [];
+  let prev = null;
+  gcPoints.forEach((v, idx) => {
     const { ra, dec } = vectorToRaDecRad(v, R);
-    return radToMollweide(ra, dec, R, lambda0);
+    let curr = radToMollweideRaw(ra, dec, R, lambda0);
+    if (prev) {
+      const adjusted = adjustMollweideWrap(prev, curr);
+      // Replace the previous point with its adjusted version
+      result[result.length - 1] = adjusted[0];
+      curr = adjusted[1];
+    }
+    result.push(curr);
+    prev = curr;
   });
+  return result;
 }


### PR DESCRIPTION
## Summary
- add `radToMollweideRaw` for continuous Mollweide longitude offsets
- generate great-circle arcs using the new function and keep points consistent with `adjustMollweideWrap`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c5406bd4832aad279c44f51b8010