### PR TITLE
Add map projection toggle UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,11 @@
               <label for="show-map-mollweide">Mollweide</label>
             </div>
             <div class="filter-item">
-              <input type="checkbox" id="show-map-true" name="show-map-true" checked />
+              <input type="checkbox" id="show-map-true" name="show-map-true" />
               <label for="show-map-true">True Coordinates</label>
             </div>
             <div class="filter-item">
-              <input type="checkbox" id="show-map-globe" name="show-map-globe" checked />
+              <input type="checkbox" id="show-map-globe" name="show-map-globe" />
               <label for="show-map-globe">Globe</label>
             </div>
           </div>
@@ -220,12 +220,12 @@
 
     <!-- Maps Section -->
     <section class="maps-section">
-      <div class="map-container" id="trueMapContainer">
+      <div class="map-container" id="trueMapContainer" style="display: none;">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
         <canvas id="map3D"></canvas>
       </div>
-      <div class="map-container" id="globeMapContainer">
+      <div class="map-container" id="globeMapContainer" style="display: none;">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
         <canvas id="sphereMap"></canvas>

--- a/index.html
+++ b/index.html
@@ -31,11 +31,11 @@
               <label for="show-map-mollweide">Mollweide</label>
             </div>
             <div class="filter-item">
-              <input type="checkbox" id="show-map-true" name="show-map-true" />
+              <input type="checkbox" id="show-map-true" name="show-map-true" checked />
               <label for="show-map-true">True Coordinates</label>
             </div>
             <div class="filter-item">
-              <input type="checkbox" id="show-map-globe" name="show-map-globe" />
+              <input type="checkbox" id="show-map-globe" name="show-map-globe" checked />
               <label for="show-map-globe">Globe</label>
             </div>
           </div>
@@ -220,12 +220,12 @@
 
     <!-- Maps Section -->
     <section class="maps-section">
-      <div class="map-container" id="trueMapContainer" style="display:none;">
+      <div class="map-container" id="trueMapContainer">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
         <canvas id="map3D"></canvas>
       </div>
-      <div class="map-container" id="globeMapContainer" style="display:none;">
+      <div class="map-container" id="globeMapContainer">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
         <canvas id="sphereMap"></canvas>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,24 @@
     <aside class="sidebar">
       <h2>Filters</h2>
       <form id="filters-form">
+        <!-- Map Projection Category -->
+        <fieldset>
+          <legend class="collapsible" aria-expanded="false">Map Projection</legend>
+          <div class="filter-content">
+            <div class="filter-item">
+              <input type="checkbox" id="show-map-mollweide" name="show-map-mollweide" checked />
+              <label for="show-map-mollweide">Mollweide</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="show-map-true" name="show-map-true" />
+              <label for="show-map-true">True Coordinates</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="show-map-globe" name="show-map-globe" />
+              <label for="show-map-globe">Globe</label>
+            </div>
+          </div>
+        </fieldset>
         <!-- Stellar Class Filter Fieldset -->
         <fieldset>
           <legend class="collapsible" aria-expanded="false">Stellar Class</legend>
@@ -202,17 +220,17 @@
 
     <!-- Maps Section -->
     <section class="maps-section">
-      <div class="map-container">
+      <div class="map-container" id="trueMapContainer" style="display:none;">
         <h2>True Coordinates Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen True Coordinates Map">⤢</button>
         <canvas id="map3D"></canvas>
       </div>
-      <div class="map-container">
+      <div class="map-container" id="globeMapContainer" style="display:none;">
         <h2>Globe Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Globe Map">⤢</button>
         <canvas id="sphereMap"></canvas>
       </div>
-      <div class="map-container">
+      <div class="map-container" id="mollweideMapContainer">
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>

--- a/script.js
+++ b/script.js
@@ -205,7 +205,11 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xaaaaaa,
+    transparent: true,
+    opacity: 0.5
+  });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -705,6 +709,18 @@ class MapManager {
 }
 
 const mapManagers = [];
+function addMapManager(mgr) {
+  if (!mapManagers.includes(mgr)) {
+    mapManagers.push(mgr);
+  }
+}
+
+function removeMapManager(mgr) {
+  const idx = mapManagers.indexOf(mgr);
+  if (idx !== -1) {
+    mapManagers.splice(idx, 1);
+  }
+}
 let renderRequested = false;
 function requestRender() {
   if (!renderRequested) {
@@ -716,6 +732,42 @@ function requestRender() {
   }
 }
 window.requestRender = requestRender;
+
+function toggleMapVisibility(mapType, visible) {
+  let manager, container, stars, connections;
+  switch (mapType) {
+    case 'TrueCoordinates':
+      manager = trueCoordinatesMap;
+      container = document.getElementById('trueMapContainer');
+      stars = currentFilteredStars;
+      connections = currentConnections;
+      break;
+    case 'Globe':
+      manager = globeMap;
+      container = document.getElementById('globeMapContainer');
+      stars = currentGlobeFilteredStars;
+      connections = currentGlobeConnections;
+      break;
+    default:
+      manager = mollweideMap;
+      container = document.getElementById('mollweideMapContainer');
+      stars = currentMollweideFilteredStars;
+      connections = currentMollweideConnections;
+      break;
+  }
+  if (!manager || !container) return;
+  if (visible) {
+    container.style.display = '';
+    addMapManager(manager);
+    manager.updateMap(stars, connections);
+    manager.labelManager.refreshLabels(stars);
+  } else {
+    container.style.display = 'none';
+    removeMapManager(manager);
+  }
+  requestRender();
+}
+window.toggleMapVisibility = toggleMapVisibility;
 
 function initStarInteractions(map) {
   const raycaster = new THREE.Raycaster();
@@ -897,7 +949,7 @@ async function main() {
     trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });
     globeMap = new MapManager({ canvasId: 'sphereMap', mapType: 'Globe' });
     mollweideMap = new MapManager({ canvasId: 'mollweideMap', mapType: 'Mollweide' });
-    mapManagers.push(trueCoordinatesMap, globeMap, mollweideMap);
+    addMapManager(mollweideMap);
     window.trueCoordinatesMap = trueCoordinatesMap;
     window.globeMap = globeMap;
     window.mollweideMap = mollweideMap;
@@ -913,6 +965,9 @@ async function main() {
     initStarInteractions(trueCoordinatesMap);
     initStarInteractions(globeMap);
     initStarInteractions(mollweideMap);
+    toggleMapVisibility('TrueCoordinates', document.getElementById('show-map-true').checked);
+    toggleMapVisibility('Globe', document.getElementById('show-map-globe').checked);
+    toggleMapVisibility('Mollweide', document.getElementById('show-map-mollweide').checked);
     requestRender();
     loader.classList.add('hidden');
   } catch (err) {

--- a/script.js
+++ b/script.js
@@ -967,6 +967,8 @@ async function main() {
     trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });
     globeMap = new MapManager({ canvasId: 'sphereMap', mapType: 'Globe' });
     mollweideMap = new MapManager({ canvasId: 'mollweideMap', mapType: 'Mollweide' });
+    addMapManager(trueCoordinatesMap);
+    addMapManager(globeMap);
     addMapManager(mollweideMap);
     window.trueCoordinatesMap = trueCoordinatesMap;
     window.globeMap = globeMap;

--- a/script.js
+++ b/script.js
@@ -851,6 +851,14 @@ function toggleMapVisibility(mapType, visible) {
           selectedHighlightGlobe.material.dispose();
           selectedHighlightGlobe = null;
         }
+      } else {
+        mollweideMap = null;
+        window.mollweideMap = null;
+        if (selectedHighlightMollweide) {
+          selectedHighlightMollweide.geometry.dispose();
+          selectedHighlightMollweide.material.dispose();
+          selectedHighlightMollweide = null;
+        }
       }
     }
     requestRender();

--- a/script.js
+++ b/script.js
@@ -715,6 +715,23 @@ function addMapManager(mgr) {
   }
 }
 
+function ensureMapResized(manager) {
+  let tries = 0;
+  function attempt() {
+    const w = manager.canvas.clientWidth;
+    const h = manager.canvas.clientHeight;
+    if ((w > 0 && h > 0) || tries > 10) {
+      manager.onResize();
+      window.dispatchEvent(new Event('resize'));
+      if (window.requestRender) window.requestRender();
+    } else {
+      tries += 1;
+      requestAnimationFrame(attempt);
+    }
+  }
+  attempt();
+}
+
 function removeMapManager(mgr) {
   const idx = mapManagers.indexOf(mgr);
   if (idx !== -1) {
@@ -758,23 +775,13 @@ function toggleMapVisibility(mapType, visible) {
   if (!manager || !container) return;
   if (visible) {
     container.style.display = '';
-    // Wait two frames so layout fully updates before resizing
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        manager.onResize();
-        // Trigger global resize listeners for good measure
-        window.dispatchEvent(new Event('resize'));
-        if (window.requestRender) window.requestRender();
-      });
-    });
+    ensureMapResized(manager);
     addMapManager(manager);
     manager.updateMap(stars, connections);
     manager.labelManager.refreshLabels(stars);
   } else {
     container.style.display = 'none';
     removeMapManager(manager);
-  }
-  if (!visible) {
     requestRender();
   }
 }

--- a/script.js
+++ b/script.js
@@ -828,7 +828,31 @@ function toggleMapVisibility(mapType, visible) {
     }
   } else {
     container.style.display = 'none';
-    if (manager) removeMapManager(manager);
+    if (manager) {
+      removeMapManager(manager);
+      window.removeEventListener('resize', manager.debouncedResize, false);
+      if (manager.controls && typeof manager.controls.dispose === 'function') {
+        manager.controls.dispose();
+      }
+      manager.renderer.dispose();
+      if (mapType === 'TrueCoordinates') {
+        trueCoordinatesMap = null;
+        window.trueCoordinatesMap = null;
+        if (selectedHighlightTrue) {
+          selectedHighlightTrue.geometry.dispose();
+          selectedHighlightTrue.material.dispose();
+          selectedHighlightTrue = null;
+        }
+      } else if (mapType === 'Globe') {
+        globeMap = null;
+        window.globeMap = null;
+        if (selectedHighlightGlobe) {
+          selectedHighlightGlobe.geometry.dispose();
+          selectedHighlightGlobe.material.dispose();
+          selectedHighlightGlobe = null;
+        }
+      }
+    }
     requestRender();
   }
 }

--- a/script.js
+++ b/script.js
@@ -758,7 +758,11 @@ function toggleMapVisibility(mapType, visible) {
   if (!manager || !container) return;
   if (visible) {
     container.style.display = '';
-    manager.onResize();
+    // Delay resize to ensure layout updated after showing container
+    requestAnimationFrame(() => {
+      manager.onResize();
+      if (window.requestRender) window.requestRender();
+    });
     addMapManager(manager);
     manager.updateMap(stars, connections);
     manager.labelManager.refreshLabels(stars);
@@ -766,7 +770,9 @@ function toggleMapVisibility(mapType, visible) {
     container.style.display = 'none';
     removeMapManager(manager);
   }
-  requestRender();
+  if (!visible) {
+    requestRender();
+  }
 }
 window.toggleMapVisibility = toggleMapVisibility;
 

--- a/script.js
+++ b/script.js
@@ -736,15 +736,18 @@ function addMapManager(mgr) {
 function ensureMapResized(manager) {
   let tries = 0;
   function attempt() {
-    const w = manager.canvas.clientWidth;
-    const h = manager.canvas.clientHeight;
-    if ((w > 0 && h > 0) || tries > 10) {
+    const w = manager.canvas.offsetWidth;
+    const h = manager.canvas.offsetHeight;
+    if (w > 0 && h > 0) {
       manager.onResize();
       window.dispatchEvent(new Event('resize'));
       if (window.requestRender) window.requestRender();
-    } else {
+    } else if (tries < 30) {
       tries += 1;
       requestAnimationFrame(attempt);
+    } else {
+      manager.onResize();
+      if (window.requestRender) window.requestRender();
     }
   }
   attempt();
@@ -793,6 +796,9 @@ function toggleMapVisibility(mapType, visible) {
   if (!container) return;
   if (visible) {
     container.style.display = '';
+    if (container.parentElement) {
+      container.parentElement.appendChild(container);
+    }
     if (!manager) {
       if (mapType === 'TrueCoordinates') {
         trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });

--- a/script.js
+++ b/script.js
@@ -758,10 +758,14 @@ function toggleMapVisibility(mapType, visible) {
   if (!manager || !container) return;
   if (visible) {
     container.style.display = '';
-    // Delay resize to ensure layout updated after showing container
+    // Wait two frames so layout fully updates before resizing
     requestAnimationFrame(() => {
-      manager.onResize();
-      if (window.requestRender) window.requestRender();
+      requestAnimationFrame(() => {
+        manager.onResize();
+        // Trigger global resize listeners for good measure
+        window.dispatchEvent(new Event('resize'));
+        if (window.requestRender) window.requestRender();
+      });
     });
     addMapManager(manager);
     manager.updateMap(stars, connections);

--- a/script.js
+++ b/script.js
@@ -758,6 +758,7 @@ function toggleMapVisibility(mapType, visible) {
   if (!manager || !container) return;
   if (visible) {
     container.style.display = '';
+    manager.onResize();
     addMapManager(manager);
     manager.updateMap(stars, connections);
     manager.labelManager.refreshLabels(stars);

--- a/script.js
+++ b/script.js
@@ -326,10 +326,14 @@ async function buildAndApplyFilters() {
     updateMollweidePosition(star);
   });
 
-  trueCoordinatesMap.updateMap(currentFilteredStars, currentConnections);
-  trueCoordinatesMap.labelManager.refreshLabels(currentFilteredStars);
-  globeMap.updateMap(currentGlobeFilteredStars, currentGlobeConnections);
-  globeMap.labelManager.refreshLabels(currentGlobeFilteredStars);
+  if (trueCoordinatesMap) {
+    trueCoordinatesMap.updateMap(currentFilteredStars, currentConnections);
+    trueCoordinatesMap.labelManager.refreshLabels(currentFilteredStars);
+  }
+  if (globeMap) {
+    globeMap.updateMap(currentGlobeFilteredStars, currentGlobeConnections);
+    globeMap.labelManager.refreshLabels(currentGlobeFilteredStars);
+  }
   mollweideMap.addStars(currentMollweideFilteredStars);
   mollweideMap.updateStarPositions(currentMollweideFilteredStars);
   mollweideMap.updateConnections(currentMollweideFilteredStars, currentMollweideConnections);
@@ -339,22 +343,28 @@ async function buildAndApplyFilters() {
   removeConstellationOverlayObjectsFromGlobe();
 
   if (showConstellationBoundaries) {
-    constellationLinesGlobe = createConstellationBoundariesForGlobe();
-    constellationLinesGlobe.forEach(ln => globeMap.scene.add(ln));
+    if (globeMap) {
+      constellationLinesGlobe = createConstellationBoundariesForGlobe();
+      constellationLinesGlobe.forEach(ln => globeMap.scene.add(ln));
+    }
     constellationLinesMoll = createConstellationBoundariesForMollweide();
     constellationLinesMoll.forEach(ln => mollweideMap.scene.add(ln));
   }
   if (showConstellationNames) {
-    constellationLabelsGlobe = createConstellationLabelsForGlobe();
-    constellationLabelsGlobe.forEach(lbl => globeMap.scene.add(lbl));
+    if (globeMap) {
+      constellationLabelsGlobe = createConstellationLabelsForGlobe();
+      constellationLabelsGlobe.forEach(lbl => globeMap.scene.add(lbl));
+    }
     constellationLabelsMoll = createConstellationLabelsForMollweide();
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
   }
   if (showConstellationOverlay) {
-    const constellationOverlay = createConstellationOverlayForGlobe();
-    constellationOverlay.forEach(mesh => {
-      window.globeMap.scene.add(mesh);
-    });
+    if (globeMap) {
+      const constellationOverlay = createConstellationOverlayForGlobe();
+      constellationOverlay.forEach(mesh => {
+        window.globeMap.scene.add(mesh);
+      });
+    }
     constellationOverlayMoll = createConstellationOverlayForMollweide();
     constellationOverlayMoll.forEach(mesh => {
       mollweideMap.scene.add(mesh);
@@ -367,8 +377,12 @@ async function buildAndApplyFilters() {
     // Get the file paths from the checked dust cloud checkboxes.
     const cloudDataFiles = new FormData(form).getAll('dust-clouds');
     // Use the complete star list (cachedStars) so that the clouds overlay ignores the distance filter.
-    updateCloudsOverlay(cachedStars, trueCoordinatesMap.scene, 'TrueCoordinates', cloudDataFiles);
-    updateCloudsOverlay(cachedStars, globeMap.scene, 'Globe', cloudDataFiles);
+    if (trueCoordinatesMap) {
+      updateCloudsOverlay(cachedStars, trueCoordinatesMap.scene, 'TrueCoordinates', cloudDataFiles);
+    }
+    if (globeMap) {
+      updateCloudsOverlay(cachedStars, globeMap.scene, 'Globe', cloudDataFiles);
+    }
     updateCloudsOverlay(cachedStars, mollweideMap.scene, 'Mollweide', cloudDataFiles);
   }
 
@@ -379,11 +393,11 @@ async function buildAndApplyFilters() {
 }
 
 function removeConstellationObjectsFromGlobe() {
-  if (constellationLinesGlobe && constellationLinesGlobe.length > 0) {
+  if (globeMap && constellationLinesGlobe && constellationLinesGlobe.length > 0) {
     constellationLinesGlobe.forEach(l => globeMap.scene.remove(l));
   }
   constellationLinesGlobe = [];
-  if (constellationLabelsGlobe && constellationLabelsGlobe.length > 0) {
+  if (globeMap && constellationLabelsGlobe && constellationLabelsGlobe.length > 0) {
     constellationLabelsGlobe.forEach(lbl => globeMap.scene.remove(lbl));
   }
   constellationLabelsGlobe = [];
@@ -398,7 +412,7 @@ function removeConstellationObjectsFromGlobe() {
 }
 
 function removeConstellationOverlayObjectsFromGlobe() {
-  if (constellationOverlayGlobe && constellationOverlayGlobe.length > 0) {
+  if (globeMap && constellationOverlayGlobe && constellationOverlayGlobe.length > 0) {
     constellationOverlayGlobe.forEach(mesh => globeMap.scene.remove(mesh));
   }
   constellationOverlayGlobe = [];
@@ -410,11 +424,11 @@ function removeConstellationOverlayObjectsFromGlobe() {
 
 function applyPlanes(showGal, showEcl, showEq) {
   if (showGal) {
-    if (!galacticPlaneTrue) {
+    if (trueCoordinatesMap && !galacticPlaneTrue) {
       galacticPlaneTrue = createGalacticPlaneMesh(200);
       trueCoordinatesMap.scene.add(galacticPlaneTrue);
     }
-    if (!galacticPlaneGlobe) {
+    if (globeMap && !galacticPlaneGlobe) {
       galacticPlaneGlobe = createGalacticPlaneGlobe(100);
       globeMap.scene.add(galacticPlaneGlobe);
     }
@@ -424,11 +438,11 @@ function applyPlanes(showGal, showEcl, showEq) {
     } else {
       updateGalacticPlaneMollweide(galacticPlaneMoll);
     }
-    if (galacticDirectionLabelsTrue.length === 0) {
+    if (trueCoordinatesMap && galacticDirectionLabelsTrue.length === 0) {
       galacticDirectionLabelsTrue = createGalacticDirectionLabelsTrue();
       galacticDirectionLabelsTrue.forEach(lbl => trueCoordinatesMap.scene.add(lbl));
     }
-    if (galacticDirectionLabelsGlobe.length === 0) {
+    if (globeMap && galacticDirectionLabelsGlobe.length === 0) {
       galacticDirectionLabelsGlobe = createGalacticDirectionLabelsGlobe();
       galacticDirectionLabelsGlobe.forEach(lbl => globeMap.scene.add(lbl));
     }
@@ -439,23 +453,27 @@ function applyPlanes(showGal, showEcl, showEq) {
       updateGalacticDirectionLabelsMollweide(galacticDirectionLabelsMoll);
     }
   } else {
-    if (galacticPlaneTrue) { trueCoordinatesMap.scene.remove(galacticPlaneTrue); galacticPlaneTrue.geometry.dispose(); galacticPlaneTrue.material.dispose(); galacticPlaneTrue = null; }
-    if (galacticPlaneGlobe) { globeMap.scene.remove(galacticPlaneGlobe); galacticPlaneGlobe.geometry.dispose(); galacticPlaneGlobe.material.dispose(); galacticPlaneGlobe = null; }
+    if (galacticPlaneTrue && trueCoordinatesMap) { trueCoordinatesMap.scene.remove(galacticPlaneTrue); galacticPlaneTrue.geometry.dispose(); galacticPlaneTrue.material.dispose(); galacticPlaneTrue = null; }
+    if (galacticPlaneGlobe && globeMap) { globeMap.scene.remove(galacticPlaneGlobe); galacticPlaneGlobe.geometry.dispose(); galacticPlaneGlobe.material.dispose(); galacticPlaneGlobe = null; }
     if (galacticPlaneMoll) { mollweideMap.scene.remove(galacticPlaneMoll); galacticPlaneMoll.geometry.dispose(); galacticPlaneMoll.material.dispose(); galacticPlaneMoll = null; }
-    galacticDirectionLabelsTrue.forEach(lbl => trueCoordinatesMap.scene.remove(lbl));
+    if (trueCoordinatesMap) {
+      galacticDirectionLabelsTrue.forEach(lbl => trueCoordinatesMap.scene.remove(lbl));
+    }
     galacticDirectionLabelsTrue = [];
-    galacticDirectionLabelsGlobe.forEach(lbl => globeMap.scene.remove(lbl));
+    if (globeMap) {
+      galacticDirectionLabelsGlobe.forEach(lbl => globeMap.scene.remove(lbl));
+    }
     galacticDirectionLabelsGlobe = [];
     galacticDirectionLabelsMoll.forEach(lbl => mollweideMap.scene.remove(lbl));
     galacticDirectionLabelsMoll = [];
   }
 
   if (showEcl) {
-    if (!eclipticPlaneTrue) {
+    if (trueCoordinatesMap && !eclipticPlaneTrue) {
       eclipticPlaneTrue = createEclipticPlaneMesh(200);
       trueCoordinatesMap.scene.add(eclipticPlaneTrue);
     }
-    if (!eclipticPlaneGlobe) {
+    if (globeMap && !eclipticPlaneGlobe) {
       eclipticPlaneGlobe = createEclipticPlaneGlobe(100);
       globeMap.scene.add(eclipticPlaneGlobe);
     }
@@ -466,17 +484,17 @@ function applyPlanes(showGal, showEcl, showEq) {
       updateEclipticPlaneMollweide(eclipticPlaneMoll);
     }
   } else {
-    if (eclipticPlaneTrue) { trueCoordinatesMap.scene.remove(eclipticPlaneTrue); eclipticPlaneTrue.geometry.dispose(); eclipticPlaneTrue.material.dispose(); eclipticPlaneTrue = null; }
-    if (eclipticPlaneGlobe) { globeMap.scene.remove(eclipticPlaneGlobe); eclipticPlaneGlobe.geometry.dispose(); eclipticPlaneGlobe.material.dispose(); eclipticPlaneGlobe = null; }
+    if (eclipticPlaneTrue && trueCoordinatesMap) { trueCoordinatesMap.scene.remove(eclipticPlaneTrue); eclipticPlaneTrue.geometry.dispose(); eclipticPlaneTrue.material.dispose(); eclipticPlaneTrue = null; }
+    if (eclipticPlaneGlobe && globeMap) { globeMap.scene.remove(eclipticPlaneGlobe); eclipticPlaneGlobe.geometry.dispose(); eclipticPlaneGlobe.material.dispose(); eclipticPlaneGlobe = null; }
     if (eclipticPlaneMoll) { mollweideMap.scene.remove(eclipticPlaneMoll); eclipticPlaneMoll.geometry.dispose(); eclipticPlaneMoll.material.dispose(); eclipticPlaneMoll = null; }
   }
 
   if (showEq) {
-    if (!celestialEquatorTrue) {
+    if (trueCoordinatesMap && !celestialEquatorTrue) {
       celestialEquatorTrue = createCelestialEquatorMesh(200);
       trueCoordinatesMap.scene.add(celestialEquatorTrue);
     }
-    if (!celestialEquatorGlobe) {
+    if (globeMap && !celestialEquatorGlobe) {
       celestialEquatorGlobe = createCelestialEquatorGlobe(100);
       globeMap.scene.add(celestialEquatorGlobe);
     }
@@ -487,18 +505,18 @@ function applyPlanes(showGal, showEcl, showEq) {
       updateCelestialEquatorMollweide(celestialEquatorMoll);
     }
   } else {
-    if (celestialEquatorTrue) { trueCoordinatesMap.scene.remove(celestialEquatorTrue); celestialEquatorTrue.geometry.dispose(); celestialEquatorTrue.material.dispose(); celestialEquatorTrue = null; }
-    if (celestialEquatorGlobe) { globeMap.scene.remove(celestialEquatorGlobe); celestialEquatorGlobe.geometry.dispose(); celestialEquatorGlobe.material.dispose(); celestialEquatorGlobe = null; }
+    if (celestialEquatorTrue && trueCoordinatesMap) { trueCoordinatesMap.scene.remove(celestialEquatorTrue); celestialEquatorTrue.geometry.dispose(); celestialEquatorTrue.material.dispose(); celestialEquatorTrue = null; }
+    if (celestialEquatorGlobe && globeMap) { globeMap.scene.remove(celestialEquatorGlobe); celestialEquatorGlobe.geometry.dispose(); celestialEquatorGlobe.material.dispose(); celestialEquatorGlobe = null; }
     if (celestialEquatorMoll) { mollweideMap.scene.remove(celestialEquatorMoll); celestialEquatorMoll.geometry.dispose(); celestialEquatorMoll.material.dispose(); celestialEquatorMoll = null; }
   }
 }
 
 function applyGlobeSurface(isOpaque) {
-  if (globeSurfaceSphere) {
+  if (globeSurfaceSphere && globeMap) {
     globeMap.scene.remove(globeSurfaceSphere);
     globeSurfaceSphere = null;
   }
-  if (isOpaque) {
+  if (isOpaque && globeMap) {
     const geom = new THREE.SphereGeometry(99, 32, 32);
     const mat = new THREE.MeshBasicMaterial({
       color: 0x000000,
@@ -772,16 +790,39 @@ function toggleMapVisibility(mapType, visible) {
       connections = currentMollweideConnections;
       break;
   }
-  if (!manager || !container) return;
+  if (!container) return;
   if (visible) {
     container.style.display = '';
-    ensureMapResized(manager);
-    addMapManager(manager);
-    manager.updateMap(stars, connections);
-    manager.labelManager.refreshLabels(stars);
+    if (!manager) {
+      if (mapType === 'TrueCoordinates') {
+        trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });
+        manager = trueCoordinatesMap;
+        window.trueCoordinatesMap = trueCoordinatesMap;
+        initStarInteractions(manager);
+      } else if (mapType === 'Globe') {
+        globeMap = new MapManager({ canvasId: 'sphereMap', mapType: 'Globe' });
+        manager = globeMap;
+        window.globeMap = globeMap;
+        const globeGrid = createGlobeGrid(100, { color: 0x444444, opacity: 0.2, lineWidth: 1 });
+        globeMap.scene.add(globeGrid);
+        initStarInteractions(manager);
+      } else {
+        mollweideMap = mollweideMap || new MapManager({ canvasId: 'mollweideMap', mapType: 'Mollweide' });
+        manager = mollweideMap;
+        initStarInteractions(manager);
+      }
+      addMapManager(manager);
+      ensureMapResized(manager);
+      buildAndApplyFilters();
+    } else {
+      ensureMapResized(manager);
+      addMapManager(manager);
+      manager.updateMap(stars, connections);
+      manager.labelManager.refreshLabels(stars);
+    }
   } else {
     container.style.display = 'none';
-    removeMapManager(manager);
+    if (manager) removeMapManager(manager);
     requestRender();
   }
 }
@@ -853,11 +894,11 @@ function initStarInteractions(map) {
 }
 
 function updateSelectedStarHighlight() {
-  if (selectedHighlightTrue) {
+  if (selectedHighlightTrue && trueCoordinatesMap) {
     trueCoordinatesMap.scene.remove(selectedHighlightTrue);
     selectedHighlightTrue = null;
   }
-  if (selectedHighlightGlobe) {
+  if (selectedHighlightGlobe && globeMap) {
     globeMap.scene.remove(selectedHighlightGlobe);
     selectedHighlightGlobe = null;
   }
@@ -868,19 +909,23 @@ function updateSelectedStarHighlight() {
   if (!selectedStarData) return;
   let posTrue = selectedStarData.truePosition ? selectedStarData.truePosition : new THREE.Vector3(selectedStarData.x_coordinate, selectedStarData.y_coordinate, selectedStarData.z_coordinate);
   let radius = (selectedStarData.displaySize || 2) * 0.2 * 1.2;
-  const highlightGeom = new THREE.SphereGeometry(radius, 16, 16);
-  const highlightMat = new THREE.MeshBasicMaterial({ color: 0xffff00, wireframe: true });
-  selectedHighlightTrue = new THREE.Mesh(highlightGeom, highlightMat);
-  selectedHighlightTrue.position.copy(posTrue);
-  trueCoordinatesMap.scene.add(selectedHighlightTrue);
+  if (trueCoordinatesMap) {
+    const highlightGeom = new THREE.SphereGeometry(radius, 16, 16);
+    const highlightMat = new THREE.MeshBasicMaterial({ color: 0xffff00, wireframe: true });
+    selectedHighlightTrue = new THREE.Mesh(highlightGeom, highlightMat);
+    selectedHighlightTrue.position.copy(posTrue);
+    trueCoordinatesMap.scene.add(selectedHighlightTrue);
+  }
 
   let posGlobe = selectedStarData.spherePosition ? selectedStarData.spherePosition : projectStarGlobe(selectedStarData);
   let radiusGlobe = (selectedStarData.displaySize || 2) * 0.2 * 1.2;
-  const highlightGeomGlobe = new THREE.SphereGeometry(radiusGlobe, 16, 16);
-  const highlightMatGlobe = new THREE.MeshBasicMaterial({ color: 0xffff00, wireframe: true });
-  selectedHighlightGlobe = new THREE.Mesh(highlightGeomGlobe, highlightMatGlobe);
-  selectedHighlightGlobe.position.copy(posGlobe);
-  globeMap.scene.add(selectedHighlightGlobe);
+  if (globeMap) {
+    const highlightGeomGlobe = new THREE.SphereGeometry(radiusGlobe, 16, 16);
+    const highlightMatGlobe = new THREE.MeshBasicMaterial({ color: 0xffff00, wireframe: true });
+    selectedHighlightGlobe = new THREE.Mesh(highlightGeomGlobe, highlightMatGlobe);
+    selectedHighlightGlobe.position.copy(posGlobe);
+    globeMap.scene.add(selectedHighlightGlobe);
+  }
 
   let posMoll = selectedStarData.mollweidePosition ? selectedStarData.mollweidePosition : projectStarMollweide(selectedStarData);
   let radiusMoll = (selectedStarData.displaySize || 2) * 0.4 * 1.2;
@@ -964,14 +1009,8 @@ async function main() {
     if (form) {
       form.addEventListener('change', debouncedApplyFilters);
     }
-    trueCoordinatesMap = new MapManager({ canvasId: 'map3D', mapType: 'TrueCoordinates' });
-    globeMap = new MapManager({ canvasId: 'sphereMap', mapType: 'Globe' });
     mollweideMap = new MapManager({ canvasId: 'mollweideMap', mapType: 'Mollweide' });
-    addMapManager(trueCoordinatesMap);
-    addMapManager(globeMap);
     addMapManager(mollweideMap);
-    window.trueCoordinatesMap = trueCoordinatesMap;
-    window.globeMap = globeMap;
     window.mollweideMap = mollweideMap;
     cachedStars.forEach(star => {
       star.spherePosition = projectStarGlobe(star);
@@ -979,11 +1018,7 @@ async function main() {
       precalcMollweideData(star);
       updateMollweidePosition(star);
     });
-    const globeGrid = createGlobeGrid(100, { color: 0x444444, opacity: 0.2, lineWidth: 1 });
-    globeMap.scene.add(globeGrid);
     buildAndApplyFilters();
-    initStarInteractions(trueCoordinatesMap);
-    initStarInteractions(globeMap);
     initStarInteractions(mollweideMap);
     toggleMapVisibility('TrueCoordinates', document.getElementById('show-map-true').checked);
     toggleMapVisibility('Globe', document.getElementById('show-map-globe').checked);

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -7,6 +7,32 @@ export function initFilterUI() {
     document.querySelector('.sidebar').classList.toggle('open');
   });
 
+  // Map projection visibility toggles
+  const mollChk = document.getElementById('show-map-mollweide');
+  const trueChk = document.getElementById('show-map-true');
+  const globeChk = document.getElementById('show-map-globe');
+  if (mollChk) {
+    mollChk.addEventListener('change', function () {
+      if (window.toggleMapVisibility) {
+        window.toggleMapVisibility('Mollweide', this.checked);
+      }
+    });
+  }
+  if (trueChk) {
+    trueChk.addEventListener('change', function () {
+      if (window.toggleMapVisibility) {
+        window.toggleMapVisibility('TrueCoordinates', this.checked);
+      }
+    });
+  }
+  if (globeChk) {
+    globeChk.addEventListener('change', function () {
+      if (window.toggleMapVisibility) {
+        window.toggleMapVisibility('Globe', this.checked);
+      }
+    });
+  }
+
   // Enable/disable connection slider.
   const enableConnectionsChk = document.getElementById('enable-connections');
   const connectionSlider = document.getElementById('connection-slider');


### PR DESCRIPTION
## Summary
- show only the Mollweide map by default and add map toggles
- control map visibility from new **Map Projection** filter section
- keep Mollweide outline at 0.5 opacity

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684862f70e94832a931f6730ce8f6c0d