### PR TITLE
Add Mollweide map export

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,19 @@
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
+        <div class="export-controls">
+          <select id="export-format">
+            <option value="png">PNG</option>
+            <option value="pdf">PDF</option>
+          </select>
+          <select id="export-resolution">
+            <option value="3840">4K</option>
+            <option value="7680">8K</option>
+            <option value="15360">16K</option>
+            <option value="30720">32K</option>
+          </select>
+          <button id="export-mollweide" class="export-btn">Export</button>
+        </div>
       </div>
     </section>
   </div>
@@ -253,6 +266,7 @@
   <div class="label-container"></div>
 
   <!-- Scripts -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/script.js
+++ b/script.js
@@ -920,6 +920,63 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
+function exportMollweideMap(format, resolution) {
+  const width = resolution;
+  const height = Math.floor(resolution / 2);
+  const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
+  exportRenderer.setPixelRatio(1);
+  const finalCanvas = document.createElement('canvas');
+  finalCanvas.width = width;
+  finalCanvas.height = height;
+  const ctx = finalCanvas.getContext('2d');
+  const maxSize = exportRenderer.capabilities.maxTextureSize;
+  const tile = Math.min(maxSize, 8192);
+  for (let y = 0; y < height; y += tile) {
+    for (let x = 0; x < width; x += tile) {
+      const tileW = Math.min(tile, width - x);
+      const tileH = Math.min(tile, height - y);
+      exportRenderer.setSize(tileW, tileH);
+      const cam = mollweideMap.camera.clone();
+      const aspect = width / height;
+      cam.left = (-mollweideMap.frustumSize * aspect) / 2;
+      cam.right = (mollweideMap.frustumSize * aspect) / 2;
+      cam.top = mollweideMap.frustumSize / 2;
+      cam.bottom = -mollweideMap.frustumSize / 2;
+      cam.updateProjectionMatrix();
+      cam.setViewOffset(width, height, x, y, tileW, tileH);
+      exportRenderer.render(mollweideMap.scene, cam);
+      cam.clearViewOffset();
+      ctx.drawImage(exportRenderer.domElement, x, height - y - tileH, tileW, tileH);
+    }
+  }
+  exportRenderer.dispose();
+
+  if (format === 'png') {
+    finalCanvas.toBlob(b => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(b);
+      link.download = 'mollweide_map.png';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  } else {
+    const dataUrl = finalCanvas.toDataURL('image/png');
+    const pdf = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [width, height] });
+    pdf.addImage(dataUrl, 'PNG', 0, 0, width, height);
+    pdf.save('mollweide_map.pdf');
+  }
+}
+
+function setupExportControls() {
+  const btn = document.getElementById('export-mollweide');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const format = document.getElementById('export-format').value;
+    const res = parseInt(document.getElementById('export-resolution').value, 10);
+    exportMollweideMap(format, res);
+  });
+}
+
 async function main() {
   const loader = document.getElementById('loader');
   loader.classList.remove('hidden');
@@ -952,6 +1009,7 @@ async function main() {
     initStarInteractions(globeMap);
     initStarInteractions(mollweideMap);
     setupMapProjectionToggles();
+    setupExportControls();
     requestRender();
     loader.classList.add('hidden');
   } catch (err) {

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,31 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   z-index: 10;
 }
 
+/* Export Controls */
+.export-controls {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  gap: 6px;
+  background: rgba(20, 20, 20, 0.7);
+  padding: 5px;
+  border-radius: 4px;
+  z-index: 10;
+}
+.export-controls select,
+.export-controls button {
+  background: rgba(20, 20, 20, 0.9);
+  color: #ff6f61;
+  border: 1px solid #555;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+.export-btn {
+  cursor: pointer;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- enable export for the Mollweide map
- add resolution and format selectors
- support PNG and PDF outputs at resolutions from 4K–32K

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684882242c8c832ab9b496f16b11c418