### PR TITLE
Add zipped exports for >8k

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
 
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/script.js
+++ b/script.js
@@ -951,7 +951,43 @@ function exportMollweideMap(format, resolution) {
   }
   exportRenderer.dispose();
 
-  if (format === 'png') {
+  const splitNeeded = resolution > 8192 && format === 'png';
+  if (splitNeeded) {
+    const zip = new JSZip();
+    const partWidth = 8192;
+    const partHeight = 4096;
+    const cols = Math.ceil(width / partWidth);
+    const rows = Math.ceil(height / partHeight);
+    const promises = [];
+
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < cols; col++) {
+        const w = Math.min(partWidth, width - col * partWidth);
+        const h = Math.min(partHeight, height - row * partHeight);
+        const partCanvas = document.createElement('canvas');
+        partCanvas.width = w;
+        partCanvas.height = h;
+        const partCtx = partCanvas.getContext('2d');
+        partCtx.drawImage(finalCanvas, col * partWidth, row * partHeight, w, h, 0, 0, w, h);
+        promises.push(new Promise(resolve => {
+          partCanvas.toBlob(blob => {
+            zip.file(`mollweide_part_${row + 1}_${col + 1}.png`, blob);
+            resolve();
+          }, 'image/png');
+        }));
+      }
+    }
+
+    Promise.all(promises).then(() => {
+      zip.generateAsync({ type: 'blob' }).then(content => {
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(content);
+        link.download = 'mollweide_map_parts.zip';
+        link.click();
+        URL.revokeObjectURL(link.href);
+      });
+    });
+  } else if (format === 'png') {
     finalCanvas.toBlob(b => {
       const link = document.createElement('a');
       link.href = URL.createObjectURL(b);

--- a/script.js
+++ b/script.js
@@ -951,11 +951,11 @@ function exportMollweideMap(format, resolution) {
   }
   exportRenderer.dispose();
 
-  const splitNeeded = resolution > 8192 && format === 'png';
+  const splitNeeded = resolution > 8192;
   if (splitNeeded) {
     const zip = new JSZip();
-    const partWidth = 8192;
-    const partHeight = 4096;
+    const partWidth = 4096;
+    const partHeight = 2048;
     const cols = Math.ceil(width / partWidth);
     const rows = Math.ceil(height / partHeight);
     const promises = [];
@@ -969,24 +969,31 @@ function exportMollweideMap(format, resolution) {
         partCanvas.height = h;
         const partCtx = partCanvas.getContext('2d');
         partCtx.drawImage(finalCanvas, col * partWidth, row * partHeight, w, h, 0, 0, w, h);
-        promises.push(new Promise(resolve => {
-          partCanvas.toBlob(blob => {
-            zip.file(`mollweide_part_${row + 1}_${col + 1}.png`, blob);
-            resolve();
-          }, 'image/png');
-        }));
+
+        const dataUrl = partCanvas.toDataURL('image/png');
+        if (format === 'png') {
+          const base64 = dataUrl.split(',')[1];
+          zip.file(`mollweide_part_${row + 1}_${col + 1}.png`, base64, { base64: true });
+        } else {
+          const pdf = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [w, h] });
+          pdf.addImage(dataUrl, 'PNG', 0, 0, w, h);
+          const blob = pdf.output('blob');
+          promises.push(blob.arrayBuffer().then(buf => {
+            zip.file(`mollweide_part_${row + 1}_${col + 1}.pdf`, buf);
+          }));
+        }
       }
     }
 
-    Promise.all(promises).then(() => {
-      zip.generateAsync({ type: 'blob' }).then(content => {
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(content);
-        link.download = 'mollweide_map_parts.zip';
-        link.click();
-        URL.revokeObjectURL(link.href);
-      });
+  Promise.all(promises).then(() => {
+    zip.generateAsync({ type: 'blob' }).then(content => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(content);
+      link.download = 'mollweide_map_parts.zip';
+      link.click();
+      URL.revokeObjectURL(link.href);
     });
+  });
   } else if (format === 'png') {
     finalCanvas.toBlob(b => {
       const link = document.createElement('a');

--- a/script.js
+++ b/script.js
@@ -954,8 +954,8 @@ function exportMollweideMap(format, resolution) {
   const splitNeeded = resolution > 8192;
   if (splitNeeded) {
     const zip = new JSZip();
-    const partWidth = 4096;
-    const partHeight = 2048;
+    const partWidth = 8192;
+    const partHeight = 4096;
     const cols = Math.ceil(width / partWidth);
     const rows = Math.ceil(height / partHeight);
     const promises = [];
@@ -968,7 +968,8 @@ function exportMollweideMap(format, resolution) {
         partCanvas.width = w;
         partCanvas.height = h;
         const partCtx = partCanvas.getContext('2d');
-        partCtx.drawImage(finalCanvas, col * partWidth, row * partHeight, w, h, 0, 0, w, h);
+        const srcY = height - row * partHeight - h;
+        partCtx.drawImage(finalCanvas, col * partWidth, srcY, w, h, 0, 0, w, h);
 
         const dataUrl = partCanvas.toDataURL('image/png');
         if (format === 'png') {


### PR DESCRIPTION
## Summary
- allow zipping of large exports in `exportMollweideMap`
- include JSZip in the page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68488ec0c5d4832a96a1d80cdae1b8fb