### PR TITLE
Enhance Mollweide map features

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -176,9 +176,12 @@ class DensityGridOverlay {
             color: 0xff0000,
             transparent: true,
             opacity: 0.9,
-            linewidth: 5
+            linewidth: 5,
+            depthTest: false,
+            depthWrite: false
           });
           const lineM = new THREE.LineSegments(geomM, mollMat);
+          lineM.renderOrder = 2;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });

--- a/index.html
+++ b/index.html
@@ -215,6 +215,13 @@
       <div class="map-container">
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
+        <select id="download-mollweide-format" class="download-select">
+          <option value="png">PNG</option>
+          <option value="jpg">JPG</option>
+          <option value="svg">SVG</option>
+          <option value="pdf">PDF</option>
+        </select>
+        <button class="download-btn" id="download-mollweide-btn" aria-label="Download Mollweide Map">⬇</button>
         <canvas id="mollweideMap"></canvas>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -205,7 +205,11 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xaaaaaa,
+    transparent: true,
+    opacity: 0.5
+  });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -863,6 +867,44 @@ function updateMollweideView() {
   }
 }
 window.updateMollweideView = updateMollweideView;
+
+function downloadMollweideMap(format = 'png') {
+  if (!window.mollweideMap) return;
+  const canvas = window.mollweideMap.renderer.domElement;
+  if (format === 'png' || format === 'jpg') {
+    const mime = format === 'jpg' ? 'image/jpeg' : 'image/png';
+    const dataUrl = canvas.toDataURL(mime);
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = `mollweide_map.${format}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } else if (format === 'svg') {
+    const imgUrl = canvas.toDataURL('image/png');
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" width="${canvas.width}" height="${canvas.height}"><image href="${imgUrl}" width="${canvas.width}" height="${canvas.height}"/></svg>`;
+    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'mollweide_map.svg';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } else if (format === 'pdf') {
+    const imgUrl = canvas.toDataURL('image/png');
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write('<html><head><title>Print Map</title></head><body style="margin:0">');
+    w.document.write(`<img src="${imgUrl}" style="width:100%"/>`);
+    w.document.write('</body></html>');
+    w.document.close();
+    w.focus();
+    w.print();
+  }
+}
+window.downloadMollweideMap = downloadMollweideMap;
 
 async function main() {
   const loader = document.getElementById('loader');

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,33 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   z-index: 10;
 }
 
+/* Download controls */
+.download-select {
+  position: absolute;
+  top: 10px;
+  right: 90px;
+  background: rgba(20, 20, 20, 0.7);
+  color: #e0e0e0;
+  border: none;
+  padding: 5px;
+  border-radius: 4px;
+  z-index: 10;
+}
+
+.download-btn {
+  position: absolute;
+  top: 10px;
+  right: 50px;
+  font-size: 20px;
+  background: rgba(20, 20, 20, 0.7);
+  border: none;
+  color: #ff6f61;
+  cursor: pointer;
+  padding: 5px 10px;
+  border-radius: 4px;
+  z-index: 10;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -159,6 +159,17 @@ export function initFilterUI() {
     }
   });
 
+  const dlBtn = document.getElementById('download-mollweide-btn');
+  const dlSelect = document.getElementById('download-mollweide-format');
+  if (dlBtn && dlSelect) {
+    dlBtn.addEventListener('click', () => {
+      const fmt = dlSelect.value;
+      if (window.downloadMollweideMap) {
+        window.downloadMollweideMap(fmt);
+      }
+    });
+  }
+
   console.log("[filterUI] Filter UI initialized.");
 }
 


### PR DESCRIPTION
## Summary
- adjust Mollweide border with 50% opacity
- keep density filter lines visible while zooming
- add export/download controls for the Mollweide map with PNG/JPG/SVG/PDF support
- style new download controls

## Testing
- `pre-commit` *(fails: no command)*

------
https://chatgpt.com/codex/tasks/task_e_68481d283e48832a9be43e509cdf0247