### PR TITLE
Add export options and improve Mollweide overlay

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -172,6 +172,8 @@ class DensityGridOverlay {
           });
           const line = new THREE.Line(geom, mat);
           line.renderOrder = 1;
+          line.material.depthWrite = false;
+          line.material.depthTest = false;
           const mollMat = new THREE.LineBasicMaterial({
             color: 0xff0000,
             transparent: true,
@@ -179,6 +181,9 @@ class DensityGridOverlay {
             linewidth: 5
           });
           const lineM = new THREE.LineSegments(geomM, mollMat);
+          lineM.renderOrder = 1;
+          lineM.material.depthWrite = false;
+          lineM.material.depthTest = false;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });

--- a/filters/distanceFilter.js
+++ b/filters/distanceFilter.js
@@ -19,9 +19,9 @@ export function applyDistanceFilter(stars, filters) {
     ? parseFloat(filters.maxDistance)
     : 20;
   return stars.filter(star => {
-    // Use the new 'distance' property if available, otherwise fall back to legacy 'Distance_from_the_Sun'
-    const distance = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
-    if (distance === undefined) return false;
+    const dVal = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
+    const distance = parseFloat(dVal);
+    if (!Number.isFinite(distance)) return false;
     return distance >= minDist && distance <= maxDist;
   });
 }

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
 
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gif.js.optimized/dist/gif.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/index.html
+++ b/index.html
@@ -238,6 +238,7 @@
   <div class="label-container"></div>
 
   <!-- Scripts -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">

--- a/index.html
+++ b/index.html
@@ -238,6 +238,8 @@
   <div class="label-container"></div>
 
   <!-- Scripts -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gif.js.optimized/dist/gif.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/index.html
+++ b/index.html
@@ -205,16 +205,19 @@
       <div class="map-container">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
+        <button class="print-btn" id="print-map3D" aria-label="Export True Coordinates Map">💾</button>
         <canvas id="map3D"></canvas>
       </div>
       <div class="map-container">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
+        <button class="print-btn" id="print-sphereMap" aria-label="Export Globe Map">💾</button>
         <canvas id="sphereMap"></canvas>
       </div>
       <div class="map-container">
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
+        <button class="print-btn" id="print-mollweideMap" aria-label="Export Mollweide Map">💾</button>
         <canvas id="mollweideMap"></canvas>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -239,7 +239,6 @@
 
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/index.html
+++ b/index.html
@@ -240,6 +240,8 @@
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.worker.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/script.js
+++ b/script.js
@@ -1,7 +1,6 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { OBJExporter } from './utils/OBJExporter.js';
-import { STLExporter } from './utils/STLExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
@@ -730,19 +729,53 @@ class MapManager {
     return data;
   }
 
-  exportSTL() {
-    const exporter = new STLExporter();
-    return exporter.parse(this.scene);
-  }
-
   exportOBJ() {
     const exporter = new OBJExporter();
     return exporter.parse(this.scene);
   }
 
-  exportOBJWithTexture() {
+  generateGlobeTexture(resolution = 4096) {
+    const width = resolution;
+    const height = Math.round(resolution / 2);
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#000000';
+    ctx.fillRect(0, 0, width, height);
+    if (this.starObjects) {
+      this.starObjects.forEach(star => {
+        let ra = star.RA_in_radian !== undefined ? star.RA_in_radian : (star.RA_in_degrees !== undefined ? degToRad(star.RA_in_degrees) : 0);
+        let dec = star.DEC_in_radian !== undefined ? star.DEC_in_radian : (star.DEC_in_degrees !== undefined ? degToRad(star.DEC_in_degrees) : 0);
+        const x = (ra % (Math.PI * 2)) / (Math.PI * 2) * width;
+        const y = (0.5 - dec / Math.PI) * height;
+        const size = (star.displaySize !== undefined ? star.displaySize : 1) * 0.4;
+        ctx.fillStyle = star.displayColor || '#ffffff';
+        ctx.beginPath();
+        ctx.arc(x, y, size, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    }
+    return canvas.toDataURL('image/png');
+  }
+
+  async exportOBJWithTexture(resolution = 4096) {
+    const textureData = this.generateGlobeTexture(resolution);
+    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 32));
     const exporter = new OBJExporter();
-    return exporter.parse(this.scene);
+    const objData = exporter.parse(sphere);
+    const mtlData = 'newmtl material0\nKd 1 1 1\nmap_Kd texture.png\n';
+    if (window.JSZip) {
+      const zip = new window.JSZip();
+      zip.file('globe.obj', objData);
+      zip.file('globe.mtl', mtlData);
+      const binary = atob(textureData.split(',')[1]);
+      const array = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) array[i] = binary.charCodeAt(i);
+      zip.file('texture.png', array);
+      return zip.generateAsync({ type: 'blob' });
+    }
+    return { obj: objData, mtl: mtlData, texture: textureData };
   }
 
   animate() {
@@ -958,14 +991,21 @@ function downloadBlob(blob, filename) {
   URL.revokeObjectURL(url);
 }
 
+function dataURLToBlob(dataURL) {
+  const binary = atob(dataURL.split(',')[1]);
+  const array = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) array[i] = binary.charCodeAt(i);
+  return new Blob([array], { type: 'image/png' });
+}
+
 function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      pickExport(btn3D, ['stl'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
-        if (fmt === 'stl') {
-          const data = trueCoordinatesMap.exportSTL();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.stl');
+      pickExport(btn3D, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
+        if (fmt === 'obj') {
+          const data = trueCoordinatesMap.exportOBJ();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.obj');
         }
       });
     });
@@ -974,10 +1014,16 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192], async (fmt) => {
+      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
         if (fmt === 'obj') {
-          const data = globeMap.exportOBJWithTexture();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
+          const blob = await globeMap.exportOBJWithTexture(res);
+          if (blob instanceof Blob) {
+            downloadBlob(blob, 'globe.zip');
+          } else {
+            downloadBlob(new Blob([blob.obj], { type: 'text/plain' }), 'globe.obj');
+            downloadBlob(new Blob([blob.mtl], { type: 'text/plain' }), 'globe.mtl');
+            downloadBlob(dataURLToBlob(blob.texture), 'texture.png');
+          }
         }
       });
     });
@@ -986,7 +1032,7 @@ function setupPrintButtons() {
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192], async (fmt, res) => {
+      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
         const maxSize = mollweideMap.renderer.capabilities.maxTextureSize || 8192;
         res = Math.max(mollweideMap.canvas.width, Math.min(res, maxSize));
         if (fmt === 'png' || fmt === 'jpg') {
@@ -1004,7 +1050,7 @@ function setupPrintButtons() {
             const w = mollweideMap.canvas.width;
             const h = mollweideMap.canvas.height;
             const doc = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [w, h] });
-            doc.addImage(url, 'PNG', 0, 0, w, h);
+            doc.addImage(url, 'PNG', 0, 0, w, h, undefined, 'FAST');
             doc.save('mollweide.pdf');
           } else {
             console.warn('jsPDF not loaded');

--- a/script.js
+++ b/script.js
@@ -734,6 +734,7 @@ class MapManager {
   }
 
   exportOBJ() {
+    this.scene.updateMatrixWorld(true);
     const exporter = new OBJExporter();
     const objData = exporter.parse(this.scene, 'true_coordinates.mtl');
     const mtlData = 'newmtl material0\nKd 1 1 1\n';
@@ -741,15 +742,16 @@ class MapManager {
   }
 
   exportSTL() {
+    this.scene.updateMatrixWorld(true);
     const exporter = new STLExporter();
     return exporter.parse(this.scene);
   }
 
   async exportOBJWithTexture(textureData) {
     if (!textureData) textureData = this.captureImage('png');
-    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 32));
+    this.scene.updateMatrixWorld(true);
     const exporter = new OBJExporter();
-    const objData = exporter.parse(sphere, 'globe.mtl');
+    const objData = exporter.parse(this.scene, 'globe.mtl');
     const mtlData = 'newmtl material0\nKd 1 1 1\nmap_Kd texture.png\n';
     if (window.JSZip) {
       const zip = new window.JSZip();

--- a/script.js
+++ b/script.js
@@ -9,6 +9,8 @@ import { initIsolationFilter, updateIsolationFilter } from './filters/isolationF
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
 import { applyGlobeSurfaceFilter } from './filters/globeSurfaceFilter.js';
 import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct import
+const EXPORT_SIZE = 4096;
+
 import {
   createGalacticPlaneMesh,
   createEclipticPlaneMesh,
@@ -731,10 +733,12 @@ class MapManager {
 
   exportOBJ() {
     const exporter = new OBJExporter();
-    return exporter.parse(this.scene);
+    const objData = exporter.parse(this.scene, 'true_coordinates.mtl');
+    const mtlData = 'newmtl material0\nKd 1 1 1\n';
+    return { obj: objData, mtl: mtlData };
   }
 
-  generateGlobeTexture(resolution = 4096) {
+  generateGlobeTexture(resolution = EXPORT_SIZE) {
     const width = resolution;
     const height = Math.round(resolution / 2);
     const canvas = document.createElement('canvas');
@@ -759,11 +763,11 @@ class MapManager {
     return canvas.toDataURL('image/png');
   }
 
-  async exportOBJWithTexture(resolution = 4096) {
+  async exportOBJWithTexture(resolution = EXPORT_SIZE) {
     const textureData = this.generateGlobeTexture(resolution);
     const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 32));
     const exporter = new OBJExporter();
-    const objData = exporter.parse(sphere);
+    const objData = exporter.parse(sphere, 'globe.mtl');
     const mtlData = 'newmtl material0\nKd 1 1 1\nmap_Kd texture.png\n';
     if (window.JSZip) {
       const zip = new window.JSZip();
@@ -974,11 +978,9 @@ function showExportMenu(button, options, callback) {
   document.body.appendChild(menu);
 }
 
-function pickExport(button, formats, resolutions, callback) {
+function pickExport(button, formats, callback) {
   showExportMenu(button, formats, fmt => {
-    showExportMenu(button, resolutions, res => {
-      callback(fmt, res);
-    });
+    callback(fmt);
   });
 }
 
@@ -1002,10 +1004,11 @@ function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      pickExport(btn3D, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
+      pickExport(btn3D, ['obj'], async (fmt) => {
         if (fmt === 'obj') {
           const data = trueCoordinatesMap.exportOBJ();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.obj');
+          downloadBlob(new Blob([data.obj], { type: 'text/plain' }), 'true_coordinates.obj');
+          downloadBlob(new Blob([data.mtl], { type: 'text/plain' }), 'true_coordinates.mtl');
         }
       });
     });
@@ -1014,9 +1017,9 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
+      pickExport(btnSphere, ['obj'], async (fmt) => {
         if (fmt === 'obj') {
-          const blob = await globeMap.exportOBJWithTexture(res);
+          const blob = await globeMap.exportOBJWithTexture(EXPORT_SIZE);
           if (blob instanceof Blob) {
             downloadBlob(blob, 'globe.zip');
           } else {
@@ -1032,9 +1035,8 @@ function setupPrintButtons() {
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
-        const maxSize = mollweideMap.renderer.capabilities.maxTextureSize || 8192;
-        res = Math.max(mollweideMap.canvas.width, Math.min(res, maxSize));
+      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt) => {
+        const res = EXPORT_SIZE;
         if (fmt === 'png' || fmt === 'jpg') {
           const url = mollweideMap.captureImage(fmt, res);
           downloadBlob(await (await fetch(url)).blob(), `mollweide.${fmt}`);

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { OBJExporter } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/jsm/exporters/OBJExporter.js';
+import { OBJExporter } from './utils/OBJExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { OBJExporter } from './utils/OBJExporter.js';
+import { STLExporter } from './utils/STLExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
@@ -10,6 +11,7 @@ import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.
 import { applyGlobeSurfaceFilter } from './filters/globeSurfaceFilter.js';
 import { updateCloudsOverlay } from './filters/cloudsFilter.js'; // Correct import
 const EXPORT_SIZE = 4096;
+const EXPORT_SIZES = [1024, 2048, 4096, 8192, 16384, 32768];
 
 import {
   createGalacticPlaneMesh,
@@ -738,33 +740,13 @@ class MapManager {
     return { obj: objData, mtl: mtlData };
   }
 
-  generateGlobeTexture(resolution = EXPORT_SIZE) {
-    const width = resolution;
-    const height = Math.round(resolution / 2);
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = '#000000';
-    ctx.fillRect(0, 0, width, height);
-    if (this.starObjects) {
-      this.starObjects.forEach(star => {
-        let ra = star.RA_in_radian !== undefined ? star.RA_in_radian : (star.RA_in_degrees !== undefined ? degToRad(star.RA_in_degrees) : 0);
-        let dec = star.DEC_in_radian !== undefined ? star.DEC_in_radian : (star.DEC_in_degrees !== undefined ? degToRad(star.DEC_in_degrees) : 0);
-        const x = (ra % (Math.PI * 2)) / (Math.PI * 2) * width;
-        const y = (0.5 - dec / Math.PI) * height;
-        const size = (star.displaySize !== undefined ? star.displaySize : 1) * 0.4;
-        ctx.fillStyle = star.displayColor || '#ffffff';
-        ctx.beginPath();
-        ctx.arc(x, y, size, 0, Math.PI * 2);
-        ctx.fill();
-      });
-    }
-    return canvas.toDataURL('image/png');
+  exportSTL() {
+    const exporter = new STLExporter();
+    return exporter.parse(this.scene);
   }
 
-  async exportOBJWithTexture(resolution = EXPORT_SIZE) {
-    const textureData = this.generateGlobeTexture(resolution);
+  async exportOBJWithTexture(textureData) {
+    if (!textureData) textureData = this.captureImage('png');
     const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 32));
     const exporter = new OBJExporter();
     const objData = exporter.parse(sphere, 'globe.mtl');
@@ -780,6 +762,37 @@ class MapManager {
       return zip.generateAsync({ type: 'blob' });
     }
     return { obj: objData, mtl: mtlData, texture: textureData };
+  }
+
+  async exportGIF(width = 512, frames = 36) {
+    if (!window.GIF) {
+      console.warn('gif.js not loaded');
+      return null;
+    }
+    const origSize = this.renderer.getSize(new THREE.Vector2());
+    const origRatio = this.renderer.getPixelRatio();
+    const aspect = origSize.y / origSize.x;
+    width = Math.min(width, this.renderer.capabilities.maxTextureSize || width);
+    const height = Math.round(width * aspect);
+    this.renderer.setPixelRatio(1);
+    this.renderer.setSize(width, height, false);
+    const radius = this.camera.position.length();
+    const gif = new window.GIF({ workers: 2, quality: 10, width, height });
+    const startPos = this.camera.position.clone();
+    for (let i = 0; i < frames; i++) {
+      const angle = (i / frames) * Math.PI * 2;
+      this.camera.position.set(Math.sin(angle) * radius, startPos.y, Math.cos(angle) * radius);
+      this.camera.lookAt(0, 0, 0);
+      this.renderer.render(this.scene, this.camera);
+      gif.addFrame(this.renderer.domElement, { copy: true, delay: 100 });
+    }
+    this.camera.position.copy(startPos);
+    this.renderer.setPixelRatio(origRatio);
+    this.renderer.setSize(origSize.x, origSize.y, false);
+    return new Promise(resolve => {
+      gif.on('finished', blob => resolve(blob));
+      gif.render();
+    });
   }
 
   animate() {
@@ -980,7 +993,9 @@ function showExportMenu(button, options, callback) {
 
 function pickExport(button, formats, callback) {
   showExportMenu(button, formats, fmt => {
-    callback(fmt);
+    showExportMenu(button, EXPORT_SIZES, res => {
+      callback(fmt, res);
+    });
   });
 }
 
@@ -1004,11 +1019,32 @@ function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      pickExport(btn3D, ['obj'], async (fmt) => {
+      pickExport(btn3D, ['obj', 'stl', 'gif'], async (fmt, res) => {
         if (fmt === 'obj') {
           const data = trueCoordinatesMap.exportOBJ();
-          downloadBlob(new Blob([data.obj], { type: 'text/plain' }), 'true_coordinates.obj');
-          downloadBlob(new Blob([data.mtl], { type: 'text/plain' }), 'true_coordinates.mtl');
+          if (window.JSZip) {
+            const zip = new window.JSZip();
+            zip.file('true_coordinates.obj', data.obj);
+            zip.file('true_coordinates.mtl', data.mtl);
+            const blob = await zip.generateAsync({ type: 'blob' });
+            downloadBlob(blob, 'true_coordinates.zip');
+          } else {
+            downloadBlob(new Blob([data.obj], { type: 'text/plain' }), 'true_coordinates.obj');
+            downloadBlob(new Blob([data.mtl], { type: 'text/plain' }), 'true_coordinates.mtl');
+          }
+        } else if (fmt === 'stl') {
+          const stl = trueCoordinatesMap.exportSTL();
+          if (window.JSZip) {
+            const zip = new window.JSZip();
+            zip.file('true_coordinates.stl', stl);
+            const blob = await zip.generateAsync({ type: 'blob' });
+            downloadBlob(blob, 'true_coordinates.zip');
+          } else {
+            downloadBlob(new Blob([stl], { type: 'text/plain' }), 'true_coordinates.stl');
+          }
+        } else if (fmt === 'gif') {
+          const blob = await trueCoordinatesMap.exportGIF(res);
+          if (blob) downloadBlob(blob, 'true_coordinates.gif');
         }
       });
     });
@@ -1017,9 +1053,11 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      pickExport(btnSphere, ['obj'], async (fmt) => {
+      pickExport(btnSphere, ['obj', 'gif'], async (fmt, res) => {
         if (fmt === 'obj') {
-          const blob = await globeMap.exportOBJWithTexture(EXPORT_SIZE);
+          updateMollweideView();
+          const tex = mollweideMap.captureImage('png', res || EXPORT_SIZE);
+          const blob = await globeMap.exportOBJWithTexture(tex);
           if (blob instanceof Blob) {
             downloadBlob(blob, 'globe.zip');
           } else {
@@ -1027,6 +1065,9 @@ function setupPrintButtons() {
             downloadBlob(new Blob([blob.mtl], { type: 'text/plain' }), 'globe.mtl');
             downloadBlob(dataURLToBlob(blob.texture), 'texture.png');
           }
+        } else if (fmt === 'gif') {
+          const gifBlob = await globeMap.exportGIF(res);
+          if (gifBlob) downloadBlob(gifBlob, 'globe.gif');
         }
       });
     });
@@ -1035,19 +1076,19 @@ function setupPrintButtons() {
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt) => {
-        const res = EXPORT_SIZE;
+      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt, res) => {
+        const width = res || EXPORT_SIZE;
         if (fmt === 'png' || fmt === 'jpg') {
-          const url = mollweideMap.captureImage(fmt, res);
+          const url = mollweideMap.captureImage(fmt, width);
           downloadBlob(await (await fetch(url)).blob(), `mollweide.${fmt}`);
         } else if (fmt === 'svg') {
-          const url = mollweideMap.captureImage('png', res);
+          const url = mollweideMap.captureImage('png', width);
           const w = mollweideMap.canvas.width;
           const h = mollweideMap.canvas.height;
           const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><image href="${url}" width="100%" height="100%"/></svg>`;
           downloadBlob(new Blob([svg], { type: 'image/svg+xml' }), 'mollweide.svg');
         } else if (fmt === 'pdf') {
-          const url = mollweideMap.captureImage('png', res);
+          const url = mollweideMap.captureImage('png', width);
           if (window.jspdf && window.jspdf.jsPDF) {
             const w = mollweideMap.canvas.width;
             const h = mollweideMap.canvas.height;

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { OBJExporter } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/jsm/exporters/OBJExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
@@ -205,7 +206,7 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5 });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -695,6 +696,15 @@ class MapManager {
     this.renderer.setSize(w, h);
   }
 
+  captureImage() {
+    return this.renderer.domElement.toDataURL('image/png');
+  }
+
+  exportOBJ() {
+    const exporter = new OBJExporter();
+    return exporter.parse(this.scene);
+  }
+
   animate() {
     requestAnimationFrame(() => this.animate());
     this.renderer.render(this.scene, this.camera);
@@ -864,6 +874,45 @@ function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
+function setupPrintButtons() {
+  const btn3D = document.getElementById('print-map3D');
+  if (btn3D) {
+    btn3D.addEventListener('click', () => {
+      const data = trueCoordinatesMap.exportOBJ();
+      const blob = new Blob([data], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'true_coordinates.obj';
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+  const btnSphere = document.getElementById('print-sphereMap');
+  if (btnSphere) {
+    btnSphere.addEventListener('click', () => {
+      const data = globeMap.exportOBJ();
+      const blob = new Blob([data], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'globe.obj';
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+  const btnMoll = document.getElementById('print-mollweideMap');
+  if (btnMoll) {
+    btnMoll.addEventListener('click', () => {
+      const url = mollweideMap.captureImage();
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'mollweide.png';
+      a.click();
+    });
+  }
+}
+
 async function main() {
   const loader = document.getElementById('loader');
   loader.classList.remove('hidden');
@@ -882,6 +931,7 @@ async function main() {
     window.trueCoordinatesMap = trueCoordinatesMap;
     window.globeMap = globeMap;
     window.mollweideMap = mollweideMap;
+    setupPrintButtons();
     cachedStars.forEach(star => {
       star.spherePosition = projectStarGlobe(star);
       star.truePosition = getStarTruePosition(star);

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { OBJExporter } from './utils/OBJExporter.js';
+import { STLExporter } from './utils/STLExporter.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
@@ -706,9 +707,46 @@ class MapManager {
     this.renderer.setSize(w, h);
   }
 
-  captureImage() {
+  captureImage(type = 'png') {
     this.renderer.render(this.scene, this.camera);
-    return this.renderer.domElement.toDataURL('image/png');
+    const mime = type === 'jpg' || type === 'jpeg'
+      ? 'image/jpeg'
+      : 'image/png';
+    return this.renderer.domElement.toDataURL(mime);
+  }
+
+  exportSTL() {
+    const exporter = new STLExporter();
+    return exporter.parse(this.scene);
+  }
+
+  async exportGIF() {
+    if (typeof GIF === 'undefined') {
+      console.warn('GIF library not loaded');
+      return null;
+    }
+    const originalPos = this.camera.position.clone();
+    const radius = originalPos.length();
+    const target = new THREE.Vector3(0, 0, 0);
+    const frames = 36;
+    const gif = new GIF({ workers: 2, quality: 10 });
+    for (let i = 0; i < frames; i++) {
+      const angle = (i / frames) * Math.PI * 2;
+      this.camera.position.set(
+        radius * Math.sin(angle),
+        originalPos.y,
+        radius * Math.cos(angle)
+      );
+      this.camera.lookAt(target);
+      this.renderer.render(this.scene, this.camera);
+      gif.addFrame(this.renderer.domElement, { copy: true, delay: 100 });
+    }
+    this.camera.position.copy(originalPos);
+    this.camera.lookAt(target);
+    return new Promise(resolve => {
+      gif.on('finished', resolve);
+      gif.render();
+    });
   }
 
   exportOBJ() {
@@ -885,41 +923,97 @@ function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
+function showExportMenu(button, options, callback) {
+  const menu = document.createElement('div');
+  menu.className = 'export-menu';
+  options.forEach(opt => {
+    const b = document.createElement('button');
+    b.className = 'export-option';
+    b.textContent = opt.toUpperCase();
+    b.addEventListener('click', () => {
+      callback(opt);
+      document.body.removeChild(menu);
+    });
+    menu.appendChild(b);
+  });
+  const rect = button.getBoundingClientRect();
+  menu.style.top = rect.bottom + 'px';
+  menu.style.left = rect.left + 'px';
+  document.body.appendChild(menu);
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      const data = trueCoordinatesMap.exportOBJ();
-      const blob = new Blob([data], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'true_coordinates.obj';
-      a.click();
-      URL.revokeObjectURL(url);
+      showExportMenu(btn3D, ['obj', 'stl', 'gif'], async (fmt) => {
+        if (fmt === 'obj') {
+          const data = trueCoordinatesMap.exportOBJ();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.obj');
+        } else if (fmt === 'stl') {
+          const data = trueCoordinatesMap.exportSTL();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.stl');
+        } else if (fmt === 'gif') {
+          const blob = await trueCoordinatesMap.exportGIF();
+          if (blob) downloadBlob(blob, 'true_coordinates.gif');
+        }
+      });
     });
   }
+
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      const data = globeMap.exportOBJ();
-      const blob = new Blob([data], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'globe.obj';
-      a.click();
-      URL.revokeObjectURL(url);
+      showExportMenu(btnSphere, ['obj', 'stl', 'gif'], async (fmt) => {
+        if (fmt === 'obj') {
+          const data = globeMap.exportOBJ();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
+        } else if (fmt === 'stl') {
+          const data = globeMap.exportSTL();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.stl');
+        } else if (fmt === 'gif') {
+          const blob = await globeMap.exportGIF();
+          if (blob) downloadBlob(blob, 'globe.gif');
+        }
+      });
     });
   }
+
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      const url = mollweideMap.captureImage();
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'mollweide.png';
-      a.click();
+      showExportMenu(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt) => {
+        if (fmt === 'png' || fmt === 'jpg') {
+          const url = mollweideMap.captureImage(fmt);
+          downloadBlob(await (await fetch(url)).blob(), `mollweide.${fmt}`);
+        } else if (fmt === 'svg') {
+          const url = mollweideMap.captureImage('png');
+          const w = mollweideMap.canvas.width;
+          const h = mollweideMap.canvas.height;
+          const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><image href="${url}" width="100%" height="100%"/></svg>`;
+          downloadBlob(new Blob([svg], { type: 'image/svg+xml' }), 'mollweide.svg');
+        } else if (fmt === 'pdf') {
+          const url = mollweideMap.captureImage('png');
+          if (window.jspdf && window.jspdf.jsPDF) {
+            const w = mollweideMap.canvas.width;
+            const h = mollweideMap.canvas.height;
+            const doc = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [w, h] });
+            doc.addImage(url, 'PNG', 0, 0, w, h);
+            doc.save('mollweide.pdf');
+          } else {
+            console.warn('jsPDF not loaded');
+          }
+        }
+      });
     });
   }
 }

--- a/script.js
+++ b/script.js
@@ -78,8 +78,14 @@ let showGalacticPlaneFlag = false;
 let showEclipticPlaneFlag = false;
 let showCelestialEquatorFlag = false;
 
+function parseDistance(value) {
+  const num = parseFloat(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
 function getStarTruePosition(star) {
-  const R = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
+  const dist = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
+  const R = parseDistance(dist);
   let ra, dec;
   if (star.RA_in_radian !== undefined && star.DEC_in_radian !== undefined) {
     ra = star.RA_in_radian;
@@ -230,7 +236,10 @@ async function loadStarData() {
     );
     const filesData = await Promise.all(dataPromises);
     const combinedData = filesData.flat();
-    return combinedData;
+    return combinedData.filter(star => {
+      const dist = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
+      return Number.isFinite(parseFloat(dist));
+    });
   } catch (e) {
     console.warn("Error loading star data:", e);
     return [];
@@ -516,7 +525,8 @@ class MapManager {
     this.scene = new THREE.Scene();
     this.renderer = new THREE.WebGLRenderer({
       canvas: this.canvas,
-      antialias: true
+      antialias: true,
+      preserveDrawingBuffer: true
     });
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
@@ -697,6 +707,7 @@ class MapManager {
   }
 
   captureImage() {
+    this.renderer.render(this.scene, this.camera);
     return this.renderer.domElement.toDataURL('image/png');
   }
 

--- a/script.js
+++ b/script.js
@@ -707,12 +707,25 @@ class MapManager {
     this.renderer.setSize(w, h);
   }
 
-  captureImage(type = 'png') {
+  captureImage(type = 'png', width = null) {
+    const original = {
+      size: this.renderer.getSize(new THREE.Vector2()),
+      ratio: this.renderer.getPixelRatio()
+    };
+    if (width) {
+      const aspect = original.size.y / original.size.x;
+      const height = Math.round(width * aspect);
+      this.renderer.setPixelRatio(1);
+      this.renderer.setSize(width, height, false);
+    }
     this.renderer.render(this.scene, this.camera);
-    const mime = type === 'jpg' || type === 'jpeg'
-      ? 'image/jpeg'
-      : 'image/png';
-    return this.renderer.domElement.toDataURL(mime);
+    const mime = type === 'jpg' || type === 'jpeg' ? 'image/jpeg' : 'image/png';
+    const data = this.renderer.domElement.toDataURL(mime);
+    if (width) {
+      this.renderer.setPixelRatio(original.ratio);
+      this.renderer.setSize(original.size.x, original.size.y, false);
+    }
+    return data;
   }
 
   exportSTL() {
@@ -720,38 +733,18 @@ class MapManager {
     return exporter.parse(this.scene);
   }
 
-  async exportGIF() {
-    if (typeof GIF === 'undefined') {
-      console.warn('GIF library not loaded');
-      return null;
-    }
-    const originalPos = this.camera.position.clone();
-    const radius = originalPos.length();
-    const target = new THREE.Vector3(0, 0, 0);
-    const frames = 36;
-    const gif = new GIF({ workers: 2, quality: 10 });
-    for (let i = 0; i < frames; i++) {
-      const angle = (i / frames) * Math.PI * 2;
-      this.camera.position.set(
-        radius * Math.sin(angle),
-        originalPos.y,
-        radius * Math.cos(angle)
-      );
-      this.camera.lookAt(target);
-      this.renderer.render(this.scene, this.camera);
-      gif.addFrame(this.renderer.domElement, { copy: true, delay: 100 });
-    }
-    this.camera.position.copy(originalPos);
-    this.camera.lookAt(target);
-    return new Promise(resolve => {
-      gif.on('finished', resolve);
-      gif.render();
-    });
-  }
-
   exportOBJ() {
     const exporter = new OBJExporter();
     return exporter.parse(this.scene);
+  }
+
+  exportOBJWithTexture() {
+    const exporter = new OBJExporter();
+    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 64), new THREE.MeshBasicMaterial());
+    const obj = 'mtllib globe.mtl\nusemtl map\n' + exporter.parse(sphere);
+    const mtl = 'newmtl map\nKa 1 1 1\nKd 1 1 1\nmap_Kd globe_texture.png\n';
+    const texture = this.captureImage('png');
+    return { obj, mtl, texture };
   }
 
   animate() {
@@ -955,16 +948,10 @@ function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      showExportMenu(btn3D, ['obj', 'stl', 'gif'], async (fmt) => {
-        if (fmt === 'obj') {
-          const data = trueCoordinatesMap.exportOBJ();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.obj');
-        } else if (fmt === 'stl') {
+      showExportMenu(btn3D, ['stl'], async (fmt) => {
+        if (fmt === 'stl') {
           const data = trueCoordinatesMap.exportSTL();
           downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.stl');
-        } else if (fmt === 'gif') {
-          const blob = await trueCoordinatesMap.exportGIF();
-          if (blob) downloadBlob(blob, 'true_coordinates.gif');
         }
       });
     });
@@ -973,16 +960,21 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      showExportMenu(btnSphere, ['obj', 'stl', 'gif'], async (fmt) => {
+      showExportMenu(btnSphere, ['obj'], async (fmt) => {
         if (fmt === 'obj') {
-          const data = globeMap.exportOBJ();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
-        } else if (fmt === 'stl') {
-          const data = globeMap.exportSTL();
-          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.stl');
-        } else if (fmt === 'gif') {
-          const blob = await globeMap.exportGIF();
-          if (blob) downloadBlob(blob, 'globe.gif');
+          if (window.JSZip) {
+            const exp = globeMap.exportOBJWithTexture();
+            const zip = new JSZip();
+            zip.file('globe.obj', exp.obj);
+            zip.file('globe.mtl', exp.mtl);
+            const imgData = exp.texture.split(',')[1];
+            zip.file('globe_texture.png', imgData, { base64: true });
+            const blob = await zip.generateAsync({ type: 'blob' });
+            downloadBlob(blob, 'globe.zip');
+          } else {
+            const data = globeMap.exportOBJWithTexture().obj;
+            downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
+          }
         }
       });
     });
@@ -992,17 +984,21 @@ function setupPrintButtons() {
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
       showExportMenu(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt) => {
+        const defaultRes = 4096;
+        let res = parseInt(prompt('Export resolution (px, width)', defaultRes.toString()), 10);
+        if (!Number.isFinite(res)) res = defaultRes;
+        res = Math.max(mollweideMap.canvas.width, Math.min(res, 32000));
         if (fmt === 'png' || fmt === 'jpg') {
-          const url = mollweideMap.captureImage(fmt);
+          const url = mollweideMap.captureImage(fmt, res);
           downloadBlob(await (await fetch(url)).blob(), `mollweide.${fmt}`);
         } else if (fmt === 'svg') {
-          const url = mollweideMap.captureImage('png');
+          const url = mollweideMap.captureImage('png', res);
           const w = mollweideMap.canvas.width;
           const h = mollweideMap.canvas.height;
           const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><image href="${url}" width="100%" height="100%"/></svg>`;
           downloadBlob(new Blob([svg], { type: 'image/svg+xml' }), 'mollweide.svg');
         } else if (fmt === 'pdf') {
-          const url = mollweideMap.captureImage('png');
+          const url = mollweideMap.captureImage('png', res);
           if (window.jspdf && window.jspdf.jsPDF) {
             const w = mollweideMap.canvas.width;
             const h = mollweideMap.canvas.height;

--- a/script.js
+++ b/script.js
@@ -738,12 +738,14 @@ class MapManager {
     return exporter.parse(this.scene);
   }
 
-  exportOBJWithTexture() {
+  exportOBJWithTexture(resolution = 4096) {
     const exporter = new OBJExporter();
-    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, 64, 64), new THREE.MeshBasicMaterial());
+    const segments = Math.max(8, Math.round(resolution / 512));
+    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, segments, segments), new THREE.MeshBasicMaterial());
     const obj = 'mtllib globe.mtl\nusemtl map\n' + exporter.parse(sphere);
     const mtl = 'newmtl map\nKa 1 1 1\nKd 1 1 1\nmap_Kd globe_texture.png\n';
-    const texture = this.captureImage('png');
+    const target = window.mollweideMap ? window.mollweideMap : this;
+    const texture = target.captureImage('png', resolution);
     return { obj, mtl, texture };
   }
 
@@ -920,11 +922,16 @@ function showExportMenu(button, options, callback) {
   const menu = document.createElement('div');
   menu.className = 'export-menu';
   options.forEach(opt => {
+    const val = typeof opt === 'object' ? opt.value : opt;
+    let label = typeof opt === 'object' ? opt.label : opt;
+    if (typeof val === 'number' && !label.includes('k')) {
+      label = (val / 1024) + 'k';
+    }
     const b = document.createElement('button');
     b.className = 'export-option';
-    b.textContent = opt.toUpperCase();
+    b.textContent = label.toUpperCase();
     b.addEventListener('click', () => {
-      callback(opt);
+      callback(val);
       document.body.removeChild(menu);
     });
     menu.appendChild(b);
@@ -933,6 +940,14 @@ function showExportMenu(button, options, callback) {
   menu.style.top = rect.bottom + 'px';
   menu.style.left = rect.left + 'px';
   document.body.appendChild(menu);
+}
+
+function pickExport(button, formats, resolutions, callback) {
+  showExportMenu(button, formats, fmt => {
+    showExportMenu(button, resolutions, res => {
+      callback(fmt, res);
+    });
+  });
 }
 
 function downloadBlob(blob, filename) {
@@ -948,7 +963,7 @@ function setupPrintButtons() {
   const btn3D = document.getElementById('print-map3D');
   if (btn3D) {
     btn3D.addEventListener('click', () => {
-      showExportMenu(btn3D, ['stl'], async (fmt) => {
+      pickExport(btn3D, ['stl'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
         if (fmt === 'stl') {
           const data = trueCoordinatesMap.exportSTL();
           downloadBlob(new Blob([data], { type: 'text/plain' }), 'true_coordinates.stl');
@@ -960,10 +975,10 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      showExportMenu(btnSphere, ['obj'], async (fmt) => {
+      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
         if (fmt === 'obj') {
           if (window.JSZip) {
-            const exp = globeMap.exportOBJWithTexture();
+            const exp = globeMap.exportOBJWithTexture(res);
             const zip = new JSZip();
             zip.file('globe.obj', exp.obj);
             zip.file('globe.mtl', exp.mtl);
@@ -972,7 +987,7 @@ function setupPrintButtons() {
             const blob = await zip.generateAsync({ type: 'blob' });
             downloadBlob(blob, 'globe.zip');
           } else {
-            const data = globeMap.exportOBJWithTexture().obj;
+            const data = globeMap.exportOBJWithTexture(res).obj;
             downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
           }
         }
@@ -983,10 +998,7 @@ function setupPrintButtons() {
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      showExportMenu(btnMoll, ['png', 'jpg', 'svg', 'pdf'], async (fmt) => {
-        const defaultRes = 4096;
-        let res = parseInt(prompt('Export resolution (px, width)', defaultRes.toString()), 10);
-        if (!Number.isFinite(res)) res = defaultRes;
+      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
         res = Math.max(mollweideMap.canvas.width, Math.min(res, 32000));
         if (fmt === 'png' || fmt === 'jpg') {
           const url = mollweideMap.captureImage(fmt, res);

--- a/script.js
+++ b/script.js
@@ -712,7 +712,9 @@ class MapManager {
       size: this.renderer.getSize(new THREE.Vector2()),
       ratio: this.renderer.getPixelRatio()
     };
+    const maxSize = this.renderer.capabilities.maxTextureSize || 8192;
     if (width) {
+      width = Math.min(width, maxSize);
       const aspect = original.size.y / original.size.x;
       const height = Math.round(width * aspect);
       this.renderer.setPixelRatio(1);
@@ -738,15 +740,9 @@ class MapManager {
     return exporter.parse(this.scene);
   }
 
-  exportOBJWithTexture(resolution = 4096) {
+  exportOBJWithTexture() {
     const exporter = new OBJExporter();
-    const segments = Math.max(8, Math.round(resolution / 512));
-    const sphere = new THREE.Mesh(new THREE.SphereGeometry(100, segments, segments), new THREE.MeshBasicMaterial());
-    const obj = 'mtllib globe.mtl\nusemtl map\n' + exporter.parse(sphere);
-    const mtl = 'newmtl map\nKa 1 1 1\nKd 1 1 1\nmap_Kd globe_texture.png\n';
-    const target = window.mollweideMap ? window.mollweideMap : this;
-    const texture = target.captureImage('png', resolution);
-    return { obj, mtl, texture };
+    return exporter.parse(this.scene);
   }
 
   animate() {
@@ -978,21 +974,10 @@ function setupPrintButtons() {
   const btnSphere = document.getElementById('print-sphereMap');
   if (btnSphere) {
     btnSphere.addEventListener('click', () => {
-      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
+      pickExport(btnSphere, ['obj'], [1024, 2048, 4096, 8192], async (fmt) => {
         if (fmt === 'obj') {
-          if (window.JSZip) {
-            const exp = globeMap.exportOBJWithTexture(res);
-            const zip = new JSZip();
-            zip.file('globe.obj', exp.obj);
-            zip.file('globe.mtl', exp.mtl);
-            const imgData = exp.texture.split(',')[1];
-            zip.file('globe_texture.png', imgData, { base64: true });
-            const blob = await zip.generateAsync({ type: 'blob' });
-            downloadBlob(blob, 'globe.zip');
-          } else {
-            const data = globeMap.exportOBJWithTexture(res).obj;
-            downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
-          }
+          const data = globeMap.exportOBJWithTexture();
+          downloadBlob(new Blob([data], { type: 'text/plain' }), 'globe.obj');
         }
       });
     });
@@ -1001,8 +986,9 @@ function setupPrintButtons() {
   const btnMoll = document.getElementById('print-mollweideMap');
   if (btnMoll) {
     btnMoll.addEventListener('click', () => {
-      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192, 16384, 32768], async (fmt, res) => {
-        res = Math.max(mollweideMap.canvas.width, Math.min(res, 32000));
+      pickExport(btnMoll, ['png', 'jpg', 'svg', 'pdf'], [1024, 2048, 4096, 8192], async (fmt, res) => {
+        const maxSize = mollweideMap.renderer.capabilities.maxTextureSize || 8192;
+        res = Math.max(mollweideMap.canvas.width, Math.min(res, maxSize));
         if (fmt === 'png' || fmt === 'jpg') {
           const url = mollweideMap.captureImage(fmt, res);
           downloadBlob(await (await fetch(url)).blob(), `mollweide.${fmt}`);

--- a/script.js
+++ b/script.js
@@ -924,8 +924,11 @@ function showExportMenu(button, options, callback) {
   options.forEach(opt => {
     const val = typeof opt === 'object' ? opt.value : opt;
     let label = typeof opt === 'object' ? opt.label : opt;
-    if (typeof val === 'number' && !label.includes('k')) {
-      label = (val / 1024) + 'k';
+    if (typeof val === 'number') {
+      const lblStr = String(label);
+      label = lblStr.includes('k') ? lblStr : (val / 1024) + 'k';
+    } else {
+      label = String(label);
     }
     const b = document.createElement('button');
     b.className = 'export-option';

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,21 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   z-index: 10;
 }
 
+/* Print/Export Button for Maps */
+.print-btn {
+  position: absolute;
+  top: 10px;
+  right: 50px;
+  font-size: 24px;
+  background: rgba(20, 20, 20, 0.7);
+  border: none;
+  color: #ff6f61;
+  cursor: pointer;
+  padding: 5px 10px;
+  border-radius: 4px;
+  z-index: 10;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;

--- a/styles.css
+++ b/styles.css
@@ -321,6 +321,29 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   z-index: 10;
 }
 
+/* Export menu */
+.export-menu {
+  position: absolute;
+  background: rgba(20, 20, 20, 0.9);
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  gap: 4px;
+  z-index: 20;
+}
+.export-option {
+  background: none;
+  border: 1px solid #ff6f61;
+  color: #ff6f61;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+.export-option:hover {
+  background: #ff6f61;
+  color: #1a1a1a;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;

--- a/utils/OBJExporter.js
+++ b/utils/OBJExporter.js
@@ -1,0 +1,42 @@
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+
+/**
+ * Minimal OBJ exporter based on THREE.js examples.
+ * Generates vertex positions and face indices for meshes in the scene.
+ */
+export class OBJExporter {
+  parse(object) {
+    let output = '';
+    let vertexOffset = 0;
+    const vertex = new THREE.Vector3();
+    object.traverse(child => {
+      if (!child.isMesh) return;
+      const geometry = child.geometry;
+      const position = geometry.getAttribute('position');
+      const index = geometry.getIndex();
+      const worldMatrix = child.matrixWorld;
+      output += `o ${child.name || 'Mesh'}\n`;
+      for (let i = 0; i < position.count; i++) {
+        vertex.fromBufferAttribute(position, i).applyMatrix4(worldMatrix);
+        output += `v ${vertex.x} ${vertex.y} ${vertex.z}\n`;
+      }
+      if (index) {
+        for (let i = 0; i < index.count; i += 3) {
+          const a = index.getX(i) + 1 + vertexOffset;
+          const b = index.getX(i + 1) + 1 + vertexOffset;
+          const c = index.getX(i + 2) + 1 + vertexOffset;
+          output += `f ${a} ${b} ${c}\n`;
+        }
+      } else {
+        for (let i = 0; i < position.count; i += 3) {
+          const a = vertexOffset + i + 1;
+          const b = vertexOffset + i + 2;
+          const c = vertexOffset + i + 3;
+          output += `f ${a} ${b} ${c}\n`;
+        }
+      }
+      vertexOffset += position.count;
+    });
+    return output;
+  }
+}

--- a/utils/OBJExporter.js
+++ b/utils/OBJExporter.js
@@ -9,12 +9,14 @@ export class OBJExporter {
     let output = '';
     let vertexOffset = 0;
     const vertex = new THREE.Vector3();
+    const uvVec = new THREE.Vector2();
     const matrix = new THREE.Matrix4();
     object.traverse(child => {
       if (!child.isMesh && !child.isInstancedMesh) return;
       const geometry = child.geometry;
       const position = geometry.getAttribute('position');
       const index = geometry.getIndex();
+      const uvAttr = geometry.getAttribute('uv');
       const instanceCount = child.isInstancedMesh ? child.count : 1;
       for (let inst = 0; inst < instanceCount; inst++) {
         if (child.isInstancedMesh) {
@@ -27,20 +29,32 @@ export class OBJExporter {
         for (let i = 0; i < position.count; i++) {
           vertex.fromBufferAttribute(position, i).applyMatrix4(matrix);
           output += `v ${vertex.x} ${vertex.y} ${vertex.z}\n`;
+          if (uvAttr) {
+            uvVec.fromBufferAttribute(uvAttr, i);
+            output += `vt ${uvVec.x} ${uvVec.y}\n`;
+          }
         }
         if (index) {
           for (let i = 0; i < index.count; i += 3) {
             const a = index.getX(i) + 1 + vertexOffset;
             const b = index.getX(i + 1) + 1 + vertexOffset;
             const c = index.getX(i + 2) + 1 + vertexOffset;
-            output += `f ${a} ${b} ${c}\n`;
+            if (uvAttr) {
+              output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
+            } else {
+              output += `f ${a} ${b} ${c}\n`;
+            }
           }
         } else {
           for (let i = 0; i < position.count; i += 3) {
             const a = vertexOffset + i + 1;
             const b = vertexOffset + i + 2;
             const c = vertexOffset + i + 3;
-            output += `f ${a} ${b} ${c}\n`;
+            if (uvAttr) {
+              output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
+            } else {
+              output += `f ${a} ${b} ${c}\n`;
+            }
           }
         }
         vertexOffset += position.count;

--- a/utils/OBJExporter.js
+++ b/utils/OBJExporter.js
@@ -9,33 +9,42 @@ export class OBJExporter {
     let output = '';
     let vertexOffset = 0;
     const vertex = new THREE.Vector3();
+    const matrix = new THREE.Matrix4();
     object.traverse(child => {
-      if (!child.isMesh) return;
+      if (!child.isMesh && !child.isInstancedMesh) return;
       const geometry = child.geometry;
       const position = geometry.getAttribute('position');
       const index = geometry.getIndex();
-      const worldMatrix = child.matrixWorld;
-      output += `o ${child.name || 'Mesh'}\n`;
-      for (let i = 0; i < position.count; i++) {
-        vertex.fromBufferAttribute(position, i).applyMatrix4(worldMatrix);
-        output += `v ${vertex.x} ${vertex.y} ${vertex.z}\n`;
-      }
-      if (index) {
-        for (let i = 0; i < index.count; i += 3) {
-          const a = index.getX(i) + 1 + vertexOffset;
-          const b = index.getX(i + 1) + 1 + vertexOffset;
-          const c = index.getX(i + 2) + 1 + vertexOffset;
-          output += `f ${a} ${b} ${c}\n`;
+      const instanceCount = child.isInstancedMesh ? child.count : 1;
+      for (let inst = 0; inst < instanceCount; inst++) {
+        if (child.isInstancedMesh) {
+          child.getMatrixAt(inst, matrix);
+          matrix.multiplyMatrices(child.matrixWorld, matrix);
+        } else {
+          matrix.copy(child.matrixWorld);
         }
-      } else {
-        for (let i = 0; i < position.count; i += 3) {
-          const a = vertexOffset + i + 1;
-          const b = vertexOffset + i + 2;
-          const c = vertexOffset + i + 3;
-          output += `f ${a} ${b} ${c}\n`;
+        output += `o ${child.name || 'Mesh'}_${inst}\n`;
+        for (let i = 0; i < position.count; i++) {
+          vertex.fromBufferAttribute(position, i).applyMatrix4(matrix);
+          output += `v ${vertex.x} ${vertex.y} ${vertex.z}\n`;
         }
+        if (index) {
+          for (let i = 0; i < index.count; i += 3) {
+            const a = index.getX(i) + 1 + vertexOffset;
+            const b = index.getX(i + 1) + 1 + vertexOffset;
+            const c = index.getX(i + 2) + 1 + vertexOffset;
+            output += `f ${a} ${b} ${c}\n`;
+          }
+        } else {
+          for (let i = 0; i < position.count; i += 3) {
+            const a = vertexOffset + i + 1;
+            const b = vertexOffset + i + 2;
+            const c = vertexOffset + i + 3;
+            output += `f ${a} ${b} ${c}\n`;
+          }
+        }
+        vertexOffset += position.count;
       }
-      vertexOffset += position.count;
     });
     return output;
   }

--- a/utils/OBJExporter.js
+++ b/utils/OBJExporter.js
@@ -5,18 +5,18 @@ import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/thr
  * Generates vertex positions and face indices for meshes in the scene.
  */
 export class OBJExporter {
-  parse(object) {
-    let output = '';
+  parse(object, mtlName = 'export.mtl') {
+    let output = `mtllib ${mtlName}\n`;
     let vertexOffset = 0;
     const vertex = new THREE.Vector3();
     const uvVec = new THREE.Vector2();
     const matrix = new THREE.Matrix4();
     object.traverse(child => {
-      if (!child.isMesh && !child.isInstancedMesh) return;
+      if (!child.isMesh && !child.isInstancedMesh && !child.isLine && !child.isLineSegments && !child.isLineLoop && !child.isSprite) return;
       const geometry = child.geometry;
-      const position = geometry.getAttribute('position');
-      const index = geometry.getIndex();
-      const uvAttr = geometry.getAttribute('uv');
+      const position = geometry ? geometry.getAttribute('position') : null;
+      const index = geometry ? geometry.getIndex() : null;
+      const uvAttr = geometry ? geometry.getAttribute('uv') : null;
       const instanceCount = child.isInstancedMesh ? child.count : 1;
       for (let inst = 0; inst < instanceCount; inst++) {
         if (child.isInstancedMesh) {
@@ -25,7 +25,28 @@ export class OBJExporter {
         } else {
           matrix.copy(child.matrixWorld);
         }
-        output += `o ${child.name || 'Mesh'}_${inst}\n`;
+        output += `o ${child.name || 'Mesh'}_${inst}\nusemtl material0\n`;
+
+        if (child.isSprite) {
+          const hw = child.scale.x / 2;
+          const hh = child.scale.y / 2;
+          const verts = [
+            new THREE.Vector3(-hw, -hh, 0),
+            new THREE.Vector3(hw, -hh, 0),
+            new THREE.Vector3(hw, hh, 0),
+            new THREE.Vector3(-hw, hh, 0)
+          ];
+          verts.forEach(v => {
+            v.applyMatrix4(matrix);
+            output += `v ${v.x} ${v.y} ${v.z}\n`;
+          });
+          output += 'vt 0 0\nvt 1 0\nvt 1 1\nvt 0 1\n';
+          output += `f ${vertexOffset + 1}/${vertexOffset + 1} ${vertexOffset + 2}/${vertexOffset + 2} ${vertexOffset + 3}/${vertexOffset + 3}\n`;
+          output += `f ${vertexOffset + 1}/${vertexOffset + 1} ${vertexOffset + 3}/${vertexOffset + 3} ${vertexOffset + 4}/${vertexOffset + 4}\n`;
+          vertexOffset += 4;
+          continue;
+        }
+
         for (let i = 0; i < position.count; i++) {
           vertex.fromBufferAttribute(position, i).applyMatrix4(matrix);
           output += `v ${vertex.x} ${vertex.y} ${vertex.z}\n`;
@@ -34,26 +55,40 @@ export class OBJExporter {
             output += `vt ${uvVec.x} ${uvVec.y}\n`;
           }
         }
-        if (index) {
-          for (let i = 0; i < index.count; i += 3) {
-            const a = index.getX(i) + 1 + vertexOffset;
-            const b = index.getX(i + 1) + 1 + vertexOffset;
-            const c = index.getX(i + 2) + 1 + vertexOffset;
-            if (uvAttr) {
-              output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
-            } else {
-              output += `f ${a} ${b} ${c}\n`;
+        if (child.isLine || child.isLineSegments || child.isLineLoop) {
+          const verts = [];
+          if (index) {
+            for (let i = 0; i < index.count; i++) {
+              verts.push(index.getX(i) + 1 + vertexOffset);
+            }
+          } else {
+            for (let i = 0; i < position.count; i++) {
+              verts.push(vertexOffset + i + 1);
             }
           }
+          output += 'l ' + verts.join(' ') + '\n';
         } else {
-          for (let i = 0; i < position.count; i += 3) {
-            const a = vertexOffset + i + 1;
-            const b = vertexOffset + i + 2;
-            const c = vertexOffset + i + 3;
-            if (uvAttr) {
-              output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
-            } else {
-              output += `f ${a} ${b} ${c}\n`;
+          if (index) {
+            for (let i = 0; i < index.count; i += 3) {
+              const a = index.getX(i) + 1 + vertexOffset;
+              const b = index.getX(i + 1) + 1 + vertexOffset;
+              const c = index.getX(i + 2) + 1 + vertexOffset;
+              if (uvAttr) {
+                output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
+              } else {
+                output += `f ${a} ${b} ${c}\n`;
+              }
+            }
+          } else {
+            for (let i = 0; i < position.count; i += 3) {
+              const a = vertexOffset + i + 1;
+              const b = vertexOffset + i + 2;
+              const c = vertexOffset + i + 3;
+              if (uvAttr) {
+                output += `f ${a}/${a} ${b}/${b} ${c}/${c}\n`;
+              } else {
+                output += `f ${a} ${b} ${c}\n`;
+              }
             }
           }
         }

--- a/utils/STLExporter.js
+++ b/utils/STLExporter.js
@@ -1,0 +1,54 @@
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+
+// Minimal STL exporter adapted from Three.js examples
+export class STLExporter {
+  parse(scene) {
+    let output = 'solid exported\n';
+    const vector = new THREE.Vector3();
+    const matrix = new THREE.Matrix4();
+    const normal = new THREE.Vector3();
+
+    function addTriangle(a, b, c) {
+      const cb = new THREE.Vector3();
+      const ab = new THREE.Vector3();
+      cb.subVectors(c, b);
+      ab.subVectors(a, b);
+      cb.cross(ab).normalize();
+      output += `facet normal ${cb.x} ${cb.y} ${cb.z}\n`;
+      output += 'outer loop\n';
+      output += `vertex ${a.x} ${a.y} ${a.z}\n`;
+      output += `vertex ${b.x} ${b.y} ${b.z}\n`;
+      output += `vertex ${c.x} ${c.y} ${c.z}\n`;
+      output += 'endloop\nendfacet\n';
+    }
+
+    scene.traverse(child => {
+      if (!child.isMesh && !child.isInstancedMesh) return;
+      const geometry = child.geometry;
+      if (!geometry) return;
+      const index = geometry.getIndex();
+      const position = geometry.getAttribute('position');
+      const instanceCount = child.isInstancedMesh ? child.count : 1;
+      for (let inst = 0; inst < instanceCount; inst++) {
+        if (child.isInstancedMesh) {
+          child.getMatrixAt(inst, matrix);
+          matrix.multiplyMatrices(child.matrixWorld, matrix);
+        } else {
+          matrix.copy(child.matrixWorld);
+        }
+        for (let i = 0; i < position.count; i += 3) {
+          const a = index ? index.getX(i) : i;
+          const b = index ? index.getX(i + 1) : i + 1;
+          const c = index ? index.getX(i + 2) : i + 2;
+          const vA = vector.fromBufferAttribute(position, a).applyMatrix4(matrix).clone();
+          const vB = vector.fromBufferAttribute(position, b).applyMatrix4(matrix).clone();
+          const vC = vector.fromBufferAttribute(position, c).applyMatrix4(matrix).clone();
+          addTriangle(vA, vB, vC);
+        }
+      }
+    });
+
+    output += 'endsolid exported';
+    return output;
+  }
+}


### PR DESCRIPTION
## Summary
- add print/export buttons for each map
- style the new print button
- allow exporting OBJ or screenshots
- retain density overlay lines when zooming
- make Mollweide outline partially transparent

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6848181a4870832a9abc195547117f0b