### PR TITLE
Add polygon surfaces for isolation and density filters

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, radToSphere } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, radToSphere, wrapMollweidePolygon } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 
 class DensityGridOverlay {
@@ -171,7 +171,7 @@ class DensityGridOverlay {
           const mat = new THREE.LineBasicMaterial({
             vertexColors: true,
             transparent: true,
-            opacity: 0.3,
+            opacity: 0.5,
             linewidth: 2
           });
           const line = new THREE.Line(geom, mat);
@@ -179,7 +179,7 @@ class DensityGridOverlay {
           const mollMat = new THREE.LineBasicMaterial({
             color: 0xff0000,
             transparent: true,
-            opacity: 0.9,
+            opacity: 0.5,
             linewidth: 5
           });
           const lineM = new THREE.LineSegments(geomM, mollMat);
@@ -270,8 +270,18 @@ class DensityGridOverlay {
     const clusters = this.getActiveClusters();
     clusters.forEach(cluster => {
       if (cluster.length < 3) return;
-      const pts = cluster.map(c => new THREE.Vector2(c.raRad, c.decRad));
-      const hull = computeConvexHull(pts);
+      const sinSum = cluster.reduce((s, c) => s + Math.sin(c.raRad), 0);
+      const cosSum = cluster.reduce((s, c) => s + Math.cos(c.raRad), 0);
+      const meanRa = Math.atan2(sinSum, cosSum);
+      const pts = cluster.map(c => new THREE.Vector2(
+        minimalRADifference(c.raRad - meanRa), c.decRad));
+      const hullAdj = computeConvexHull(pts);
+      const hull = hullAdj.map(p => {
+        let ra = p.x + meanRa;
+        if (ra < 0) ra += 2 * Math.PI;
+        if (ra >= 2 * Math.PI) ra -= 2 * Math.PI;
+        return new THREE.Vector2(ra, p.y);
+      });
       if (hull.length < 3) return;
 
       const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
@@ -286,16 +296,16 @@ class DensityGridOverlay {
       const g = new THREE.BufferGeometry();
       g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
       g.computeVertexNormals();
-      const m = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const m = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.5, side: THREE.DoubleSide });
       const meshG = new THREE.Mesh(g, m);
       this.surfaceMeshesGlobe.push(meshG);
       if (sceneGlobe) sceneGlobe.add(meshG);
 
-      const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
-        .map(v => new THREE.Vector2(v.x, v.y));
+      const hullMollRaw = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()));
+      const hullMoll = wrapMollweidePolygon(hullMollRaw).map(v => new THREE.Vector2(v.x, v.y));
       const shape = new THREE.Shape(hullMoll);
       const g2 = new THREE.ShapeGeometry(shape);
-      const m2 = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const m2 = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.5, side: THREE.DoubleSide });
       const meshM = new THREE.Mesh(g2, m2);
       this.surfaceMeshesMoll.push(meshM);
       if (sceneMoll) sceneMoll.add(meshM);

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, radToSphere } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 
 class DensityGridOverlay {
@@ -10,6 +10,8 @@ class DensityGridOverlay {
     this.cubesData = [];
     this.adjacentLines = [];
     this.maxDensity = 0;
+    this.surfaceMeshGlobe = null;
+    this.surfaceMeshMoll = null;
   }
 
   createGrid(stars) {
@@ -231,6 +233,8 @@ class DensityGridOverlay {
     if (sceneMoll) {
       this.adjacentLines.forEach(o => { sceneMoll.add(o.lineM); });
     }
+
+    this.updateSurfaceMeshes(sceneGlobe, sceneMoll);
   }
 
   refreshMollweide(lambda0 = getMollweideLambda0()) {
@@ -256,6 +260,67 @@ class DensityGridOverlay {
       obj.lineM.geometry.setFromPoints(pts);
     });
   }
+
+  updateSurfaceMeshes(sceneGlobe, sceneMoll) {
+    if (this.surfaceMeshGlobe && sceneGlobe) sceneGlobe.remove(this.surfaceMeshGlobe);
+    if (this.surfaceMeshMoll && sceneMoll) sceneMoll.remove(this.surfaceMeshMoll);
+    this.surfaceMeshGlobe = null;
+    this.surfaceMeshMoll = null;
+
+    const active = this.cubesData.filter(c => c.active);
+    if (active.length < 3) return;
+    const pts = active.map(c => new THREE.Vector2(c.raRad, c.decRad));
+    const hull = computeConvexHull(pts);
+    if (hull.length < 3) return;
+
+    const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
+    const posArr = [];
+    for (let i = 1; i < sphereVerts.length - 1; i++) {
+      posArr.push(
+        sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
+        sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
+        sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
+      );
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
+    g.computeVertexNormals();
+    const m = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+    this.surfaceMeshGlobe = new THREE.Mesh(g, m);
+    if (sceneGlobe) sceneGlobe.add(this.surfaceMeshGlobe);
+
+    const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
+      .map(v => new THREE.Vector2(v.x, v.y));
+    const shape = new THREE.Shape(hullMoll);
+    const g2 = new THREE.ShapeGeometry(shape);
+    const m2 = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+    this.surfaceMeshMoll = new THREE.Mesh(g2, m2);
+    if (sceneMoll) sceneMoll.add(this.surfaceMeshMoll);
+  }
+}
+
+function computeConvexHull(points) {
+  if (points.length < 3) return [];
+  points.sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  const cross = (o, a, b) => (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+  const lower = [];
+  for (const p of points) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+  const upper = [];
+  for (let i = points.length - 1; i >= 0; i--) {
+    const p = points[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+  upper.pop();
+  lower.pop();
+  return lower.concat(upper);
 }
 
 export function initDensityFilter(minDistance, maxDistance, starArray, gridSize = 2) {

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -10,8 +10,8 @@ class DensityGridOverlay {
     this.cubesData = [];
     this.adjacentLines = [];
     this.maxDensity = 0;
-    this.surfaceMeshGlobe = null;
-    this.surfaceMeshMoll = null;
+    this.surfaceMeshesGlobe = [];
+    this.surfaceMeshesMoll = [];
   }
 
   createGrid(stars) {
@@ -262,40 +262,75 @@ class DensityGridOverlay {
   }
 
   updateSurfaceMeshes(sceneGlobe, sceneMoll) {
-    if (this.surfaceMeshGlobe && sceneGlobe) sceneGlobe.remove(this.surfaceMeshGlobe);
-    if (this.surfaceMeshMoll && sceneMoll) sceneMoll.remove(this.surfaceMeshMoll);
-    this.surfaceMeshGlobe = null;
-    this.surfaceMeshMoll = null;
+    this.surfaceMeshesGlobe.forEach(mesh => { if (sceneGlobe) sceneGlobe.remove(mesh); });
+    this.surfaceMeshesMoll.forEach(mesh => { if (sceneMoll) sceneMoll.remove(mesh); });
+    this.surfaceMeshesGlobe = [];
+    this.surfaceMeshesMoll = [];
 
-    const active = this.cubesData.filter(c => c.active);
-    if (active.length < 3) return;
-    const pts = active.map(c => new THREE.Vector2(c.raRad, c.decRad));
-    const hull = computeConvexHull(pts);
-    if (hull.length < 3) return;
+    const clusters = this.getActiveClusters();
+    clusters.forEach(cluster => {
+      if (cluster.length < 3) return;
+      const pts = cluster.map(c => new THREE.Vector2(c.raRad, c.decRad));
+      const hull = computeConvexHull(pts);
+      if (hull.length < 3) return;
 
-    const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
-    const posArr = [];
-    for (let i = 1; i < sphereVerts.length - 1; i++) {
-      posArr.push(
-        sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
-        sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
-        sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
-      );
-    }
-    const g = new THREE.BufferGeometry();
-    g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
-    g.computeVertexNormals();
-    const m = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
-    this.surfaceMeshGlobe = new THREE.Mesh(g, m);
-    if (sceneGlobe) sceneGlobe.add(this.surfaceMeshGlobe);
+      const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
+      const posArr = [];
+      for (let i = 1; i < sphereVerts.length - 1; i++) {
+        posArr.push(
+          sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
+          sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
+          sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
+        );
+      }
+      const g = new THREE.BufferGeometry();
+      g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
+      g.computeVertexNormals();
+      const m = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const meshG = new THREE.Mesh(g, m);
+      this.surfaceMeshesGlobe.push(meshG);
+      if (sceneGlobe) sceneGlobe.add(meshG);
 
-    const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
-      .map(v => new THREE.Vector2(v.x, v.y));
-    const shape = new THREE.Shape(hullMoll);
-    const g2 = new THREE.ShapeGeometry(shape);
-    const m2 = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
-    this.surfaceMeshMoll = new THREE.Mesh(g2, m2);
-    if (sceneMoll) sceneMoll.add(this.surfaceMeshMoll);
+      const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
+        .map(v => new THREE.Vector2(v.x, v.y));
+      const shape = new THREE.Shape(hullMoll);
+      const g2 = new THREE.ShapeGeometry(shape);
+      const m2 = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const meshM = new THREE.Mesh(g2, m2);
+      this.surfaceMeshesMoll.push(meshM);
+      if (sceneMoll) sceneMoll.add(meshM);
+    });
+  }
+
+  getActiveClusters() {
+    const neighbors = new Map();
+    this.cubesData.forEach(c => {
+      if (c.active) neighbors.set(c.id, []);
+    });
+    this.adjacentLines.forEach(obj => {
+      const { cell1, cell2 } = obj;
+      if (cell1.active && cell2.active) {
+        neighbors.get(cell1.id).push(cell2);
+        neighbors.get(cell2.id).push(cell1);
+      }
+    });
+    const visited = new Set();
+    const clusters = [];
+    this.cubesData.forEach(cell => {
+      if (!cell.active || visited.has(cell.id)) return;
+      const stack = [cell];
+      visited.add(cell.id);
+      const cluster = [];
+      while (stack.length > 0) {
+        const c = stack.pop();
+        cluster.push(c);
+        neighbors.get(c.id).forEach(n => {
+          if (!visited.has(n.id)) { visited.add(n.id); stack.push(n); }
+        });
+      }
+      clusters.push(cluster);
+    });
+    return clusters;
   }
 }
 

--- a/filters/index.js
+++ b/filters/index.js
@@ -331,6 +331,12 @@ export function applyFilters(allStars) {
             window.mollweideMap.scene.remove(obj.lineM);
           }
         });
+        if (isolationOverlay.surfaceMeshGlobe) {
+          window.globeMap.scene.remove(isolationOverlay.surfaceMeshGlobe);
+        }
+        if (isolationOverlay.surfaceMeshMoll) {
+          window.mollweideMap.scene.remove(isolationOverlay.surfaceMeshMoll);
+        }
       }
       isolationOverlay = initIsolationFilter(filters.minDistance, filters.maxDistance, allStars, gridSize);
       // Add new meshes.
@@ -353,6 +359,12 @@ export function applyFilters(allStars) {
         window.globeMap.scene.remove(obj.line);
         window.mollweideMap.scene.remove(obj.lineM);
       });
+      if (isolationOverlay.surfaceMeshGlobe) {
+        window.globeMap.scene.remove(isolationOverlay.surfaceMeshGlobe);
+      }
+      if (isolationOverlay.surfaceMeshMoll) {
+        window.mollweideMap.scene.remove(isolationOverlay.surfaceMeshMoll);
+      }
       isolationOverlay = null;
     }
   }
@@ -374,6 +386,12 @@ export function applyFilters(allStars) {
           window.globeMap.scene.remove(obj.line);
           window.mollweideMap.scene.remove(obj.lineM);
         });
+        if (densityOverlay.surfaceMeshGlobe) {
+          window.globeMap.scene.remove(densityOverlay.surfaceMeshGlobe);
+        }
+        if (densityOverlay.surfaceMeshMoll) {
+          window.mollweideMap.scene.remove(densityOverlay.surfaceMeshMoll);
+        }
       }
       densityOverlay = initDensityFilter(filters.minDistance, filters.maxDistance, allStars, gridSize);
       densityOverlay.cubesData.forEach(cell => {
@@ -394,6 +412,12 @@ export function applyFilters(allStars) {
         window.globeMap.scene.remove(obj.line);
         window.mollweideMap.scene.remove(obj.lineM);
       });
+      if (densityOverlay.surfaceMeshGlobe) {
+        window.globeMap.scene.remove(densityOverlay.surfaceMeshGlobe);
+      }
+      if (densityOverlay.surfaceMeshMoll) {
+        window.mollweideMap.scene.remove(densityOverlay.surfaceMeshMoll);
+      }
       densityOverlay = null;
     }
   }

--- a/filters/index.js
+++ b/filters/index.js
@@ -331,11 +331,11 @@ export function applyFilters(allStars) {
             window.mollweideMap.scene.remove(obj.lineM);
           }
         });
-        if (isolationOverlay.surfaceMeshGlobe) {
-          window.globeMap.scene.remove(isolationOverlay.surfaceMeshGlobe);
+        if (isolationOverlay.surfaceMeshesGlobe) {
+          isolationOverlay.surfaceMeshesGlobe.forEach(m => window.globeMap.scene.remove(m));
         }
-        if (isolationOverlay.surfaceMeshMoll) {
-          window.mollweideMap.scene.remove(isolationOverlay.surfaceMeshMoll);
+        if (isolationOverlay.surfaceMeshesMoll) {
+          isolationOverlay.surfaceMeshesMoll.forEach(m => window.mollweideMap.scene.remove(m));
         }
       }
       isolationOverlay = initIsolationFilter(filters.minDistance, filters.maxDistance, allStars, gridSize);
@@ -359,11 +359,11 @@ export function applyFilters(allStars) {
         window.globeMap.scene.remove(obj.line);
         window.mollweideMap.scene.remove(obj.lineM);
       });
-      if (isolationOverlay.surfaceMeshGlobe) {
-        window.globeMap.scene.remove(isolationOverlay.surfaceMeshGlobe);
+      if (isolationOverlay.surfaceMeshesGlobe) {
+        isolationOverlay.surfaceMeshesGlobe.forEach(m => window.globeMap.scene.remove(m));
       }
-      if (isolationOverlay.surfaceMeshMoll) {
-        window.mollweideMap.scene.remove(isolationOverlay.surfaceMeshMoll);
+      if (isolationOverlay.surfaceMeshesMoll) {
+        isolationOverlay.surfaceMeshesMoll.forEach(m => window.mollweideMap.scene.remove(m));
       }
       isolationOverlay = null;
     }
@@ -386,11 +386,11 @@ export function applyFilters(allStars) {
           window.globeMap.scene.remove(obj.line);
           window.mollweideMap.scene.remove(obj.lineM);
         });
-        if (densityOverlay.surfaceMeshGlobe) {
-          window.globeMap.scene.remove(densityOverlay.surfaceMeshGlobe);
+        if (densityOverlay.surfaceMeshesGlobe) {
+          densityOverlay.surfaceMeshesGlobe.forEach(m => window.globeMap.scene.remove(m));
         }
-        if (densityOverlay.surfaceMeshMoll) {
-          window.mollweideMap.scene.remove(densityOverlay.surfaceMeshMoll);
+        if (densityOverlay.surfaceMeshesMoll) {
+          densityOverlay.surfaceMeshesMoll.forEach(m => window.mollweideMap.scene.remove(m));
         }
       }
       densityOverlay = initDensityFilter(filters.minDistance, filters.maxDistance, allStars, gridSize);
@@ -412,11 +412,11 @@ export function applyFilters(allStars) {
         window.globeMap.scene.remove(obj.line);
         window.mollweideMap.scene.remove(obj.lineM);
       });
-      if (densityOverlay.surfaceMeshGlobe) {
-        window.globeMap.scene.remove(densityOverlay.surfaceMeshGlobe);
+      if (densityOverlay.surfaceMeshesGlobe) {
+        densityOverlay.surfaceMeshesGlobe.forEach(m => window.globeMap.scene.remove(m));
       }
-      if (densityOverlay.surfaceMeshMoll) {
-        window.mollweideMap.scene.remove(densityOverlay.surfaceMeshMoll);
+      if (densityOverlay.surfaceMeshesMoll) {
+        densityOverlay.surfaceMeshesMoll.forEach(m => window.mollweideMap.scene.remove(m));
       }
       densityOverlay = null;
     }

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -23,8 +23,8 @@ class IsolationGridOverlay {
     this.regionLabelsGroupTC = new THREE.Group();
     this.regionLabelsGroupGlobe = new THREE.Group();
     this.regionLabelsGroupMoll = new THREE.Group();
-    this.surfaceMeshGlobe = null;
-    this.surfaceMeshMoll = null;
+    this.surfaceMeshesGlobe = [];
+    this.surfaceMeshesMoll = [];
   }
 
   createGrid(stars) {
@@ -336,40 +336,75 @@ class IsolationGridOverlay {
   }
 
   updateSurfaceMeshes(sceneGlobe, sceneMoll) {
-    if (this.surfaceMeshGlobe && sceneGlobe) sceneGlobe.remove(this.surfaceMeshGlobe);
-    if (this.surfaceMeshMoll && sceneMoll) sceneMoll.remove(this.surfaceMeshMoll);
-    this.surfaceMeshGlobe = null;
-    this.surfaceMeshMoll = null;
+    this.surfaceMeshesGlobe.forEach(mesh => { if (sceneGlobe) sceneGlobe.remove(mesh); });
+    this.surfaceMeshesMoll.forEach(mesh => { if (sceneMoll) sceneMoll.remove(mesh); });
+    this.surfaceMeshesGlobe = [];
+    this.surfaceMeshesMoll = [];
 
-    const active = this.cubesData.filter(c => c.active);
-    if (active.length < 3) return;
-    const pts = active.map(c => new THREE.Vector2(c.raRad, c.decRad));
-    const hull = computeConvexHull(pts);
-    if (hull.length < 3) return;
+    const clusters = this.getActiveClusters();
+    clusters.forEach(cluster => {
+      if (cluster.length < 3) return;
+      const pts = cluster.map(c => new THREE.Vector2(c.raRad, c.decRad));
+      const hull = computeConvexHull(pts);
+      if (hull.length < 3) return;
 
-    const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
-    const posArr = [];
-    for (let i = 1; i < sphereVerts.length - 1; i++) {
-      posArr.push(
-        sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
-        sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
-        sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
-      );
-    }
-    const g = new THREE.BufferGeometry();
-    g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
-    g.computeVertexNormals();
-    const m = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
-    this.surfaceMeshGlobe = new THREE.Mesh(g, m);
-    if (sceneGlobe) sceneGlobe.add(this.surfaceMeshGlobe);
+      const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
+      const posArr = [];
+      for (let i = 1; i < sphereVerts.length - 1; i++) {
+        posArr.push(
+          sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
+          sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
+          sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
+        );
+      }
+      const g = new THREE.BufferGeometry();
+      g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
+      g.computeVertexNormals();
+      const m = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const meshG = new THREE.Mesh(g, m);
+      this.surfaceMeshesGlobe.push(meshG);
+      if (sceneGlobe) sceneGlobe.add(meshG);
 
-    const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
-      .map(v => new THREE.Vector2(v.x, v.y));
-    const shape = new THREE.Shape(hullMoll);
-    const g2 = new THREE.ShapeGeometry(shape);
-    const m2 = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
-    this.surfaceMeshMoll = new THREE.Mesh(g2, m2);
-    if (sceneMoll) sceneMoll.add(this.surfaceMeshMoll);
+      const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
+        .map(v => new THREE.Vector2(v.x, v.y));
+      const shape = new THREE.Shape(hullMoll);
+      const g2 = new THREE.ShapeGeometry(shape);
+      const m2 = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const meshM = new THREE.Mesh(g2, m2);
+      this.surfaceMeshesMoll.push(meshM);
+      if (sceneMoll) sceneMoll.add(meshM);
+    });
+  }
+
+  getActiveClusters() {
+    const neighbors = new Map();
+    this.cubesData.forEach(c => {
+      if (c.active) neighbors.set(c.id, []);
+    });
+    this.adjacentLines.forEach(obj => {
+      const { cell1, cell2 } = obj;
+      if (cell1.active && cell2.active) {
+        neighbors.get(cell1.id).push(cell2);
+        neighbors.get(cell2.id).push(cell1);
+      }
+    });
+    const visited = new Set();
+    const clusters = [];
+    this.cubesData.forEach(cell => {
+      if (!cell.active || visited.has(cell.id)) return;
+      const stack = [cell];
+      visited.add(cell.id);
+      const cluster = [];
+      while (stack.length > 0) {
+        const c = stack.pop();
+        cluster.push(c);
+        neighbors.get(c.id).forEach(n => {
+          if (!visited.has(n.id)) { visited.add(n.id); stack.push(n); }
+        });
+      }
+      clusters.push(cluster);
+    });
+    return clusters;
   }
 
   async assignConstellationsToCells() {

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, wrapMollweidePolygon } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
@@ -183,7 +183,7 @@ class IsolationGridOverlay {
           const mat = new THREE.LineBasicMaterial({
             vertexColors: true,
             transparent: true,
-            opacity: 0.3,
+            opacity: 0.5,
             linewidth: 2
           });
           const line = new THREE.Line(geom, mat);
@@ -191,7 +191,7 @@ class IsolationGridOverlay {
           const mollMat = new THREE.LineBasicMaterial({
             color: 0x0000ff,
             transparent: true,
-            opacity: 0.9,
+            opacity: 0.5,
             linewidth: 5
           });
           const lineM = new THREE.LineSegments(geomM, mollMat);
@@ -344,8 +344,18 @@ class IsolationGridOverlay {
     const clusters = this.getActiveClusters();
     clusters.forEach(cluster => {
       if (cluster.length < 3) return;
-      const pts = cluster.map(c => new THREE.Vector2(c.raRad, c.decRad));
-      const hull = computeConvexHull(pts);
+      const sinSum = cluster.reduce((s, c) => s + Math.sin(c.raRad), 0);
+      const cosSum = cluster.reduce((s, c) => s + Math.cos(c.raRad), 0);
+      const meanRa = Math.atan2(sinSum, cosSum);
+      const pts = cluster.map(c => new THREE.Vector2(
+        minimalRADifference(c.raRad - meanRa), c.decRad));
+      const hullAdj = computeConvexHull(pts);
+      const hull = hullAdj.map(p => {
+        let ra = p.x + meanRa;
+        if (ra < 0) ra += 2 * Math.PI;
+        if (ra >= 2 * Math.PI) ra -= 2 * Math.PI;
+        return new THREE.Vector2(ra, p.y);
+      });
       if (hull.length < 3) return;
 
       const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
@@ -360,16 +370,16 @@ class IsolationGridOverlay {
       const g = new THREE.BufferGeometry();
       g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
       g.computeVertexNormals();
-      const m = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const m = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.5, side: THREE.DoubleSide });
       const meshG = new THREE.Mesh(g, m);
       this.surfaceMeshesGlobe.push(meshG);
       if (sceneGlobe) sceneGlobe.add(meshG);
 
-      const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
-        .map(v => new THREE.Vector2(v.x, v.y));
+      const hullMollRaw = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()));
+      const hullMoll = wrapMollweidePolygon(hullMollRaw).map(v => new THREE.Vector2(v.x, v.y));
       const shape = new THREE.Shape(hullMoll);
       const g2 = new THREE.ShapeGeometry(shape);
-      const m2 = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+      const m2 = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.5, side: THREE.DoubleSide });
       const meshM = new THREE.Mesh(g2, m2);
       this.surfaceMeshesMoll.push(meshM);
       if (sceneMoll) sceneMoll.add(meshM);

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -23,6 +23,8 @@ class IsolationGridOverlay {
     this.regionLabelsGroupTC = new THREE.Group();
     this.regionLabelsGroupGlobe = new THREE.Group();
     this.regionLabelsGroupMoll = new THREE.Group();
+    this.surfaceMeshGlobe = null;
+    this.surfaceMeshMoll = null;
   }
 
   createGrid(stars) {
@@ -305,6 +307,8 @@ class IsolationGridOverlay {
         sceneMoll.add(obj.lineM);
       });
     }
+
+    this.updateSurfaceMeshes(sceneGlobe, sceneMoll);
   }
 
   refreshMollweide(lambda0 = getMollweideLambda0()) {
@@ -329,6 +333,43 @@ class IsolationGridOverlay {
       }
       obj.lineM.geometry.setFromPoints(pts);
     });
+  }
+
+  updateSurfaceMeshes(sceneGlobe, sceneMoll) {
+    if (this.surfaceMeshGlobe && sceneGlobe) sceneGlobe.remove(this.surfaceMeshGlobe);
+    if (this.surfaceMeshMoll && sceneMoll) sceneMoll.remove(this.surfaceMeshMoll);
+    this.surfaceMeshGlobe = null;
+    this.surfaceMeshMoll = null;
+
+    const active = this.cubesData.filter(c => c.active);
+    if (active.length < 3) return;
+    const pts = active.map(c => new THREE.Vector2(c.raRad, c.decRad));
+    const hull = computeConvexHull(pts);
+    if (hull.length < 3) return;
+
+    const sphereVerts = hull.map(p => radToSphere(p.x, p.y, 100));
+    const posArr = [];
+    for (let i = 1; i < sphereVerts.length - 1; i++) {
+      posArr.push(
+        sphereVerts[0].x, sphereVerts[0].y, sphereVerts[0].z,
+        sphereVerts[i].x, sphereVerts[i].y, sphereVerts[i].z,
+        sphereVerts[i + 1].x, sphereVerts[i + 1].y, sphereVerts[i + 1].z
+      );
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(posArr, 3));
+    g.computeVertexNormals();
+    const m = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+    this.surfaceMeshGlobe = new THREE.Mesh(g, m);
+    if (sceneGlobe) sceneGlobe.add(this.surfaceMeshGlobe);
+
+    const hullMoll = hull.map(p => radToMollweide(p.x, p.y, 100, getMollweideLambda0()))
+      .map(v => new THREE.Vector2(v.x, v.y));
+    const shape = new THREE.Shape(hullMoll);
+    const g2 = new THREE.ShapeGeometry(shape);
+    const m2 = new THREE.MeshBasicMaterial({ color: 0x0000ff, transparent: true, opacity: 0.15, side: THREE.DoubleSide });
+    this.surfaceMeshMoll = new THREE.Mesh(g2, m2);
+    if (sceneMoll) sceneMoll.add(this.surfaceMeshMoll);
   }
 
   async assignConstellationsToCells() {
@@ -435,6 +476,30 @@ function computeCellDistances(cell, stars) {
   dArr.sort((a, b) => a.distance - b.distance);
   cell.distances = dArr.map(obj => obj.distance);
   cell.nearestStar = dArr.length > 0 ? dArr[0].star : null;
+}
+
+function computeConvexHull(points) {
+  if (points.length < 3) return [];
+  points.sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+  const cross = (o, a, b) => (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+  const lower = [];
+  for (const p of points) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+  const upper = [];
+  for (let i = points.length - 1; i >= 0; i--) {
+    const p = points[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+  upper.pop();
+  lower.pop();
+  return lower.concat(upper);
 }
 
 // Helper: Convert string to Title Case.

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -287,3 +287,20 @@ export function greatCircleToMollweide(p1, p2, R = 100, segments = 32, lambda0 =
     return radToMollweide(ra, dec, R, lambda0);
   });
 }
+
+export function wrapMollweidePolygon(points) {
+  if (!points.length) return [];
+  const wrapped = [points[0].clone()];
+  for (let i = 1; i < points.length; i++) {
+    const prev = wrapped[i - 1];
+    const curr = points[i].clone();
+    while (curr.x - prev.x > 200) curr.x -= 400;
+    while (prev.x - curr.x > 200) curr.x += 400;
+    wrapped.push(curr);
+  }
+  wrapped.forEach(p => {
+    while (p.x > 200) p.x -= 400;
+    while (p.x < -200) p.x += 400;
+  });
+  return wrapped;
+}


### PR DESCRIPTION
## Summary
- add surface meshes to Isolation and Density filters
- show polygons on globe and Mollweide projections
- clean up overlays when filters are disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684704b4e62c832a8845792fb16e68da