### PR TITLE
Add galactic and ecliptic plane filters

### DIFF
--- a/filters/index.js
+++ b/filters/index.js
@@ -219,6 +219,8 @@ export function applyFilters(allStars) {
         connections: [],
         globeFilteredStars: allStars,
         globeConnections: [],
+        mollweideFilteredStars: allStars,
+        mollweideConnections: [],
         showConstellationBoundaries: false,
         showConstellationNames: false,
         showConstellationOverlay: false,
@@ -279,11 +281,14 @@ export function applyFilters(allStars) {
   filteredStars = applyOpacityFilter(filteredStars, filters);
 
   const globeFiltered = filteredStars.filter(s => s.Common_name_of_the_star !== 'Sol');
+  const mollweideFiltered = filteredStars.filter(s => s.Common_name_of_the_star !== 'Sol');
   let pairs = [];
   let globePairs = [];
+  let mollweidePairs = [];
   if (filters.enableConnections) {
     pairs = computeConnectionPairs(filteredStars, filters.connections);
     globePairs = computeConnectionPairs(globeFiltered, filters.connections);
+    mollweidePairs = computeConnectionPairs(mollweideFiltered, filters.connections);
   }
 
   applyGlobeSurfaceFilter(filters);
@@ -403,6 +408,8 @@ export function applyFilters(allStars) {
     connections: pairs,
     globeFilteredStars: globeFiltered,
     globeConnections: globePairs,
+    mollweideFilteredStars: mollweideFiltered,
+    mollweideConnections: mollweidePairs,
     showConstellationBoundaries: filters.showConstellationBoundaries,
     showConstellationNames: filters.showConstellationNames,
     showConstellationOverlay: filters.showConstellationOverlay,

--- a/filters/index.js
+++ b/filters/index.js
@@ -192,6 +192,20 @@ function addPlanesFieldset() {
   eclDiv.appendChild(eclLbl);
   contentDiv.appendChild(eclDiv);
 
+  const eqDiv = document.createElement('div');
+  eqDiv.classList.add('filter-item');
+  const eqChk = document.createElement('input');
+  eqChk.type = 'checkbox';
+  eqChk.id = 'show-celestial-equator';
+  eqChk.name = 'show-celestial-equator';
+  eqChk.checked = false;
+  const eqLbl = document.createElement('label');
+  eqLbl.htmlFor = 'show-celestial-equator';
+  eqLbl.textContent = 'Show Celestial Equator';
+  eqDiv.appendChild(eqChk);
+  eqDiv.appendChild(eqLbl);
+  contentDiv.appendChild(eqDiv);
+
   fs.appendChild(contentDiv);
   filterForm.appendChild(fs);
 }
@@ -223,7 +237,8 @@ export function applyFilters(allStars) {
         densityGridSize: 0,
         showClouds: false,
         showGalacticPlane: false,
-        showEclipticPlane: false
+        showEclipticPlane: false,
+        showCelestialEquator: false
       };
     }
   }
@@ -252,7 +267,8 @@ export function applyFilters(allStars) {
     densityGridSize: parseFloat(formData.get('density-grid-size')) || 0,
     showClouds: (formData.getAll('dust-clouds').length > 0),
     showGalacticPlane: (formData.get('show-galactic-plane') !== null),
-    showEclipticPlane: (formData.get('show-ecliptic-plane') !== null)
+    showEclipticPlane: (formData.get('show-ecliptic-plane') !== null),
+    showCelestialEquator: (formData.get('show-celestial-equator') !== null)
   };
 
   let filteredStars = applyDistanceFilter(allStars, filters);
@@ -406,6 +422,7 @@ export function applyFilters(allStars) {
     showClouds: filters.showClouds,
     showGalacticPlane: filters.showGalacticPlane,
     showEclipticPlane: filters.showEclipticPlane,
+    showCelestialEquator: filters.showCelestialEquator,
     isolationOverlay,
     densityOverlay
   };

--- a/filters/index.js
+++ b/filters/index.js
@@ -51,6 +51,7 @@ export async function setupFilterUI(allStars) {
   });
   addConstellationsFieldset();
   addGlobeSurfaceFieldset();
+  addPlanesFieldset();
   // Clouds fieldset is added in the UI file.
   await loadConstellationBoundaries();
   await loadConstellationCenters();
@@ -146,6 +147,55 @@ function addGlobeSurfaceFieldset() {
   filterForm.appendChild(fs);
 }
 
+function addPlanesFieldset() {
+  const fs = document.createElement('fieldset');
+  const legend = document.createElement('legend');
+  legend.classList.add('collapsible');
+  legend.textContent = 'Planes';
+  fs.appendChild(legend);
+
+  const contentDiv = document.createElement('div');
+  contentDiv.classList.add('filter-content');
+  contentDiv.style.maxHeight = '0px';
+  legend.addEventListener('click', () => {
+    legend.classList.toggle('active');
+    const isActive = legend.classList.contains('active');
+    legend.setAttribute('aria-expanded', isActive);
+    contentDiv.style.maxHeight = isActive ? contentDiv.scrollHeight + 'px' : '0px';
+  });
+
+  const galDiv = document.createElement('div');
+  galDiv.classList.add('filter-item');
+  const galChk = document.createElement('input');
+  galChk.type = 'checkbox';
+  galChk.id = 'show-galactic-plane';
+  galChk.name = 'show-galactic-plane';
+  galChk.checked = false;
+  const galLbl = document.createElement('label');
+  galLbl.htmlFor = 'show-galactic-plane';
+  galLbl.textContent = 'Show Galactic Plane';
+  galDiv.appendChild(galChk);
+  galDiv.appendChild(galLbl);
+  contentDiv.appendChild(galDiv);
+
+  const eclDiv = document.createElement('div');
+  eclDiv.classList.add('filter-item');
+  const eclChk = document.createElement('input');
+  eclChk.type = 'checkbox';
+  eclChk.id = 'show-ecliptic-plane';
+  eclChk.name = 'show-ecliptic-plane';
+  eclChk.checked = false;
+  const eclLbl = document.createElement('label');
+  eclLbl.htmlFor = 'show-ecliptic-plane';
+  eclLbl.textContent = 'Show Ecliptic Plane';
+  eclDiv.appendChild(eclChk);
+  eclDiv.appendChild(eclLbl);
+  contentDiv.appendChild(eclDiv);
+
+  fs.appendChild(contentDiv);
+  filterForm.appendChild(fs);
+}
+
 export function applyFilters(allStars) {
   if (!filterForm) {
     filterForm = document.getElementById('filters-form');
@@ -171,7 +221,9 @@ export function applyFilters(allStars) {
         maxDistance: 20,
         isolationGridSize: 0,
         densityGridSize: 0,
-        showClouds: false
+        showClouds: false,
+        showGalacticPlane: false,
+        showEclipticPlane: false
       };
     }
   }
@@ -198,7 +250,9 @@ export function applyFilters(allStars) {
     maxDistance: formData.get('max-distance'),
     isolationGridSize: parseFloat(formData.get('isolation-grid-size')) || 0,
     densityGridSize: parseFloat(formData.get('density-grid-size')) || 0,
-    showClouds: (formData.getAll('dust-clouds').length > 0)
+    showClouds: (formData.getAll('dust-clouds').length > 0),
+    showGalacticPlane: (formData.get('show-galactic-plane') !== null),
+    showEclipticPlane: (formData.get('show-ecliptic-plane') !== null)
   };
 
   let filteredStars = applyDistanceFilter(allStars, filters);
@@ -350,6 +404,8 @@ export function applyFilters(allStars) {
     isolationGridSize: filters.isolationGridSize,
     densityGridSize: filters.densityGridSize,
     showClouds: filters.showClouds,
+    showGalacticPlane: filters.showGalacticPlane,
+    showEclipticPlane: filters.showEclipticPlane,
     isolationOverlay,
     densityOverlay
   };

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -70,7 +70,12 @@ export function createCelestialEquatorMesh(size = 250) {
 
 function createGreatCircleLine(points, color, width = 2) {
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.2, linewidth: width });
+  const mat = new THREE.LineBasicMaterial({
+    color,
+    transparent: true,
+    opacity: 0.5,
+    linewidth: width
+  });
   return new THREE.Line(geom, mat);
 }
 
@@ -81,7 +86,7 @@ export function createGalacticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = galacticToEquatorial(l, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffffff, 6);
+  return createGreatCircleLine(pts, 0xffffff, 12);
 }
 
 export function createEclipticPlaneGlobe(R = 100, segments = 180) {
@@ -91,7 +96,7 @@ export function createEclipticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = eclipticToEquatorial(lam, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffff00, 2);
+  return createGreatCircleLine(pts, 0xffff00, 6);
 }
 
 export function createCelestialEquatorGlobe(R = 100, segments = 180) {
@@ -101,13 +106,13 @@ export function createCelestialEquatorGlobe(R = 100, segments = 180) {
     const dec = 0;
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xff0000, 2);
+  return createGreatCircleLine(pts, 0xff0000, 6);
 }
 
 export function createGalacticPlaneMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 6, transparent: true, opacity: 0.2 })
+    new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 12, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateGalacticPlaneMollweide(line);
@@ -140,7 +145,7 @@ export function updateGalacticPlaneMollweide(line) {
 export function createEclipticPlaneMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 2, transparent: true, opacity: 0.2 })
+    new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 6, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateEclipticPlaneMollweide(line);
@@ -150,7 +155,7 @@ export function createEclipticPlaneMollweide(segments = 180) {
 export function createCelestialEquatorMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 2, transparent: true, opacity: 0.2 })
+    new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 6, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateCelestialEquatorMollweide(line);

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -1,0 +1,146 @@
+// filters/planesFilter.js
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { radToSphere, radToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
+
+const DEG2RAD = Math.PI / 180;
+
+// Galactic to equatorial conversion constants (J2000)
+const alphaGP = 192.85948 * DEG2RAD;
+const deltaGP = 27.12825 * DEG2RAD;
+const lOmega  = 32.93192 * DEG2RAD;
+
+// Obliquity of the ecliptic
+const epsilon = 23.43928 * DEG2RAD;
+
+function galacticToEquatorial(l, b) {
+  const sinb = Math.sin(b);
+  const cosb = Math.cos(b);
+  const sinl = Math.sin(l - lOmega);
+  const cosl = Math.cos(l - lOmega);
+  const sinDec = sinb * Math.cos(deltaGP) + cosb * Math.sin(deltaGP) * cosl;
+  const dec = Math.asin(sinDec);
+  const y = sinl * cosb;
+  const x = cosb * cosl * Math.cos(deltaGP) - sinb * Math.sin(deltaGP);
+  let ra = Math.atan2(y, x) + alphaGP;
+  if (ra < 0) ra += 2 * Math.PI;
+  if (ra > 2 * Math.PI) ra -= 2 * Math.PI;
+  return { ra, dec };
+}
+
+function eclipticToEquatorial(lambda, beta = 0) {
+  const sinB = Math.sin(beta);
+  const cosB = Math.cos(beta);
+  const sinL = Math.sin(lambda);
+  const cosL = Math.cos(lambda);
+  const sinDec = sinB * Math.cos(epsilon) + cosB * Math.sin(epsilon) * sinL;
+  const dec = Math.asin(sinDec);
+  const y = sinL * Math.cos(epsilon) - sinB * Math.sin(epsilon) * cosL / cosB;
+  const x = cosL;
+  let ra = Math.atan2(y, x);
+  if (ra < 0) ra += 2 * Math.PI;
+  return { ra, dec };
+}
+
+export function createGalacticPlaneMesh(size = 250) {
+  const geom = new THREE.PlaneGeometry(size, size);
+  const mat = new THREE.MeshBasicMaterial({ color: 0xffffff, opacity: 0.5, transparent: true, side: THREE.DoubleSide, depthWrite: false });
+  const mesh = new THREE.Mesh(geom, mat);
+  const pole = radToSphere(alphaGP, deltaGP, 1);
+  mesh.lookAt(pole);
+  return mesh;
+}
+
+export function createEclipticPlaneMesh(size = 250) {
+  const geom = new THREE.PlaneGeometry(size, size);
+  const mat = new THREE.MeshBasicMaterial({ color: 0xffff00, opacity: 0.5, transparent: true, side: THREE.DoubleSide, depthWrite: false });
+  const mesh = new THREE.Mesh(geom, mat);
+  const pole = radToSphere(270 * DEG2RAD, 66.5607 * DEG2RAD, 1);
+  mesh.lookAt(pole);
+  return mesh;
+}
+
+function createGreatCircleLine(points, color) {
+  const geom = new THREE.BufferGeometry().setFromPoints(points);
+  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.9, linewidth: 2 });
+  return new THREE.Line(geom, mat);
+}
+
+export function createGalacticPlaneGlobe(R = 100, segments = 180) {
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const l = (i / segments) * 2 * Math.PI;
+    const { ra, dec } = galacticToEquatorial(l, 0);
+    pts.push(radToSphere(ra, dec, R));
+  }
+  return createGreatCircleLine(pts, 0xffffff);
+}
+
+export function createEclipticPlaneGlobe(R = 100, segments = 180) {
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const lam = (i / segments) * 2 * Math.PI;
+    const { ra, dec } = eclipticToEquatorial(lam, 0);
+    pts.push(radToSphere(ra, dec, R));
+  }
+  return createGreatCircleLine(pts, 0xffff00);
+}
+
+export function createGalacticPlaneMollweide(segments = 180) {
+  const line = new THREE.LineSegments(new THREE.BufferGeometry(), new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 2 }));
+  line.userData.segments = segments;
+  updateGalacticPlaneMollweide(line);
+  return line;
+}
+
+export function updateGalacticPlaneMollweide(line) {
+  const segments = line.userData.segments || 180;
+  const lambda0 = getMollweideLambda0();
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const l = (i / segments) * 2 * Math.PI;
+    const { ra, dec } = galacticToEquatorial(l, 0);
+    pts.push(radToMollweide(ra, dec, 100, lambda0));
+  }
+  const positions = [];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const splits = splitMollweideWrap(pts[i], pts[i + 1]);
+    splits.forEach(pair => {
+      positions.push(pair[0].x, pair[0].y, 0);
+      positions.push(pair[1].x, pair[1].y, 0);
+    });
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  line.geometry.dispose();
+  line.geometry = geom;
+}
+
+export function createEclipticPlaneMollweide(segments = 180) {
+  const line = new THREE.LineSegments(new THREE.BufferGeometry(), new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 2 }));
+  line.userData.segments = segments;
+  updateEclipticPlaneMollweide(line);
+  return line;
+}
+
+export function updateEclipticPlaneMollweide(line) {
+  const segments = line.userData.segments || 180;
+  const lambda0 = getMollweideLambda0();
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const lam = (i / segments) * 2 * Math.PI;
+    const { ra, dec } = eclipticToEquatorial(lam, 0);
+    pts.push(radToMollweide(ra, dec, 100, lambda0));
+  }
+  const positions = [];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const splits = splitMollweideWrap(pts[i], pts[i + 1]);
+    splits.forEach(pair => {
+      positions.push(pair[0].x, pair[0].y, 0);
+      positions.push(pair[1].x, pair[1].y, 0);
+    });
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  line.geometry.dispose();
+  line.geometry = geom;
+}

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -43,7 +43,7 @@ function eclipticToEquatorial(lambda, beta = 0) {
 
 export function createGalacticPlaneMesh(size = 250) {
   const geom = new THREE.PlaneGeometry(size, size);
-  const mat = new THREE.MeshBasicMaterial({ color: 0xffffff, opacity: 0.5, transparent: true, side: THREE.DoubleSide, depthWrite: false });
+  const mat = new THREE.MeshBasicMaterial({ color: 0xffffff, opacity: 0.2, transparent: true, side: THREE.DoubleSide, depthWrite: false });
   const mesh = new THREE.Mesh(geom, mat);
   const pole = radToSphere(alphaGP, deltaGP, 1);
   mesh.lookAt(pole);
@@ -52,16 +52,25 @@ export function createGalacticPlaneMesh(size = 250) {
 
 export function createEclipticPlaneMesh(size = 250) {
   const geom = new THREE.PlaneGeometry(size, size);
-  const mat = new THREE.MeshBasicMaterial({ color: 0xffff00, opacity: 0.5, transparent: true, side: THREE.DoubleSide, depthWrite: false });
+  const mat = new THREE.MeshBasicMaterial({ color: 0xffff00, opacity: 0.2, transparent: true, side: THREE.DoubleSide, depthWrite: false });
   const mesh = new THREE.Mesh(geom, mat);
   const pole = radToSphere(270 * DEG2RAD, 66.5607 * DEG2RAD, 1);
   mesh.lookAt(pole);
   return mesh;
 }
 
-function createGreatCircleLine(points, color) {
+export function createCelestialEquatorMesh(size = 250) {
+  const geom = new THREE.PlaneGeometry(size, size);
+  const mat = new THREE.MeshBasicMaterial({ color: 0xff0000, opacity: 0.2, transparent: true, side: THREE.DoubleSide, depthWrite: false });
+  const mesh = new THREE.Mesh(geom, mat);
+  const pole = radToSphere(0, 90 * DEG2RAD, 1);
+  mesh.lookAt(pole);
+  return mesh;
+}
+
+function createGreatCircleLine(points, color, width = 2) {
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.9, linewidth: 2 });
+  const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.2, linewidth: width });
   return new THREE.Line(geom, mat);
 }
 
@@ -72,7 +81,7 @@ export function createGalacticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = galacticToEquatorial(l, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffffff);
+  return createGreatCircleLine(pts, 0xffffff, 6);
 }
 
 export function createEclipticPlaneGlobe(R = 100, segments = 180) {
@@ -82,11 +91,24 @@ export function createEclipticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = eclipticToEquatorial(lam, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffff00);
+  return createGreatCircleLine(pts, 0xffff00, 2);
+}
+
+export function createCelestialEquatorGlobe(R = 100, segments = 180) {
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const ra = (i / segments) * 2 * Math.PI;
+    const dec = 0;
+    pts.push(radToSphere(ra, dec, R));
+  }
+  return createGreatCircleLine(pts, 0xff0000, 2);
 }
 
 export function createGalacticPlaneMollweide(segments = 180) {
-  const line = new THREE.LineSegments(new THREE.BufferGeometry(), new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 2 }));
+  const line = new THREE.LineSegments(
+    new THREE.BufferGeometry(),
+    new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 6, transparent: true, opacity: 0.2 })
+  );
   line.userData.segments = segments;
   updateGalacticPlaneMollweide(line);
   return line;
@@ -116,9 +138,22 @@ export function updateGalacticPlaneMollweide(line) {
 }
 
 export function createEclipticPlaneMollweide(segments = 180) {
-  const line = new THREE.LineSegments(new THREE.BufferGeometry(), new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 2 }));
+  const line = new THREE.LineSegments(
+    new THREE.BufferGeometry(),
+    new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 2, transparent: true, opacity: 0.2 })
+  );
   line.userData.segments = segments;
   updateEclipticPlaneMollweide(line);
+  return line;
+}
+
+export function createCelestialEquatorMollweide(segments = 180) {
+  const line = new THREE.LineSegments(
+    new THREE.BufferGeometry(),
+    new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 2, transparent: true, opacity: 0.2 })
+  );
+  line.userData.segments = segments;
+  updateCelestialEquatorMollweide(line);
   return line;
 }
 
@@ -130,6 +165,28 @@ export function updateEclipticPlaneMollweide(line) {
     const lam = (i / segments) * 2 * Math.PI;
     const { ra, dec } = eclipticToEquatorial(lam, 0);
     pts.push(radToMollweide(ra, dec, 100, lambda0));
+  }
+  const positions = [];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const splits = splitMollweideWrap(pts[i], pts[i + 1]);
+    splits.forEach(pair => {
+      positions.push(pair[0].x, pair[0].y, 0);
+      positions.push(pair[1].x, pair[1].y, 0);
+    });
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  line.geometry.dispose();
+  line.geometry = geom;
+}
+
+export function updateCelestialEquatorMollweide(line) {
+  const segments = line.userData.segments || 180;
+  const lambda0 = getMollweideLambda0();
+  const pts = [];
+  for (let i = 0; i <= segments; i++) {
+    const ra = (i / segments) * 2 * Math.PI;
+    pts.push(radToMollweide(ra, 0, 100, lambda0));
   }
   const positions = [];
   for (let i = 0; i < pts.length - 1; i++) {

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -86,7 +86,7 @@ export function createGalacticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = galacticToEquatorial(l, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffffff, 12);
+  return createGreatCircleLine(pts, 0xffffff, 20);
 }
 
 export function createEclipticPlaneGlobe(R = 100, segments = 180) {
@@ -96,7 +96,7 @@ export function createEclipticPlaneGlobe(R = 100, segments = 180) {
     const { ra, dec } = eclipticToEquatorial(lam, 0);
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xffff00, 6);
+  return createGreatCircleLine(pts, 0xffff00, 10);
 }
 
 export function createCelestialEquatorGlobe(R = 100, segments = 180) {
@@ -106,13 +106,13 @@ export function createCelestialEquatorGlobe(R = 100, segments = 180) {
     const dec = 0;
     pts.push(radToSphere(ra, dec, R));
   }
-  return createGreatCircleLine(pts, 0xff0000, 6);
+  return createGreatCircleLine(pts, 0xff0000, 10);
 }
 
 export function createGalacticPlaneMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 12, transparent: true, opacity: 0.5 })
+    new THREE.LineBasicMaterial({ color: 0xffffff, linewidth: 20, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateGalacticPlaneMollweide(line);
@@ -145,7 +145,7 @@ export function updateGalacticPlaneMollweide(line) {
 export function createEclipticPlaneMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 6, transparent: true, opacity: 0.5 })
+    new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 10, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateEclipticPlaneMollweide(line);
@@ -155,7 +155,7 @@ export function createEclipticPlaneMollweide(segments = 180) {
 export function createCelestialEquatorMollweide(segments = 180) {
   const line = new THREE.LineSegments(
     new THREE.BufferGeometry(),
-    new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 6, transparent: true, opacity: 0.5 })
+    new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 10, transparent: true, opacity: 0.5 })
   );
   line.userData.segments = segments;
   updateCelestialEquatorMollweide(line);

--- a/script.js
+++ b/script.js
@@ -8,6 +8,16 @@ import { initIsolationFilter, updateIsolationFilter } from './filters/isolationF
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
 import { applyGlobeSurfaceFilter } from './filters/globeSurfaceFilter.js';
 import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct import
+import {
+  createGalacticPlaneMesh,
+  createEclipticPlaneMesh,
+  createGalacticPlaneGlobe,
+  createEclipticPlaneGlobe,
+  createGalacticPlaneMollweide,
+  updateGalacticPlaneMollweide,
+  createEclipticPlaneMollweide,
+  updateEclipticPlaneMollweide
+} from './filters/planesFilter.js';
 import { ThreeDControls, TwoDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
 import { showTooltip, hideTooltip } from './tooltips.js';
@@ -35,12 +45,20 @@ let constellationOverlayMoll = [];
 let globeSurfaceSphere = null;
 let isolationOverlay = null;
 let densityOverlay = null;
+let galacticPlaneTrue = null;
+let eclipticPlaneTrue = null;
+let galacticPlaneGlobe = null;
+let eclipticPlaneGlobe = null;
+let galacticPlaneMoll = null;
+let eclipticPlaneMoll = null;
 let showConstellationBoundariesFlag = false;
 let showConstellationNamesFlag = false;
 let showConstellationOverlayFlag = false;
 let enableIsolationFilterFlag = false;
 let enableDensityFilterFlag = false;
 let showCloudsFlag = false;
+let showGalacticPlaneFlag = false;
+let showEclipticPlaneFlag = false;
 
 function getStarTruePosition(star) {
   const R = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
@@ -245,6 +263,8 @@ async function buildAndApplyFilters() {
     isolationGridSize,
     densityGridSize,
     showClouds,
+    showGalacticPlane,
+    showEclipticPlane,
     isolationOverlay: returnedIsolationOverlay,
     densityOverlay: returnedDensityOverlay
   } = filters;
@@ -255,6 +275,8 @@ async function buildAndApplyFilters() {
   enableIsolationFilterFlag = enableIsolationFilter;
   enableDensityFilterFlag = enableDensityFilter;
   showCloudsFlag = showClouds;
+  showGalacticPlaneFlag = showGalacticPlane;
+  showEclipticPlaneFlag = showEclipticPlane;
 
   // store overlay references for external refresh calls
   isolationOverlay = returnedIsolationOverlay;
@@ -320,6 +342,8 @@ async function buildAndApplyFilters() {
     updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudDataFiles);
   }
 
+  applyPlanes(showGalacticPlane, showEclipticPlane);
+
   applyGlobeSurface(globeOpaqueSurface);
 }
 
@@ -351,6 +375,50 @@ function removeConstellationOverlayObjectsFromGlobe() {
     constellationOverlayMoll.forEach(mesh => mollweideMap.scene.remove(mesh));
   }
   constellationOverlayMoll = [];
+}
+
+function applyPlanes(showGal, showEcl) {
+  if (showGal) {
+    if (!galacticPlaneTrue) {
+      galacticPlaneTrue = createGalacticPlaneMesh(200);
+      trueCoordinatesMap.scene.add(galacticPlaneTrue);
+    }
+    if (!galacticPlaneGlobe) {
+      galacticPlaneGlobe = createGalacticPlaneGlobe(100);
+      globeMap.scene.add(galacticPlaneGlobe);
+    }
+    if (!galacticPlaneMoll) {
+      galacticPlaneMoll = createGalacticPlaneMollweide();
+      mollweideMap.scene.add(galacticPlaneMoll);
+    } else {
+      updateGalacticPlaneMollweide(galacticPlaneMoll);
+    }
+  } else {
+    if (galacticPlaneTrue) { trueCoordinatesMap.scene.remove(galacticPlaneTrue); galacticPlaneTrue.geometry.dispose(); galacticPlaneTrue.material.dispose(); galacticPlaneTrue = null; }
+    if (galacticPlaneGlobe) { globeMap.scene.remove(galacticPlaneGlobe); galacticPlaneGlobe.geometry.dispose(); galacticPlaneGlobe.material.dispose(); galacticPlaneGlobe = null; }
+    if (galacticPlaneMoll) { mollweideMap.scene.remove(galacticPlaneMoll); galacticPlaneMoll.geometry.dispose(); galacticPlaneMoll.material.dispose(); galacticPlaneMoll = null; }
+  }
+
+  if (showEcl) {
+    if (!eclipticPlaneTrue) {
+      eclipticPlaneTrue = createEclipticPlaneMesh(200);
+      trueCoordinatesMap.scene.add(eclipticPlaneTrue);
+    }
+    if (!eclipticPlaneGlobe) {
+      eclipticPlaneGlobe = createEclipticPlaneGlobe(100);
+      globeMap.scene.add(eclipticPlaneGlobe);
+    }
+    if (!eclipticPlaneMoll) {
+      eclipticPlaneMoll = createEclipticPlaneMollweide();
+      mollweideMap.scene.add(eclipticPlaneMoll);
+    } else {
+      updateEclipticPlaneMollweide(eclipticPlaneMoll);
+    }
+  } else {
+    if (eclipticPlaneTrue) { trueCoordinatesMap.scene.remove(eclipticPlaneTrue); eclipticPlaneTrue.geometry.dispose(); eclipticPlaneTrue.material.dispose(); eclipticPlaneTrue = null; }
+    if (eclipticPlaneGlobe) { globeMap.scene.remove(eclipticPlaneGlobe); eclipticPlaneGlobe.geometry.dispose(); eclipticPlaneGlobe.material.dispose(); eclipticPlaneGlobe = null; }
+    if (eclipticPlaneMoll) { mollweideMap.scene.remove(eclipticPlaneMoll); eclipticPlaneMoll.geometry.dispose(); eclipticPlaneMoll.material.dispose(); eclipticPlaneMoll = null; }
+  }
 }
 
 function applyGlobeSurface(isOpaque) {
@@ -713,6 +781,12 @@ function updateMollweideView() {
     if (typeof densityOverlay.refreshMollweide === 'function') {
       densityOverlay.refreshMollweide();
     }
+  }
+  if (showGalacticPlaneFlag && galacticPlaneMoll) {
+    updateGalacticPlaneMollweide(galacticPlaneMoll);
+  }
+  if (showEclipticPlaneFlag && eclipticPlaneMoll) {
+    updateEclipticPlaneMollweide(eclipticPlaneMoll);
   }
 }
 window.updateMollweideView = updateMollweideView;

--- a/script.js
+++ b/script.js
@@ -11,12 +11,16 @@ import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct impo
 import {
   createGalacticPlaneMesh,
   createEclipticPlaneMesh,
+  createCelestialEquatorMesh,
   createGalacticPlaneGlobe,
   createEclipticPlaneGlobe,
+  createCelestialEquatorGlobe,
   createGalacticPlaneMollweide,
   updateGalacticPlaneMollweide,
   createEclipticPlaneMollweide,
-  updateEclipticPlaneMollweide
+  updateEclipticPlaneMollweide,
+  createCelestialEquatorMollweide,
+  updateCelestialEquatorMollweide
 } from './filters/planesFilter.js';
 import { ThreeDControls, TwoDControls } from './cameraControls.js';
 import { LabelManager } from './labelManager.js';
@@ -47,10 +51,13 @@ let isolationOverlay = null;
 let densityOverlay = null;
 let galacticPlaneTrue = null;
 let eclipticPlaneTrue = null;
+let celestialEquatorTrue = null;
 let galacticPlaneGlobe = null;
 let eclipticPlaneGlobe = null;
+let celestialEquatorGlobe = null;
 let galacticPlaneMoll = null;
 let eclipticPlaneMoll = null;
+let celestialEquatorMoll = null;
 let showConstellationBoundariesFlag = false;
 let showConstellationNamesFlag = false;
 let showConstellationOverlayFlag = false;
@@ -59,6 +66,7 @@ let enableDensityFilterFlag = false;
 let showCloudsFlag = false;
 let showGalacticPlaneFlag = false;
 let showEclipticPlaneFlag = false;
+let showCelestialEquatorFlag = false;
 
 function getStarTruePosition(star) {
   const R = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
@@ -265,6 +273,7 @@ async function buildAndApplyFilters() {
     showClouds,
     showGalacticPlane,
     showEclipticPlane,
+    showCelestialEquator,
     isolationOverlay: returnedIsolationOverlay,
     densityOverlay: returnedDensityOverlay
   } = filters;
@@ -277,6 +286,7 @@ async function buildAndApplyFilters() {
   showCloudsFlag = showClouds;
   showGalacticPlaneFlag = showGalacticPlane;
   showEclipticPlaneFlag = showEclipticPlane;
+  showCelestialEquatorFlag = showCelestialEquator;
 
   // store overlay references for external refresh calls
   isolationOverlay = returnedIsolationOverlay;
@@ -342,7 +352,7 @@ async function buildAndApplyFilters() {
     updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudDataFiles);
   }
 
-  applyPlanes(showGalacticPlane, showEclipticPlane);
+  applyPlanes(showGalacticPlane, showEclipticPlane, showCelestialEquator);
 
   applyGlobeSurface(globeOpaqueSurface);
 }
@@ -377,7 +387,7 @@ function removeConstellationOverlayObjectsFromGlobe() {
   constellationOverlayMoll = [];
 }
 
-function applyPlanes(showGal, showEcl) {
+function applyPlanes(showGal, showEcl, showEq) {
   if (showGal) {
     if (!galacticPlaneTrue) {
       galacticPlaneTrue = createGalacticPlaneMesh(200);
@@ -418,6 +428,27 @@ function applyPlanes(showGal, showEcl) {
     if (eclipticPlaneTrue) { trueCoordinatesMap.scene.remove(eclipticPlaneTrue); eclipticPlaneTrue.geometry.dispose(); eclipticPlaneTrue.material.dispose(); eclipticPlaneTrue = null; }
     if (eclipticPlaneGlobe) { globeMap.scene.remove(eclipticPlaneGlobe); eclipticPlaneGlobe.geometry.dispose(); eclipticPlaneGlobe.material.dispose(); eclipticPlaneGlobe = null; }
     if (eclipticPlaneMoll) { mollweideMap.scene.remove(eclipticPlaneMoll); eclipticPlaneMoll.geometry.dispose(); eclipticPlaneMoll.material.dispose(); eclipticPlaneMoll = null; }
+  }
+
+  if (showEq) {
+    if (!celestialEquatorTrue) {
+      celestialEquatorTrue = createCelestialEquatorMesh(200);
+      trueCoordinatesMap.scene.add(celestialEquatorTrue);
+    }
+    if (!celestialEquatorGlobe) {
+      celestialEquatorGlobe = createCelestialEquatorGlobe(100);
+      globeMap.scene.add(celestialEquatorGlobe);
+    }
+    if (!celestialEquatorMoll) {
+      celestialEquatorMoll = createCelestialEquatorMollweide();
+      mollweideMap.scene.add(celestialEquatorMoll);
+    } else {
+      updateCelestialEquatorMollweide(celestialEquatorMoll);
+    }
+  } else {
+    if (celestialEquatorTrue) { trueCoordinatesMap.scene.remove(celestialEquatorTrue); celestialEquatorTrue.geometry.dispose(); celestialEquatorTrue.material.dispose(); celestialEquatorTrue = null; }
+    if (celestialEquatorGlobe) { globeMap.scene.remove(celestialEquatorGlobe); celestialEquatorGlobe.geometry.dispose(); celestialEquatorGlobe.material.dispose(); celestialEquatorGlobe = null; }
+    if (celestialEquatorMoll) { mollweideMap.scene.remove(celestialEquatorMoll); celestialEquatorMoll.geometry.dispose(); celestialEquatorMoll.material.dispose(); celestialEquatorMoll = null; }
   }
 }
 
@@ -787,6 +818,9 @@ function updateMollweideView() {
   }
   if (showEclipticPlaneFlag && eclipticPlaneMoll) {
     updateEclipticPlaneMollweide(eclipticPlaneMoll);
+  }
+  if (showCelestialEquatorFlag && celestialEquatorMoll) {
+    updateCelestialEquatorMollweide(celestialEquatorMoll);
   }
 }
 window.updateMollweideView = updateMollweideView;

--- a/script.js
+++ b/script.js
@@ -33,6 +33,8 @@ let currentFilteredStars = [];
 let currentConnections = [];
 let currentGlobeFilteredStars = [];
 let currentGlobeConnections = [];
+let currentMollweideFilteredStars = [];
+let currentMollweideConnections = [];
 let selectedStarData = null;
 let selectedHighlightTrue = null;
 let selectedHighlightGlobe = null;
@@ -254,6 +256,8 @@ async function buildAndApplyFilters() {
     connections,
     globeFilteredStars,
     globeConnections,
+    mollweideFilteredStars,
+    mollweideConnections,
     showConstellationBoundaries,
     showConstellationNames,
     showConstellationOverlay,
@@ -296,12 +300,16 @@ async function buildAndApplyFilters() {
   currentConnections = connections;
   currentGlobeFilteredStars = globeFilteredStars;
   currentGlobeConnections = globeConnections;
+  currentMollweideFilteredStars = mollweideFilteredStars;
+  currentMollweideConnections = mollweideConnections;
 
   currentGlobeFilteredStars.forEach(star => {
     star.spherePosition = projectStarGlobe(star);
   });
   currentFilteredStars.forEach(star => {
     star.truePosition = getStarTruePosition(star);
+  });
+  currentMollweideFilteredStars.forEach(star => {
     precalcMollweideData(star);
     updateMollweidePosition(star);
   });
@@ -310,10 +318,10 @@ async function buildAndApplyFilters() {
   trueCoordinatesMap.labelManager.refreshLabels(currentFilteredStars);
   globeMap.updateMap(currentGlobeFilteredStars, currentGlobeConnections);
   globeMap.labelManager.refreshLabels(currentGlobeFilteredStars);
-  mollweideMap.addStars(currentFilteredStars);
-  mollweideMap.updateStarPositions(currentFilteredStars);
-  mollweideMap.updateConnections(currentFilteredStars, currentConnections);
-  mollweideMap.labelManager.refreshLabels(currentFilteredStars);
+  mollweideMap.addStars(currentMollweideFilteredStars);
+  mollweideMap.updateStarPositions(currentMollweideFilteredStars);
+  mollweideMap.updateConnections(currentMollweideFilteredStars, currentMollweideConnections);
+  mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
 
   removeConstellationObjectsFromGlobe();
   removeConstellationOverlayObjectsFromGlobe();
@@ -770,15 +778,15 @@ function updateSelectedStarHighlight() {
 }
 
 function updateMollweideView() {
-  if (!currentFilteredStars || currentFilteredStars.length === 0) return;
-  currentFilteredStars.forEach(star => {
+  if (!currentMollweideFilteredStars || currentMollweideFilteredStars.length === 0) return;
+  currentMollweideFilteredStars.forEach(star => {
     updateMollweidePosition(star);
   });
 
-  mollweideMap.addStars(currentFilteredStars);
-  mollweideMap.updateStarPositions(currentFilteredStars);
-  mollweideMap.updateConnectionPositions(currentFilteredStars, currentConnections);
-  mollweideMap.labelManager.refreshLabels(currentFilteredStars);
+  mollweideMap.addStars(currentMollweideFilteredStars);
+  mollweideMap.updateStarPositions(currentMollweideFilteredStars);
+  mollweideMap.updateConnectionPositions(currentMollweideFilteredStars, currentMollweideConnections);
+  mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
 
   if (showConstellationBoundariesFlag) {
     if (constellationLinesMoll.length === 0) {


### PR DESCRIPTION
## Summary
- implement planesFilter to draw galactic and ecliptic planes
- extend filter UI with new Planes fieldset
- handle plane overlays and updates in main script

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846d6e11f3c832a99487481fdbadd19