### PR TITLE
Add map projection options and improve Mollweide display

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,24 @@
     <aside class="sidebar">
       <h2>Filters</h2>
       <form id="filters-form">
+        <!-- Map Projection Filter -->
+        <fieldset>
+          <legend class="collapsible" aria-expanded="false">Map Projection</legend>
+          <div class="filter-content">
+            <div class="filter-item">
+              <input type="checkbox" id="proj-mollweide" name="map-projection" value="mollweide" checked />
+              <label for="proj-mollweide">Mollweide</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="proj-true" name="map-projection" value="true" />
+              <label for="proj-true">True Coordinates</label>
+            </div>
+            <div class="filter-item">
+              <input type="checkbox" id="proj-globe" name="map-projection" value="globe" />
+              <label for="proj-globe">Globe</label>
+            </div>
+          </div>
+        </fieldset>
         <!-- Stellar Class Filter Fieldset -->
         <fieldset>
           <legend class="collapsible" aria-expanded="false">Stellar Class</legend>

--- a/script.js
+++ b/script.js
@@ -205,7 +205,11 @@ function createMollweideBorder(R = 100) {
     points.push(new THREE.Vector3(x, y, 0));
   }
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa });
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xaaaaaa,
+    transparent: true,
+    opacity: 0.5
+  });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -711,7 +715,12 @@ function requestRender() {
     renderRequested = true;
     requestAnimationFrame(() => {
       renderRequested = false;
-      mapManagers.forEach(m => m.render());
+      mapManagers.forEach(m => {
+        const container = m.canvas.parentElement;
+        if (!container || container.style.display !== 'none') {
+          m.render();
+        }
+      });
     });
   }
 }

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -23,6 +23,37 @@ export function initFilterUI() {
     connectionSlider.value = this.value;
   });
 
+  // Map Projection controls
+  const mapsSection = document.querySelector('.maps-section');
+  const mapContainers = {
+    mollweide: document.getElementById('mollweideMap').parentElement,
+    true: document.getElementById('map3D').parentElement,
+    globe: document.getElementById('sphereMap').parentElement
+  };
+  const projectionChecks = {
+    mollweide: document.getElementById('proj-mollweide'),
+    true: document.getElementById('proj-true'),
+    globe: document.getElementById('proj-globe')
+  };
+  // Hide non-default projections
+  mapContainers.true.style.display = 'none';
+  mapContainers.globe.style.display = 'none';
+
+  Object.keys(projectionChecks).forEach(key => {
+    projectionChecks[key].addEventListener('change', function () {
+      const container = mapContainers[key];
+      if (this.checked) {
+        container.style.display = '';
+        mapsSection.appendChild(container);
+        container.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        container.style.display = 'none';
+      }
+      window.dispatchEvent(new Event('resize'));
+      if (window.requestRender) window.requestRender();
+    });
+  });
+
   // Isolation Filter UI controls.
   const enableIsolationChk = document.getElementById('enable-isolation-filter');
   const isolationSlider = document.getElementById('isolation-slider');


### PR DESCRIPTION
## Summary
- add a map projection category with checkboxes for each map
- hide True Coordinates and Globe maps by default
- show newly selected maps below the visible ones and scroll to them
- render only visible maps
- make Mollweide border semi-transparent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848729e85c8832ab98baa3d9a2b5cd7