### PR TITLE
Fix pixelation in high-res Mollweide exports

### DIFF
--- a/script.js
+++ b/script.js
@@ -924,7 +924,7 @@ function exportMollweideMap(format, resolution) {
   const width = resolution;
   const height = Math.floor(resolution / 2);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
-  exportRenderer.setPixelRatio( Math.min(window.devicePixelRatio, 2) );
+  exportRenderer.setPixelRatio( Math.min(window.devicePixelRatio, 10) );
   const finalCanvas = document.createElement('canvas');
   finalCanvas.width = width;
   finalCanvas.height = height;

--- a/script.js
+++ b/script.js
@@ -924,7 +924,7 @@ function exportMollweideMap(format, resolution) {
   const width = resolution;
   const height = Math.floor(resolution / 2);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
-  exportRenderer.setPixelRatio(1);
+  exportRenderer.setPixelRatio( Math.min(window.devicePixelRatio, 2) );
   const finalCanvas = document.createElement('canvas');
   finalCanvas.width = width;
   finalCanvas.height = height;


### PR DESCRIPTION
## Summary
- supersample mollweide export renderer by using device pixel ratio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684952146604832a9c870df104db50cc