### PR TITLE
Add map projection controls and refine Mollweide view

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,25 @@
     <aside class="sidebar">
       <h2>Filters</h2>
       <form id="filters-form">
+        <!-- Map Projection Category -->
+        <fieldset>
+          <legend class="collapsible" aria-expanded="false">Map Projections</legend>
+          <div class="filter-content">
+            <div class="filter-item">
+              <input type="checkbox" id="projection-mollweide" name="projection-mollweide" checked />
+              <label for="projection-mollweide">Mollweide</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="projection-true" name="projection-true" />
+              <label for="projection-true">True Coordinates</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="projection-globe" name="projection-globe" />
+              <label for="projection-globe">Globe</label>
+            </div>
+          </div>
+        </fieldset>
+
         <!-- Stellar Class Filter Fieldset -->
         <fieldset>
           <legend class="collapsible" aria-expanded="false">Stellar Class</legend>
@@ -202,17 +221,17 @@
 
     <!-- Maps Section -->
     <section class="maps-section">
-      <div class="map-container">
+      <div id="true-map-container" class="map-container" style="display:none;">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
         <canvas id="map3D"></canvas>
       </div>
-      <div class="map-container">
+      <div id="globe-map-container" class="map-container" style="display:none;">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
         <canvas id="sphereMap"></canvas>
       </div>
-      <div class="map-container">
+      <div id="mollweide-map-container" class="map-container">
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>

--- a/script.js
+++ b/script.js
@@ -205,7 +205,7 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5 });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -716,6 +716,7 @@ function requestRender() {
   }
 }
 window.requestRender = requestRender;
+window.mapManagers = mapManagers;
 
 function initStarInteractions(map) {
   const raycaster = new THREE.Raycaster();

--- a/script.js
+++ b/script.js
@@ -902,6 +902,7 @@ async function main() {
     window.trueCoordinatesMap = trueCoordinatesMap;
     window.globeMap = globeMap;
     window.mollweideMap = mollweideMap;
+    if (window.updateMapVisibility) window.updateMapVisibility();
     cachedStars.forEach(star => {
       star.spherePosition = projectStarGlobe(star);
       star.truePosition = getStarTruePosition(star);

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -35,6 +35,7 @@ export function initFilterUI() {
   projMoll.addEventListener('change', updateMapVisibility);
   projTrue.addEventListener('change', updateMapVisibility);
   projGlobe.addEventListener('change', updateMapVisibility);
+  window.updateMapVisibility = updateMapVisibility;
   updateMapVisibility();
 
   // Enable/disable connection slider.

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -7,6 +7,36 @@ export function initFilterUI() {
     document.querySelector('.sidebar').classList.toggle('open');
   });
 
+  // Map Projection toggles
+  const projMoll = document.getElementById('projection-mollweide');
+  const projTrue = document.getElementById('projection-true');
+  const projGlobe = document.getElementById('projection-globe');
+  const trueContainer = document.getElementById('true-map-container');
+  const globeContainer = document.getElementById('globe-map-container');
+  const mollContainer = document.getElementById('mollweide-map-container');
+  function updateMapVisibility() {
+    const mm = window.mapManagers || [];
+    const manage = (mgr, visible) => {
+      const idx = mm.indexOf(mgr);
+      if (visible && idx === -1) mm.push(mgr);
+      if (!visible && idx !== -1) mm.splice(idx, 1);
+    };
+    const showTrue = projTrue.checked;
+    const showGlobe = projGlobe.checked;
+    const showMoll = projMoll.checked;
+    trueContainer.style.display = showTrue ? '' : 'none';
+    globeContainer.style.display = showGlobe ? '' : 'none';
+    mollContainer.style.display = showMoll ? '' : 'none';
+    if (window.trueCoordinatesMap) manage(window.trueCoordinatesMap, showTrue);
+    if (window.globeMap) manage(window.globeMap, showGlobe);
+    if (window.mollweideMap) manage(window.mollweideMap, showMoll);
+    window.dispatchEvent(new Event('resize'));
+  }
+  projMoll.addEventListener('change', updateMapVisibility);
+  projTrue.addEventListener('change', updateMapVisibility);
+  projGlobe.addEventListener('change', updateMapVisibility);
+  updateMapVisibility();
+
   // Enable/disable connection slider.
   const enableConnectionsChk = document.getElementById('enable-connections');
   const connectionSlider = document.getElementById('connection-slider');


### PR DESCRIPTION
## Summary
- add new *Map Projections* filter category
- default to showing only the Mollweide map
- allow toggling visibility for True Coordinates and Globe maps
- reduce Mollweide map border opacity
- expose map manager list for runtime updates

## Testing
- `npm --version`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485f343e54832abd25c7a93d4e865b