### PR TITLE
Add SVG export for Mollweide map

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,14 +236,12 @@
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
           <select id="export-format">
-            <option value="png">PNG</option>
-            <option value="pdf">PDF</option>
+            <option value="svg">SVG</option>
           </select>
           <select id="export-resolution">
+            <option value="2048">2K</option>
             <option value="3840">4K</option>
             <option value="7680">8K</option>
-            <option value="15360">16K</option>
-            <option value="30720">32K</option>
           </select>
           <button id="export-mollweide" class="export-btn">Export</button>
         </div>
@@ -266,7 +264,6 @@
   <div class="label-container"></div>
 
   <!-- Scripts -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script type="module" src="script.js"></script>
   <script type="module">
     import { initFilterUI } from './ui/filterUI.js';

--- a/script.js
+++ b/script.js
@@ -923,37 +923,72 @@ window.updateMollweideView = updateMollweideView;
 function exportMollweideMap(resolution) {
   const width = resolution;
   const height = Math.floor(resolution / 2);
-  const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
-  exportRenderer.setPixelRatio(1);
-  const finalCanvas = document.createElement('canvas');
-  finalCanvas.width = width;
-  finalCanvas.height = height;
-  const ctx = finalCanvas.getContext('2d');
-  const maxSize = exportRenderer.capabilities.maxTextureSize;
-  const tile = Math.min(maxSize, 8192);
-  for (let y = 0; y < height; y += tile) {
-    for (let x = 0; x < width; x += tile) {
-      const tileW = Math.min(tile, width - x);
-      const tileH = Math.min(tile, height - y);
-      exportRenderer.setSize(tileW, tileH);
-      const cam = mollweideMap.camera.clone();
-      const aspect = width / height;
-      cam.left = (-mollweideMap.frustumSize * aspect) / 2;
-      cam.right = (mollweideMap.frustumSize * aspect) / 2;
-      cam.top = mollweideMap.frustumSize / 2;
-      cam.bottom = -mollweideMap.frustumSize / 2;
-      cam.updateProjectionMatrix();
-      cam.setViewOffset(width, height, x, y, tileW, tileH);
-      exportRenderer.render(mollweideMap.scene, cam);
-      cam.clearViewOffset();
-      ctx.drawImage(exportRenderer.domElement, x, height - y - tileH, tileW, tileH);
+  const aspect = width / height;
+  const fs = mollweideMap.frustumSize;
+  const left = (-fs * aspect) / 2;
+  const top = fs / 2;
+  const scaleX = width / (fs * aspect);
+  const scaleY = height / fs;
+  const unitToPx = height / fs;
+
+  const parts = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" style="background:#000">`
+  ];
+
+  // Border
+  const border = [];
+  for (let i = 0; i <= 64; i++) {
+    const theta = (i / 64) * Math.PI * 2;
+    const x = 2 * 100 * Math.cos(theta);
+    const y = 100 * Math.sin(theta);
+    const sx = (x - left) * scaleX;
+    const sy = (top - y) * scaleY;
+    border.push(`${i === 0 ? 'M' : 'L'}${sx.toFixed(2)} ${sy.toFixed(2)}`);
+  }
+  parts.push(`<path d="${border.join(' ')} Z" fill="none" stroke="#aaaaaa" stroke-opacity="0.5" stroke-width="1"/>`);
+
+  // Connection lines
+  if (mollweideMap.connectionGroup && mollweideMap.connectionGroup.children[0]) {
+    const segs = mollweideMap.connectionGroup.children[0];
+    const posAttr = segs.geometry.getAttribute('position');
+    const colAttr = segs.geometry.getAttribute('color');
+    const posArr = posAttr.array;
+    const colArr = colAttr.array;
+    for (let i = 0; i < posArr.length; i += 6) {
+      if (
+        posArr[i] === 0 && posArr[i + 1] === 0 &&
+        posArr[i + 3] === 0 && posArr[i + 4] === 0
+      ) {
+        continue;
+      }
+      const x1 = (posArr[i] - left) * scaleX;
+      const y1 = (top - posArr[i + 1]) * scaleY;
+      const x2 = (posArr[i + 3] - left) * scaleX;
+      const y2 = (top - posArr[i + 4]) * scaleY;
+      const r = Math.round(((colArr[i] + colArr[i + 3]) / 2) * 255);
+      const g = Math.round(((colArr[i + 1] + colArr[i + 4]) / 2) * 255);
+      const b = Math.round(((colArr[i + 2] + colArr[i + 5]) / 2) * 255);
+      parts.push(
+        `<line x1="${x1.toFixed(2)}" y1="${y1.toFixed(2)}" x2="${x2.toFixed(2)}" y2="${y2.toFixed(2)}" ` +
+        `stroke="rgb(${r},${g},${b})" stroke-opacity="0.5" stroke-width="1" />`
+      );
     }
   }
-  exportRenderer.dispose();
-  const dataUrl = finalCanvas.toDataURL('image/png');
-  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
-    `<image href="${dataUrl}" width="${width}" height="${height}"/></svg>`;
-  const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+
+  // Stars
+  currentMollweideFilteredStars.forEach(star => {
+    const pos = star.mollweidePosition;
+    if (!pos) return;
+    const x = (pos.x - left) * scaleX;
+    const y = (top - pos.y) * scaleY;
+    const size = star.displaySize !== undefined ? star.displaySize : 1;
+    const r = size * 0.4 * unitToPx;
+    const color = star.displayColor || '#ffffff';
+    parts.push(`<circle cx="${x.toFixed(2)}" cy="${y.toFixed(2)}" r="${r.toFixed(2)}" fill="${color}" />`);
+  });
+
+  parts.push('</svg>');
+  const blob = new Blob(parts, { type: 'image/svg+xml;charset=utf-8' });
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
   link.download = 'mollweide_map.svg';

--- a/script.js
+++ b/script.js
@@ -978,11 +978,41 @@ function exportMollweideMap(resolution) {
     }
   }
 
+  function addMesh(obj) {
+    const geom = obj.geometry;
+    if (!geom || !geom.getAttribute) return;
+    const posAttr = geom.getAttribute('position');
+    if (!posAttr) return;
+    const idx = geom.index ? geom.index.array : null;
+    const posArr = posAttr.array;
+    const mat = obj.material || {};
+    const fillOpacity = mat.opacity !== undefined ? mat.opacity : 0.2;
+    const fillColor = mat.color ? `#${mat.color.getHexString()}` : '#ffffff';
+    const loop = idx ? idx.length / 3 : posArr.length / 9;
+    for (let i = 0; i < loop; i++) {
+      const i1 = idx ? idx[i * 3] : i * 3;
+      const i2 = idx ? idx[i * 3 + 1] : i * 3 + 1;
+      const i3 = idx ? idx[i * 3 + 2] : i * 3 + 2;
+      const p1 = toScreen(posArr[i1 * 3], posArr[i1 * 3 + 1]);
+      const p2 = toScreen(posArr[i2 * 3], posArr[i2 * 3 + 1]);
+      const p3 = toScreen(posArr[i3 * 3], posArr[i3 * 3 + 1]);
+      parts.push(
+        `<polygon points="${p1.x.toFixed(2)},${p1.y.toFixed(2)} ` +
+        `${p2.x.toFixed(2)},${p2.y.toFixed(2)} ` +
+        `${p3.x.toFixed(2)},${p3.y.toFixed(2)}" ` +
+        `fill="${fillColor}" fill-opacity="${fillOpacity}" stroke="none" />`
+      );
+    }
+  }
+
   function traverse(obj) {
     if (obj === mollweideMap.starGroup) return; // stars handled separately
     if (obj.type === 'LineSegments' || obj.type === 'Line') {
       addLineSegments(obj);
-    } else if (obj.type === 'Group' || obj.type === 'Object3D') {
+    } else if (obj.type === 'Mesh') {
+      addMesh(obj);
+    }
+    if (obj.children && obj.children.length) {
       obj.children.forEach(c => traverse(c));
     }
   }
@@ -999,6 +1029,22 @@ function exportMollweideMap(resolution) {
     const color = star.displayColor || '#ffffff';
     parts.push(`<circle cx="${p.x.toFixed(2)}" cy="${p.y.toFixed(2)}" r="${r.toFixed(2)}" fill="${color}" />`);
   });
+
+  // Labels
+  if (mollweideMap.labelManager && mollweideMap.labelManager.sprites) {
+    mollweideMap.labelManager.sprites.forEach((sprite, star) => {
+      const text = star.displayName || '';
+      if (!text) return;
+      const pos = toScreen(sprite.position.x, sprite.position.y);
+      const color = star.displayColor || '#ffffff';
+      const fontSize = 12 * Math.max(star.displaySize || 1, 1);
+      parts.push(
+        `<text x="${pos.x.toFixed(2)}" y="${pos.y.toFixed(2)}" ` +
+        `fill="${color}" font-size="${fontSize}" ` +
+        `dominant-baseline="middle">${text}</text>`
+      );
+    });
+  }
 
   parts.push('</svg>');
   const blob = new Blob(parts, { type: 'image/svg+xml;charset=utf-8' });

--- a/script.js
+++ b/script.js
@@ -920,7 +920,7 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap(format, resolution) {
+function exportMollweideMap(resolution) {
   const width = resolution;
   const height = Math.floor(resolution / 2);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
@@ -950,30 +950,23 @@ function exportMollweideMap(format, resolution) {
     }
   }
   exportRenderer.dispose();
-
-  if (format === 'png') {
-    finalCanvas.toBlob(b => {
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(b);
-      link.download = 'mollweide_map.png';
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }, 'image/png');
-  } else {
-    const dataUrl = finalCanvas.toDataURL('image/png');
-    const pdf = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [width, height] });
-    pdf.addImage(dataUrl, 'PNG', 0, 0, width, height);
-    pdf.save('mollweide_map.pdf');
-  }
+  const dataUrl = finalCanvas.toDataURL('image/png');
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<image href="${dataUrl}" width="${width}" height="${height}"/></svg>`;
+  const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'mollweide_map.svg';
+  link.click();
+  URL.revokeObjectURL(link.href);
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    const format = document.getElementById('export-format').value;
     const res = parseInt(document.getElementById('export-resolution').value, 10);
-    exportMollweideMap(format, res);
+    exportMollweideMap(res);
   });
 }
 

--- a/script.js
+++ b/script.js
@@ -935,56 +935,69 @@ function exportMollweideMap(resolution) {
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" style="background:#000">`
   ];
 
+  function toScreen(x, y) {
+    return { x: (x - left) * scaleX, y: (top - y) * scaleY };
+  }
+
   // Border
   const border = [];
   for (let i = 0; i <= 64; i++) {
     const theta = (i / 64) * Math.PI * 2;
     const x = 2 * 100 * Math.cos(theta);
     const y = 100 * Math.sin(theta);
-    const sx = (x - left) * scaleX;
-    const sy = (top - y) * scaleY;
-    border.push(`${i === 0 ? 'M' : 'L'}${sx.toFixed(2)} ${sy.toFixed(2)}`);
+    const p = toScreen(x, y);
+    border.push(`${i === 0 ? 'M' : 'L'}${p.x.toFixed(2)} ${p.y.toFixed(2)}`);
   }
   parts.push(`<path d="${border.join(' ')} Z" fill="none" stroke="#aaaaaa" stroke-opacity="0.5" stroke-width="1"/>`);
 
-  // Connection lines
-  if (mollweideMap.connectionGroup && mollweideMap.connectionGroup.children[0]) {
-    const segs = mollweideMap.connectionGroup.children[0];
-    const posAttr = segs.geometry.getAttribute('position');
-    const colAttr = segs.geometry.getAttribute('color');
+  function addLineSegments(obj, defaultColor = '#aaaaaa', defaultOpacity = 0.5, defaultWidth = 1) {
+    const posAttr = obj.geometry.getAttribute('position');
+    const colAttr = obj.geometry.getAttribute('color');
     const posArr = posAttr.array;
-    const colArr = colAttr.array;
+    const colArr = colAttr ? colAttr.array : null;
+    const mat = obj.material || {};
+    const strokeOpacity = mat.opacity !== undefined ? mat.opacity : defaultOpacity;
+    const strokeWidth = mat.linewidth !== undefined ? mat.linewidth : defaultWidth;
     for (let i = 0; i < posArr.length; i += 6) {
       if (
         posArr[i] === 0 && posArr[i + 1] === 0 &&
         posArr[i + 3] === 0 && posArr[i + 4] === 0
-      ) {
-        continue;
+      ) continue;
+      const p1 = toScreen(posArr[i], posArr[i + 1]);
+      const p2 = toScreen(posArr[i + 3], posArr[i + 4]);
+      let color = defaultColor;
+      if (colArr) {
+        const r = Math.round(((colArr[i] + colArr[i + 3]) / 2) * 255);
+        const g = Math.round(((colArr[i + 1] + colArr[i + 4]) / 2) * 255);
+        const b = Math.round(((colArr[i + 2] + colArr[i + 5]) / 2) * 255);
+        color = `rgb(${r},${g},${b})`;
+      } else if (mat.color) {
+        color = `#${mat.color.getHexString()}`;
       }
-      const x1 = (posArr[i] - left) * scaleX;
-      const y1 = (top - posArr[i + 1]) * scaleY;
-      const x2 = (posArr[i + 3] - left) * scaleX;
-      const y2 = (top - posArr[i + 4]) * scaleY;
-      const r = Math.round(((colArr[i] + colArr[i + 3]) / 2) * 255);
-      const g = Math.round(((colArr[i + 1] + colArr[i + 4]) / 2) * 255);
-      const b = Math.round(((colArr[i + 2] + colArr[i + 5]) / 2) * 255);
-      parts.push(
-        `<line x1="${x1.toFixed(2)}" y1="${y1.toFixed(2)}" x2="${x2.toFixed(2)}" y2="${y2.toFixed(2)}" ` +
-        `stroke="rgb(${r},${g},${b})" stroke-opacity="0.5" stroke-width="1" />`
-      );
+      parts.push(`<line x1="${p1.x.toFixed(2)}" y1="${p1.y.toFixed(2)}" x2="${p2.x.toFixed(2)}" y2="${p2.y.toFixed(2)}" stroke="${color}" stroke-opacity="${strokeOpacity}" stroke-width="${strokeWidth}" />`);
     }
   }
+
+  function traverse(obj) {
+    if (obj === mollweideMap.starGroup) return; // stars handled separately
+    if (obj.type === 'LineSegments' || obj.type === 'Line') {
+      addLineSegments(obj);
+    } else if (obj.type === 'Group' || obj.type === 'Object3D') {
+      obj.children.forEach(c => traverse(c));
+    }
+  }
+
+  traverse(mollweideMap.scene);
 
   // Stars
   currentMollweideFilteredStars.forEach(star => {
     const pos = star.mollweidePosition;
     if (!pos) return;
-    const x = (pos.x - left) * scaleX;
-    const y = (top - pos.y) * scaleY;
+    const p = toScreen(pos.x, pos.y);
     const size = star.displaySize !== undefined ? star.displaySize : 1;
     const r = size * 0.4 * unitToPx;
     const color = star.displayColor || '#ffffff';
-    parts.push(`<circle cx="${x.toFixed(2)}" cy="${y.toFixed(2)}" r="${r.toFixed(2)}" fill="${color}" />`);
+    parts.push(`<circle cx="${p.x.toFixed(2)}" cy="${p.y.toFixed(2)}" r="${r.toFixed(2)}" fill="${color}" />`);
   });
 
   parts.push('</svg>');


### PR DESCRIPTION
## Summary
- export Mollweide map to SVG instead of PNG/PDF
- limit export resolutions to 2K/4K/8K
- remove unused jsPDF dependency

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68489a9b7a28832aa8d52b572440c648