### PR TITLE
Fill triangles in isolation & density overlays

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -218,11 +218,11 @@ class DensityGridOverlay {
             const c2 = cells.find(c => c.id === jId);
             const c3 = cells.find(c => c.id === kId);
             const geomG = createSphericalTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, 2, 100);
-            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.5, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshG = new THREE.Mesh(geomG, matG);
 
             const geomM = createMollweideTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, getMollweideLambda0(), 16);
-            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.5, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshM = new THREE.Mesh(geomM, matM);
             this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
           }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideWrap } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 
 class DensityGridOverlay {

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideTriangleWrap } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, createSphericalTriangleGeometry, createMollweideTriangleGeometry } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 
 class DensityGridOverlay {
@@ -217,28 +217,12 @@ class DensityGridOverlay {
             const c1 = cells[i];
             const c2 = cells.find(c => c.id === jId);
             const c3 = cells.find(c => c.id === kId);
-            const vertsG = [c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position];
-            const gPos = [];
-            vertsG.forEach(v => { gPos.push(v.x, v.y, v.z); });
-            const geomG = new THREE.BufferGeometry();
-            geomG.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
-            geomG.setIndex([0,1,2]);
-            geomG.computeVertexNormals();
-            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+            const geomG = createSphericalTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, 2, 100);
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshG = new THREE.Mesh(geomG, matG);
 
-            const vertsM = [
-              radToMollweide(c1.raRad, c1.decRad, 100, getMollweideLambda0()),
-              radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
-              radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
-            ];
-            const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
-            const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-            const geomM = new THREE.BufferGeometry();
-            geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-            geomM.setIndex([0,1,2]);
-            geomM.computeVertexNormals();
-            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide });
+            const geomM = createMollweideTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, getMollweideLambda0(), 16);
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshM = new THREE.Mesh(geomM, matM);
             this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
           }
@@ -289,19 +273,10 @@ class DensityGridOverlay {
       meshG.visible = visible;
       meshM.visible = visible;
       if (visible) {
-        const gPos = [cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position]
-          .flatMap(v => [v.x, v.y, v.z]);
-        meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
-        meshG.geometry.attributes.position.needsUpdate = true;
-        const vertsM = [
-          radToMollweide(cell1.raRad, cell1.decRad, 100, getMollweideLambda0()),
-          radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
-          radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
-        ];
-        const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
-        const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-        meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-        meshM.geometry.attributes.position.needsUpdate = true;
+        meshG.geometry.dispose();
+        meshM.geometry.dispose();
+        meshG.geometry = createSphericalTriangleGeometry(cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position, 2, 100);
+        meshM.geometry = createMollweideTriangleGeometry(cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position, getMollweideLambda0(), 16);
       }
     });
     if (sceneTC) {
@@ -341,15 +316,8 @@ class DensityGridOverlay {
     });
 
     this.triangleMeshes.forEach(obj => {
-      const verts = [
-        radToMollweide(obj.cell1.raRad, obj.cell1.decRad, 100, lambda0),
-        radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
-        radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
-      ];
-      const [a1,a2,a3] = adjustMollweideTriangleWrap(verts[0], verts[1], verts[2]);
-      const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-      obj.meshM.geometry.attributes.position.needsUpdate = true;
+      obj.meshM.geometry.dispose();
+      obj.meshM.geometry = createMollweideTriangleGeometry(obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position, lambda0, 16);
     });
   }
 }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -9,7 +9,9 @@ class DensityGridOverlay {
     this.gridSize = gridSize;
     this.cubesData = [];
     this.adjacentLines = [];
+    this.triangleMeshes = [];
     this.maxDensity = 0;
+    this.lineColor = 0xff0000;
   }
 
   createGrid(stars) {
@@ -180,11 +182,65 @@ class DensityGridOverlay {
             opacity: 0.9,
             linewidth: 5
           });
-          const lineM = new THREE.LineSegments(geomM, mollMat);
-          this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
-        }
-      });
+        const lineM = new THREE.LineSegments(geomM, mollMat);
+        this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
+      }
     });
+  });
+
+    this.computeTriangles();
+  }
+
+  computeTriangles() {
+    this.triangleMeshes = [];
+    const neighbors = new Map();
+    this.adjacentLines.forEach(obj => {
+      const a = obj.cell1.id;
+      const b = obj.cell2.id;
+      if (!neighbors.has(a)) neighbors.set(a, new Set());
+      if (!neighbors.has(b)) neighbors.set(b, new Set());
+      neighbors.get(a).add(b);
+      neighbors.get(b).add(a);
+    });
+
+    const cells = this.cubesData;
+    for (let i = 0; i < cells.length; i++) {
+      const ni = neighbors.get(cells[i].id);
+      if (!ni) continue;
+      ni.forEach(jId => {
+        if (jId <= cells[i].id) return;
+        const nj = neighbors.get(jId);
+        if (!nj) return;
+        ni.forEach(kId => {
+          if (kId <= jId) return;
+          if (nj.has(kId) && neighbors.get(kId)?.has(cells[i].id)) {
+            const c1 = cells[i];
+            const c2 = cells.find(c => c.id === jId);
+            const c3 = cells.find(c => c.id === kId);
+            const vertsG = [c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position];
+            const gPos = [];
+            vertsG.forEach(v => { gPos.push(v.x, v.y, v.z); });
+            const geomG = new THREE.BufferGeometry();
+            geomG.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
+            geomG.setIndex([0,1,2]);
+            geomG.computeVertexNormals();
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+            const meshG = new THREE.Mesh(geomG, matG);
+
+            const vertsM = [c1.mollweideMesh.position, c2.mollweideMesh.position, c3.mollweideMesh.position];
+            const mPos = [];
+            vertsM.forEach(v => { mPos.push(v.x, v.y, 0); });
+            const geomM = new THREE.BufferGeometry();
+            geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
+            geomM.setIndex([0,1,2]);
+            geomM.computeVertexNormals();
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide });
+            const meshM = new THREE.Mesh(geomM, matM);
+            this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
+          }
+        });
+      });
+    }
   }
 
   update(stars, sceneTC, sceneGlobe, sceneMoll) {
@@ -222,14 +278,33 @@ class DensityGridOverlay {
       line.visible = cell1.active && cell2.active;
       lineM.visible = cell1.active && cell2.active;
     });
+
+    this.triangleMeshes.forEach(obj => {
+      const { meshG, meshM, cell1, cell2, cell3 } = obj;
+      const visible = cell1.active && cell2.active && cell3.active;
+      meshG.visible = visible;
+      meshM.visible = visible;
+      if (visible) {
+        const gPos = [cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position]
+          .flatMap(v => [v.x, v.y, v.z]);
+        meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
+        meshG.geometry.attributes.position.needsUpdate = true;
+        const mPos = [cell1.mollweideMesh.position, cell2.mollweideMesh.position, cell3.mollweideMesh.position]
+          .flatMap(v => [v.x, v.y, 0]);
+        meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
+        meshM.geometry.attributes.position.needsUpdate = true;
+      }
+    });
     if (sceneTC) {
       this.cubesData.forEach(c => { sceneTC.add(c.tcMesh); });
     }
     if (sceneGlobe) {
       this.adjacentLines.forEach(o => { sceneGlobe.add(o.line); });
+      this.triangleMeshes.forEach(o => { sceneGlobe.add(o.meshG); });
     }
     if (sceneMoll) {
       this.adjacentLines.forEach(o => { sceneMoll.add(o.lineM); });
+      this.triangleMeshes.forEach(o => { sceneMoll.add(o.meshM); });
     }
   }
 
@@ -254,6 +329,17 @@ class DensityGridOverlay {
         segs.forEach(([s,e]) => { pts.push(s, e); });
       }
       obj.lineM.geometry.setFromPoints(pts);
+    });
+
+    this.triangleMeshes.forEach(obj => {
+      const verts = [obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position]
+        .map(v => {
+          const { ra, dec } = vectorToRaDecRad(v, 100);
+          return radToMollweide(ra, dec, 100, lambda0);
+        });
+      const pos = verts.flatMap(v => [v.x, v.y, 0]);
+      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(pos,3));
+      obj.meshM.geometry.attributes.position.needsUpdate = true;
     });
   }
 }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -227,9 +227,20 @@ class DensityGridOverlay {
             const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
             const meshG = new THREE.Mesh(geomG, matG);
 
-            const vertsM = [c1.mollweideMesh.position, c2.mollweideMesh.position, c3.mollweideMesh.position];
+            const vertsM = [
+              radToMollweide(c1.raRad, c1.decRad, 100, getMollweideLambda0()),
+              radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
+              radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
+            ];
             const mPos = [];
-            vertsM.forEach(v => { mPos.push(v.x, v.y, 0); });
+            vertsM.forEach((v, idx) => {
+              if (idx > 0) {
+                const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
+                v = adj;
+                vertsM[idx] = v;
+              }
+              mPos.push(v.x, v.y, 0);
+            });
             const geomM = new THREE.BufferGeometry();
             geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
             geomM.setIndex([0,1,2]);
@@ -289,8 +300,20 @@ class DensityGridOverlay {
           .flatMap(v => [v.x, v.y, v.z]);
         meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
         meshG.geometry.attributes.position.needsUpdate = true;
-        const mPos = [cell1.mollweideMesh.position, cell2.mollweideMesh.position, cell3.mollweideMesh.position]
-          .flatMap(v => [v.x, v.y, 0]);
+        const vertsM = [
+          radToMollweide(cell1.raRad, cell1.decRad, 100, getMollweideLambda0()),
+          radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
+          radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
+        ];
+        const mPos = [];
+        vertsM.forEach((v, idx) => {
+          if (idx > 0) {
+            const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
+            v = adj;
+            vertsM[idx] = v;
+          }
+          mPos.push(v.x, v.y, 0);
+        });
         meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
         meshM.geometry.attributes.position.needsUpdate = true;
       }
@@ -332,13 +355,21 @@ class DensityGridOverlay {
     });
 
     this.triangleMeshes.forEach(obj => {
-      const verts = [obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position]
-        .map(v => {
-          const { ra, dec } = vectorToRaDecRad(v, 100);
-          return radToMollweide(ra, dec, 100, lambda0);
-        });
-      const pos = verts.flatMap(v => [v.x, v.y, 0]);
-      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(pos,3));
+      const verts = [
+        radToMollweide(obj.cell1.raRad, obj.cell1.decRad, 100, lambda0),
+        radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
+        radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
+      ];
+      const mPos = [];
+      verts.forEach((v, idx) => {
+        if (idx > 0) {
+          const [adj] = adjustMollweideWrap(v, verts[idx - 1]);
+          v = adj;
+          verts[idx] = v;
+        }
+        mPos.push(v.x, v.y, 0);
+      });
+      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
       obj.meshM.geometry.attributes.position.needsUpdate = true;
     });
   }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideTriangleWrap } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 
 class DensityGridOverlay {
@@ -232,15 +232,8 @@ class DensityGridOverlay {
               radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
               radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
             ];
-            const mPos = [];
-            vertsM.forEach((v, idx) => {
-              if (idx > 0) {
-                const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
-                v = adj;
-                vertsM[idx] = v;
-              }
-              mPos.push(v.x, v.y, 0);
-            });
+            const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
+            const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
             const geomM = new THREE.BufferGeometry();
             geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
             geomM.setIndex([0,1,2]);
@@ -305,15 +298,8 @@ class DensityGridOverlay {
           radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
           radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
         ];
-        const mPos = [];
-        vertsM.forEach((v, idx) => {
-          if (idx > 0) {
-            const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
-            v = adj;
-            vertsM[idx] = v;
-          }
-          mPos.push(v.x, v.y, 0);
-        });
+        const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
+        const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
         meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
         meshM.geometry.attributes.position.needsUpdate = true;
       }
@@ -360,15 +346,8 @@ class DensityGridOverlay {
         radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
         radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
       ];
-      const mPos = [];
-      verts.forEach((v, idx) => {
-        if (idx > 0) {
-          const [adj] = adjustMollweideWrap(v, verts[idx - 1]);
-          v = adj;
-          verts[idx] = v;
-        }
-        mPos.push(v.x, v.y, 0);
-      });
+      const [a1,a2,a3] = adjustMollweideTriangleWrap(verts[0], verts[1], verts[2]);
+      const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
       obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
       obj.meshM.geometry.attributes.position.needsUpdate = true;
     });

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -19,10 +19,12 @@ class IsolationGridOverlay {
     this.gridSize = gridSize;
     this.cubesData = [];
     this.adjacentLines = [];
+    this.triangleMeshes = [];
     this.regionClusters = [];
     this.regionLabelsGroupTC = new THREE.Group();
     this.regionLabelsGroupGlobe = new THREE.Group();
     this.regionLabelsGroupMoll = new THREE.Group();
+    this.lineColor = 0x0000ff;
   }
 
   createGrid(stars) {
@@ -192,11 +194,65 @@ class IsolationGridOverlay {
             opacity: 0.9,
             linewidth: 5
           });
-          const lineM = new THREE.LineSegments(geomM, mollMat);
-          this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
-        }
-      });
+        const lineM = new THREE.LineSegments(geomM, mollMat);
+        this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
+      }
     });
+  });
+
+    this.computeTriangles();
+  }
+
+  computeTriangles() {
+    this.triangleMeshes = [];
+    const neighbors = new Map();
+    this.adjacentLines.forEach(obj => {
+      const a = obj.cell1.id;
+      const b = obj.cell2.id;
+      if (!neighbors.has(a)) neighbors.set(a, new Set());
+      if (!neighbors.has(b)) neighbors.set(b, new Set());
+      neighbors.get(a).add(b);
+      neighbors.get(b).add(a);
+    });
+
+    const cells = this.cubesData;
+    for (let i = 0; i < cells.length; i++) {
+      const ni = neighbors.get(cells[i].id);
+      if (!ni) continue;
+      ni.forEach(jId => {
+        if (jId <= cells[i].id) return;
+        const nj = neighbors.get(jId);
+        if (!nj) return;
+        ni.forEach(kId => {
+          if (kId <= jId) return;
+          if (nj.has(kId) && neighbors.get(kId)?.has(cells[i].id)) {
+            const c1 = cells[i];
+            const c2 = cells.find(c => c.id === jId);
+            const c3 = cells.find(c => c.id === kId);
+            const vertsG = [c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position];
+            const gPos = [];
+            vertsG.forEach(v => { gPos.push(v.x, v.y, v.z); });
+            const geomG = new THREE.BufferGeometry();
+            geomG.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
+            geomG.setIndex([0,1,2]);
+            geomG.computeVertexNormals();
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+            const meshG = new THREE.Mesh(geomG, matG);
+
+            const vertsM = [c1.mollweideMesh.position, c2.mollweideMesh.position, c3.mollweideMesh.position];
+            const mPos = [];
+            vertsM.forEach(v => { mPos.push(v.x, v.y, 0); });
+            const geomM = new THREE.BufferGeometry();
+            geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
+            geomM.setIndex([0,1,2]);
+            geomM.computeVertexNormals();
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide });
+            const meshM = new THREE.Mesh(geomM, matM);
+            this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
+          }
+        });
+      });
+    }
   }
 
   // Updated update() method now accepts sceneTC, sceneGlobe, and sceneMoll to re-add new meshes.
@@ -287,6 +343,23 @@ class IsolationGridOverlay {
       }
     });
 
+    this.triangleMeshes.forEach(obj => {
+      const { meshG, meshM, cell1, cell2, cell3 } = obj;
+      const visible = cell1.active && cell2.active && cell3.active;
+      meshG.visible = visible;
+      meshM.visible = visible;
+      if (visible) {
+        const gPos = [cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position]
+          .flatMap(v => [v.x, v.y, v.z]);
+        meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
+        meshG.geometry.attributes.position.needsUpdate = true;
+        const mPos = [cell1.mollweideMesh.position, cell2.mollweideMesh.position, cell3.mollweideMesh.position]
+          .flatMap(v => [v.x, v.y, 0]);
+        meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
+        meshM.geometry.attributes.position.needsUpdate = true;
+      }
+    });
+
     // Re‑add the updated meshes to the scenes. Only the cubes are shown for
     // True Coordinates, while the Globe and Mollweide maps display just the
     // connecting lines.
@@ -299,10 +372,16 @@ class IsolationGridOverlay {
       this.adjacentLines.forEach(obj => {
         sceneGlobe.add(obj.line);
       });
+      this.triangleMeshes.forEach(obj => {
+        sceneGlobe.add(obj.meshG);
+      });
     }
     if (sceneMoll) {
       this.adjacentLines.forEach(obj => {
         sceneMoll.add(obj.lineM);
+      });
+      this.triangleMeshes.forEach(obj => {
+        sceneMoll.add(obj.meshM);
       });
     }
   }
@@ -328,6 +407,17 @@ class IsolationGridOverlay {
         segs.forEach(([s,e]) => { pts.push(s, e); });
       }
       obj.lineM.geometry.setFromPoints(pts);
+    });
+
+    this.triangleMeshes.forEach(obj => {
+      const verts = [obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position]
+        .map(v => {
+          const { ra, dec } = vectorToRaDecRad(v, 100);
+          return radToMollweide(ra, dec, 100, lambda0);
+        });
+      const pos = verts.flatMap(v => [v.x, v.y, 0]);
+      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(pos,3));
+      obj.meshM.geometry.attributes.position.needsUpdate = true;
     });
   }
 

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideTriangleWrap } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
@@ -244,15 +244,8 @@ class IsolationGridOverlay {
               radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
               radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
             ];
-            const mPos = [];
-            vertsM.forEach((v, idx) => {
-              if (idx > 0) {
-                const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
-                v = adj;
-                vertsM[idx] = v;
-              }
-              mPos.push(v.x, v.y, 0);
-            });
+            const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
+            const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
             const geomM = new THREE.BufferGeometry();
             geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
             geomM.setIndex([0,1,2]);
@@ -369,15 +362,8 @@ class IsolationGridOverlay {
           radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
           radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
         ];
-        const mPos = [];
-        vertsM.forEach((v, idx) => {
-          if (idx > 0) {
-            const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
-            v = adj;
-            vertsM[idx] = v;
-          }
-          mPos.push(v.x, v.y, 0);
-        });
+        const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
+        const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
         meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
         meshM.geometry.attributes.position.needsUpdate = true;
       }
@@ -438,15 +424,8 @@ class IsolationGridOverlay {
         radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
         radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
       ];
-      const mPos = [];
-      verts.forEach((v, idx) => {
-        if (idx > 0) {
-          const [adj] = adjustMollweideWrap(v, verts[idx - 1]);
-          v = adj;
-          verts[idx] = v;
-        }
-        mPos.push(v.x, v.y, 0);
-      });
+      const [a1,a2,a3] = adjustMollweideTriangleWrap(verts[0], verts[1], verts[2]);
+      const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
       obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
       obj.meshM.geometry.attributes.position.needsUpdate = true;
     });

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideTriangleWrap } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, createSphericalTriangleGeometry, createMollweideTriangleGeometry } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 
@@ -229,28 +229,12 @@ class IsolationGridOverlay {
             const c1 = cells[i];
             const c2 = cells.find(c => c.id === jId);
             const c3 = cells.find(c => c.id === kId);
-            const vertsG = [c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position];
-            const gPos = [];
-            vertsG.forEach(v => { gPos.push(v.x, v.y, v.z); });
-            const geomG = new THREE.BufferGeometry();
-            geomG.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
-            geomG.setIndex([0,1,2]);
-            geomG.computeVertexNormals();
-            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+            const geomG = createSphericalTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, 2, 100);
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshG = new THREE.Mesh(geomG, matG);
 
-            const vertsM = [
-              radToMollweide(c1.raRad, c1.decRad, 100, getMollweideLambda0()),
-              radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
-              radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
-            ];
-            const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
-            const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-            const geomM = new THREE.BufferGeometry();
-            geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-            geomM.setIndex([0,1,2]);
-            geomM.computeVertexNormals();
-            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide });
+            const geomM = createMollweideTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, getMollweideLambda0(), 16);
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshM = new THREE.Mesh(geomM, matM);
             this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
           }
@@ -353,19 +337,10 @@ class IsolationGridOverlay {
       meshG.visible = visible;
       meshM.visible = visible;
       if (visible) {
-        const gPos = [cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position]
-          .flatMap(v => [v.x, v.y, v.z]);
-        meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
-        meshG.geometry.attributes.position.needsUpdate = true;
-        const vertsM = [
-          radToMollweide(cell1.raRad, cell1.decRad, 100, getMollweideLambda0()),
-          radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
-          radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
-        ];
-        const [a1,a2,a3] = adjustMollweideTriangleWrap(vertsM[0], vertsM[1], vertsM[2]);
-        const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-        meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-        meshM.geometry.attributes.position.needsUpdate = true;
+        meshG.geometry.dispose();
+        meshM.geometry.dispose();
+        meshG.geometry = createSphericalTriangleGeometry(cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position, 2, 100);
+        meshM.geometry = createMollweideTriangleGeometry(cell1.globeMesh.position, cell2.globeMesh.position, cell3.globeMesh.position, getMollweideLambda0(), 16);
       }
     });
 
@@ -419,15 +394,8 @@ class IsolationGridOverlay {
     });
 
     this.triangleMeshes.forEach(obj => {
-      const verts = [
-        radToMollweide(obj.cell1.raRad, obj.cell1.decRad, 100, lambda0),
-        radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
-        radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
-      ];
-      const [a1,a2,a3] = adjustMollweideTriangleWrap(verts[0], verts[1], verts[2]);
-      const mPos = [a1,a2,a3].flatMap(v => [v.x, v.y, 0]);
-      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
-      obj.meshM.geometry.attributes.position.needsUpdate = true;
+      obj.meshM.geometry.dispose();
+      obj.meshM.geometry = createMollweideTriangleGeometry(obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position, lambda0, 16);
     });
   }
 

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -239,9 +239,20 @@ class IsolationGridOverlay {
             const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
             const meshG = new THREE.Mesh(geomG, matG);
 
-            const vertsM = [c1.mollweideMesh.position, c2.mollweideMesh.position, c3.mollweideMesh.position];
+            const vertsM = [
+              radToMollweide(c1.raRad, c1.decRad, 100, getMollweideLambda0()),
+              radToMollweide(c2.raRad, c2.decRad, 100, getMollweideLambda0()),
+              radToMollweide(c3.raRad, c3.decRad, 100, getMollweideLambda0())
+            ];
             const mPos = [];
-            vertsM.forEach(v => { mPos.push(v.x, v.y, 0); });
+            vertsM.forEach((v, idx) => {
+              if (idx > 0) {
+                const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
+                v = adj;
+                vertsM[idx] = v;
+              }
+              mPos.push(v.x, v.y, 0);
+            });
             const geomM = new THREE.BufferGeometry();
             geomM.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
             geomM.setIndex([0,1,2]);
@@ -353,8 +364,20 @@ class IsolationGridOverlay {
           .flatMap(v => [v.x, v.y, v.z]);
         meshG.geometry.setAttribute('position', new THREE.Float32BufferAttribute(gPos,3));
         meshG.geometry.attributes.position.needsUpdate = true;
-        const mPos = [cell1.mollweideMesh.position, cell2.mollweideMesh.position, cell3.mollweideMesh.position]
-          .flatMap(v => [v.x, v.y, 0]);
+        const vertsM = [
+          radToMollweide(cell1.raRad, cell1.decRad, 100, getMollweideLambda0()),
+          radToMollweide(cell2.raRad, cell2.decRad, 100, getMollweideLambda0()),
+          radToMollweide(cell3.raRad, cell3.decRad, 100, getMollweideLambda0())
+        ];
+        const mPos = [];
+        vertsM.forEach((v, idx) => {
+          if (idx > 0) {
+            const [adj] = adjustMollweideWrap(v, vertsM[idx - 1]);
+            v = adj;
+            vertsM[idx] = v;
+          }
+          mPos.push(v.x, v.y, 0);
+        });
         meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
         meshM.geometry.attributes.position.needsUpdate = true;
       }
@@ -410,13 +433,21 @@ class IsolationGridOverlay {
     });
 
     this.triangleMeshes.forEach(obj => {
-      const verts = [obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, obj.cell3.globeMesh.position]
-        .map(v => {
-          const { ra, dec } = vectorToRaDecRad(v, 100);
-          return radToMollweide(ra, dec, 100, lambda0);
-        });
-      const pos = verts.flatMap(v => [v.x, v.y, 0]);
-      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(pos,3));
+      const verts = [
+        radToMollweide(obj.cell1.raRad, obj.cell1.decRad, 100, lambda0),
+        radToMollweide(obj.cell2.raRad, obj.cell2.decRad, 100, lambda0),
+        radToMollweide(obj.cell3.raRad, obj.cell3.decRad, 100, lambda0)
+      ];
+      const mPos = [];
+      verts.forEach((v, idx) => {
+        if (idx > 0) {
+          const [adj] = adjustMollweideWrap(v, verts[idx - 1]);
+          v = adj;
+          verts[idx] = v;
+        }
+        mPos.push(v.x, v.y, 0);
+      });
+      obj.meshM.geometry.setAttribute('position', new THREE.Float32BufferAttribute(mPos,3));
       obj.meshM.geometry.attributes.position.needsUpdate = true;
     });
   }

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -230,11 +230,11 @@ class IsolationGridOverlay {
             const c2 = cells.find(c => c.id === jId);
             const c3 = cells.find(c => c.id === kId);
             const geomG = createSphericalTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, 2, 100);
-            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.3, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
+            const matG = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.5, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshG = new THREE.Mesh(geomG, matG);
 
             const geomM = createMollweideTriangleGeometry(c1.globeMesh.position, c2.globeMesh.position, c3.globeMesh.position, getMollweideLambda0(), 16);
-            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.9, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
+            const matM = new THREE.MeshBasicMaterial({ color: this.lineColor, transparent: true, opacity: 0.5, side: THREE.DoubleSide, blending: THREE.NoBlending, depthWrite: false });
             const meshM = new THREE.Mesh(geomM, matM);
             this.triangleMeshes.push({ meshG, meshM, cell1: c1, cell2: c2, cell3: c3 });
           }

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -2,7 +2,7 @@
 // This module implements the Isolation Filter using a uniform grid (formerly the low density filter).
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { getDoubleSidedLabelMaterial, getBlueColor, lightenColor } from './densityColorUtils.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, vectorToRaDecRad, radToMollweide, adjustMollweideWrap } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { loadConstellationCenters, getConstellationCenters, loadConstellationBoundaries, getConstellationBoundaries } from './constellationFilter.js';
 

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -238,37 +238,38 @@ export function adjustMollweideWrap(p1, p2) {
  * @returns {[THREE.Vector3, THREE.Vector3, THREE.Vector3]}
  */
 export function adjustMollweideTriangleWrap(p1, p2, p3) {
-  const verts = [p1.clone(), p2.clone(), p3.clone()];
-  let best = verts.map(v => v.clone());
+  const candidates = [-400, 0, 400];
+  let best = [p1.clone(), p2.clone(), p3.clone()];
   let minRange = Infinity;
-  for (let base = 0; base < 3; base++) {
-    const arr = verts.map(v => v.clone());
-    for (let i = 0; i < 3; i++) {
-      if (i === base) continue;
-      while (arr[i].x - arr[base].x > 200) arr[i].x -= 400;
-      while (arr[base].x - arr[i].x > 200) arr[i].x += 400;
-    }
-    const xs = arr.map(v => v.x);
-    const range = Math.max(...xs) - Math.min(...xs);
-    if (range < minRange) {
-      minRange = range;
-      best = arr.map(v => v.clone());
+
+  for (const s1 of candidates) {
+    for (const s2 of candidates) {
+      for (const s3 of candidates) {
+        const arr = [
+          new THREE.Vector3(p1.x + s1, p1.y, 0),
+          new THREE.Vector3(p2.x + s2, p2.y, 0),
+          new THREE.Vector3(p3.x + s3, p3.y, 0)
+        ];
+        const xs = arr.map(v => v.x);
+        const range = Math.max(...xs) - Math.min(...xs);
+        if (range < minRange) {
+          minRange = range;
+          best = arr.map(v => v.clone());
+        }
+      }
     }
   }
+
   const xs = best.map(v => v.x);
   let center = (Math.max(...xs) + Math.min(...xs)) / 2;
-  while (center > 200) {
-    best.forEach(v => { v.x -= 400; });
-    center -= 400;
-  }
-  while (center < -200) {
-    best.forEach(v => { v.x += 400; });
-    center += 400;
-  }
+  const shift = Math.round(center / 400);
+  best.forEach(v => { v.x -= shift * 400; });
+
   best.forEach(v => {
     while (v.x > 200) v.x -= 400;
     while (v.x < -200) v.x += 400;
   });
+
   return best;
 }
 

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -331,3 +331,65 @@ export function greatCircleToMollweide(p1, p2, R = 100, segments = 32, lambda0 =
     return radToMollweide(ra, dec, R, lambda0);
   });
 }
+
+/**
+ * Creates a curved triangular patch on the sphere by subdividing a basic
+ * triangle whose vertices lie on the sphere surface.
+ * @param {THREE.Vector3} v1
+ * @param {THREE.Vector3} v2
+ * @param {THREE.Vector3} v3
+ * @param {number} [subdivisions=2]
+ * @param {number} [R=100]
+ * @returns {THREE.BufferGeometry}
+ */
+export function createSphericalTriangleGeometry(v1, v2, v3, subdivisions = 2, R = 100) {
+  const positions = [v1, v2, v3].flatMap(v => {
+    const p = v.clone().normalize().multiplyScalar(R);
+    return [p.x, p.y, p.z];
+  });
+  let geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setIndex([0, 1, 2]);
+  geom.computeVertexNormals();
+  geom = subdivideGeometry(geom, subdivisions);
+  return geom;
+}
+
+/**
+ * Generates a Mollweide-projected curved triangle by sampling the spherical
+ * surface and splitting segments that cross the wrap boundary.
+ * @param {THREE.Vector3} v1
+ * @param {THREE.Vector3} v2
+ * @param {THREE.Vector3} v3
+ * @param {number} [lambda0=mollweideLambda0]
+ * @param {number} [segments=16]
+ * @returns {THREE.BufferGeometry}
+ */
+export function createMollweideTriangleGeometry(v1, v2, v3, lambda0 = mollweideLambda0, segments = 16) {
+  const arcs = [
+    greatCircleToMollweide(v1, v2, 100, segments, lambda0),
+    greatCircleToMollweide(v2, v3, 100, segments, lambda0),
+    greatCircleToMollweide(v3, v1, 100, segments, lambda0)
+  ];
+  const boundary = [];
+  boundary.push(...arcs[0].slice(0, -1));
+  boundary.push(...arcs[1].slice(0, -1));
+  boundary.push(...arcs[2].slice(0, -1));
+  const center = new THREE.Vector3().addVectors(v1, v2).add(v3).normalize();
+  const { ra, dec } = vectorToRaDecRad(center, 1);
+  const centerM = radToMollweide(ra, dec, 100, lambda0);
+  const positions = [];
+  for (let i = 0; i < boundary.length; i++) {
+    const next = (i + 1) % boundary.length;
+    const segs = splitMollweideWrap(boundary[i], boundary[next]);
+    segs.forEach(([s, e]) => {
+      positions.push(centerM.x, centerM.y, 0);
+      positions.push(s.x, s.y, 0);
+      positions.push(e.x, e.y, 0);
+    });
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.computeVertexNormals();
+  return geom;
+}

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -366,18 +366,45 @@ export function createSphericalTriangleGeometry(v1, v2, v3, subdivisions = 2, R 
  * @returns {THREE.BufferGeometry}
  */
 export function createMollweideTriangleGeometry(v1, v2, v3, lambda0 = mollweideLambda0, segments = 16) {
+  const vertsOrig = [v1, v2, v3].map(v => {
+    const { ra, dec } = vectorToRaDecRad(v, 100);
+    return radToMollweide(ra, dec, 100, lambda0);
+  });
+  const vertsWrapped = adjustMollweideTriangleWrap(vertsOrig[0], vertsOrig[1], vertsOrig[2]);
+  const shifts = vertsWrapped.map((v, i) => v.x - vertsOrig[i].x);
+
   const arcs = [
     greatCircleToMollweide(v1, v2, 100, segments, lambda0),
     greatCircleToMollweide(v2, v3, 100, segments, lambda0),
     greatCircleToMollweide(v3, v1, 100, segments, lambda0)
-  ];
+  ].map((arr, idx) => {
+    const dxStart = shifts[idx];
+    const dxEnd = shifts[(idx + 1) % 3];
+    return arr.map((p, i) => {
+      const t = arr.length > 1 ? i / (arr.length - 1) : 0;
+      const dx = dxStart + (dxEnd - dxStart) * t;
+      const np = p.clone();
+      np.x += dx;
+      while (np.x > 200) np.x -= 400;
+      while (np.x < -200) np.x += 400;
+      return np;
+    });
+  });
+
   const boundary = [];
   boundary.push(...arcs[0].slice(0, -1));
   boundary.push(...arcs[1].slice(0, -1));
   boundary.push(...arcs[2].slice(0, -1));
+
   const center = new THREE.Vector3().addVectors(v1, v2).add(v3).normalize();
   const { ra, dec } = vectorToRaDecRad(center, 1);
-  const centerM = radToMollweide(ra, dec, 100, lambda0);
+  let centerM = radToMollweide(ra, dec, 100, lambda0);
+  const avgShift = (shifts[0] + shifts[1] + shifts[2]) / 3;
+  centerM = centerM.clone();
+  centerM.x += avgShift;
+  while (centerM.x > 200) centerM.x -= 400;
+  while (centerM.x < -200) centerM.x += 400;
+
   const positions = [];
   for (let i = 0; i < boundary.length; i++) {
     const next = (i + 1) % boundary.length;

--- a/utils/geometryUtils.js
+++ b/utils/geometryUtils.js
@@ -230,6 +230,49 @@ export function adjustMollweideWrap(p1, p2) {
 }
 
 /**
+ * Adjust three Mollweide points so the resulting triangle spans the
+ * smallest horizontal range possible while keeping the shape contiguous.
+ * @param {THREE.Vector3} p1
+ * @param {THREE.Vector3} p2
+ * @param {THREE.Vector3} p3
+ * @returns {[THREE.Vector3, THREE.Vector3, THREE.Vector3]}
+ */
+export function adjustMollweideTriangleWrap(p1, p2, p3) {
+  const verts = [p1.clone(), p2.clone(), p3.clone()];
+  let best = verts.map(v => v.clone());
+  let minRange = Infinity;
+  for (let base = 0; base < 3; base++) {
+    const arr = verts.map(v => v.clone());
+    for (let i = 0; i < 3; i++) {
+      if (i === base) continue;
+      while (arr[i].x - arr[base].x > 200) arr[i].x -= 400;
+      while (arr[base].x - arr[i].x > 200) arr[i].x += 400;
+    }
+    const xs = arr.map(v => v.x);
+    const range = Math.max(...xs) - Math.min(...xs);
+    if (range < minRange) {
+      minRange = range;
+      best = arr.map(v => v.clone());
+    }
+  }
+  const xs = best.map(v => v.x);
+  let center = (Math.max(...xs) + Math.min(...xs)) / 2;
+  while (center > 200) {
+    best.forEach(v => { v.x -= 400; });
+    center -= 400;
+  }
+  while (center < -200) {
+    best.forEach(v => { v.x += 400; });
+    center += 400;
+  }
+  best.forEach(v => {
+    while (v.x > 200) v.x -= 400;
+    while (v.x < -200) v.x += 400;
+  });
+  return best;
+}
+
+/**
  * Splits a Mollweide segment at the map boundary if needed so that
  * wrapped lines appear on the opposite side instead of bleeding out.
  * Returns an array of [start, end] pairs.


### PR DESCRIPTION
## Summary
- draw filled triangular regions for the isolation and density overlays
- update triangles when filters refresh or scene updates

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68470aabaaf4832ab5057afcb8e57a57