### PR TITLE
Add export buttons and overlay tweaks

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -168,7 +168,9 @@ class DensityGridOverlay {
             color: 0xff0000,
             transparent: true,
             opacity: 0.3,
-            linewidth: 2
+            linewidth: 2,
+            depthWrite: false,
+            depthTest: false
           });
           const line = new THREE.Line(geom, mat);
           line.renderOrder = 1;
@@ -176,9 +178,12 @@ class DensityGridOverlay {
             color: 0xff0000,
             transparent: true,
             opacity: 0.9,
-            linewidth: 5
+            linewidth: 5,
+            depthWrite: false,
+            depthTest: false
           });
           const lineM = new THREE.LineSegments(geomM, mollMat);
+          lineM.renderOrder = 2;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });

--- a/index.html
+++ b/index.html
@@ -205,16 +205,19 @@
       <div class="map-container">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
+        <button class="export-btn" aria-label="Export True Coordinates Map">⤓</button>
         <canvas id="map3D"></canvas>
       </div>
       <div class="map-container">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
+        <button class="export-btn" aria-label="Export Globe Map">⤓</button>
         <canvas id="sphereMap"></canvas>
       </div>
       <div class="map-container">
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
+        <button class="export-btn" aria-label="Export Mollweide Map">⤓</button>
         <canvas id="mollweideMap"></canvas>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { OBJExporter } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/jsm/exporters/OBJExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
@@ -205,7 +206,11 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xaaaaaa,
+    transparent: true,
+    opacity: 0.5
+  });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -902,4 +907,48 @@ async function main() {
   }
 }
 
-window.onload = main;
+function setupExportButtons() {
+  document.querySelectorAll('.export-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const label = btn.getAttribute('aria-label') || '';
+      if (label.includes('True Coordinates')) {
+        exportMap('TrueCoordinates');
+      } else if (label.includes('Globe')) {
+        exportMap('Globe');
+      } else if (label.includes('Mollweide')) {
+        exportMap('Mollweide');
+      }
+    });
+  });
+}
+
+function exportMap(type) {
+  let map;
+  if (type === 'TrueCoordinates') map = trueCoordinatesMap;
+  else if (type === 'Globe') map = globeMap;
+  else map = mollweideMap;
+  if (!map) return;
+
+  if (type === 'Mollweide') {
+    const dataURL = map.renderer.domElement.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.href = dataURL;
+    link.download = `${type}.png`;
+    link.click();
+  } else {
+    const exporter = new OBJExporter();
+    const result = exporter.parse(map.scene);
+    const blob = new Blob([result], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${type}.obj`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+window.onload = () => {
+  main();
+  setupExportButtons();
+};

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // script.js
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { OBJExporter } from 'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/exporters/OBJExporter.js';
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.module.js';
+import { OBJExporter } from 'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/exporters/OBJExporter.js?module';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { OBJExporter } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/jsm/exporters/OBJExporter.js';
+import { OBJExporter } from 'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/exporters/OBJExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,21 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   z-index: 10;
 }
 
+/* Export Button for Maps */
+.export-btn {
+  position: absolute;
+  top: 10px;
+  right: 50px;
+  font-size: 20px;
+  background: rgba(20, 20, 20, 0.7);
+  border: none;
+  color: #ff6f61;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  z-index: 10;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- add export buttons for all maps and implement OBJ/PNG export in script
- style new export buttons
- set Mollweide map border opacity to 0.5
- keep density overlay lines visible while zooming

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847f06c9190832ab9a7ec273b0cd6ac