### PR TITLE
Adjust Mollweide labels, panning, and constellation opacity

### DIFF
--- a/cameraControls.js
+++ b/cameraControls.js
@@ -311,9 +311,10 @@ export class TwoDControls {
     }
 
     getScale() {
+        const zoom = this.camera.zoom || 1;
         return {
-            x: (this.camera.right - this.camera.left) / this.domElement.clientWidth,
-            y: (this.camera.top - this.camera.bottom) / this.domElement.clientHeight
+            x: (this.camera.right - this.camera.left) / (this.domElement.clientWidth * zoom),
+            y: (this.camera.top - this.camera.bottom) / (this.domElement.clientHeight * zoom)
         };
     }
 

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -101,7 +101,7 @@ export function createConstellationBoundariesForGlobe() {
       gapSize: 1,
       linewidth: 1,
       transparent: true,
-      opacity: 0.4
+      opacity: 0.6
     });
     const line = new THREE.Line(geometry, material);
     line.computeLineDistances();
@@ -118,7 +118,7 @@ export function createConstellationBoundariesForMollweide() {
     gapSize: 1,
     linewidth: 1,
     transparent: true,
-    opacity: 0.4
+    opacity: 0.6
   });
   const maxSegments = boundaryData.length * 32; // 16 segments per boundary, each may wrap
   const positions = new Float32Array(maxSegments * 2 * 3); // 2 vertices per segment
@@ -190,7 +190,7 @@ export function createConstellationLabelsForGlobe() {
     const material = new THREE.ShaderMaterial({
       uniforms: {
         map: { value: texture },
-        opacity: { value: 0.5 }
+        opacity: { value: 0.7 }
       },
       vertexShader: `
         varying vec2 vUv;
@@ -248,7 +248,7 @@ export function createConstellationLabelsForMollweide() {
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);
-    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.5 });
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.7 });
     const sprite = new THREE.Sprite(material);
     sprite.scale.set(canvas.width / 100, canvas.height / 100, 1);
     sprite.position.copy(p);

--- a/labelManager.js
+++ b/labelManager.js
@@ -76,11 +76,12 @@ export class LabelManager {
       const baseFontSize = (this.mapType === 'Globe'
         ? 64
         : (this.mapType === 'Mollweide' ? 72 : 24));
-      let scaleFactor = star.displaySize / 2;
+      const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 4, 7.5);
-      } else {
-        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 1, 5);
+        const newMin = 4;
+        const newMax = 7.5;
+        scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const fontSize = baseFontSize * scaleFactor;
 
@@ -203,11 +204,12 @@ export class LabelManager {
       // larger stars get more separation from their text. Use a slightly
       // larger base distance for the Mollweide map since stars are scaled up
       // there.
-      let scaleFactor = star.displaySize / 2;
+      const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 2, 8);
-      } else {
-        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 1, 5);
+        const newMin = 4;
+        const newMax = 7.5;
+        scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;
       const dist = baseDist * scaleFactor;

--- a/labelManager.js
+++ b/labelManager.js
@@ -208,6 +208,16 @@ export class LabelManager {
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
         const newMin = 4;
+
+      if (this.mapType === 'Mollweide') {
+        const angle = Math.random() * Math.PI * 2;
+        return new THREE.Vector3(
+          Math.cos(angle) * dist,
+          Math.sin(angle) * dist,
+          0
+        );
+      }
+
         const newMax = 8;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }

--- a/labelManager.js
+++ b/labelManager.js
@@ -79,8 +79,8 @@ export class LabelManager {
       const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        const newMin = 4;
-        const newMax = 8;
+        const newMin = 2;
+        const newMax = 5;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const fontSize = baseFontSize * scaleFactor;

--- a/labelManager.js
+++ b/labelManager.js
@@ -79,8 +79,8 @@ export class LabelManager {
       const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        const newMin = 4;
-        const newMax = 7.5;
+        const newMin = 1;
+        const newMax = 4;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const fontSize = baseFontSize * scaleFactor;

--- a/labelManager.js
+++ b/labelManager.js
@@ -79,8 +79,8 @@ export class LabelManager {
       const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        const newMin = 1;
-        const newMax = 4;
+        const newMin = 4;
+        const newMax = 8;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const fontSize = baseFontSize * scaleFactor;
@@ -207,8 +207,8 @@ export class LabelManager {
       const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        const newMin = 1;
-        const newMax = 4;
+        const newMin = 4;
+        const newMax = 8;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;

--- a/labelManager.js
+++ b/labelManager.js
@@ -207,8 +207,8 @@ export class LabelManager {
       const baseFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       let scaleFactor = baseFactor;
       if (this.mapType === 'Mollweide') {
-        const newMin = 4;
-        const newMax = 7.5;
+        const newMin = 1;
+        const newMax = 4;
         scaleFactor = newMin + ((baseFactor - 1) * (newMax - newMin)) / 4;
       }
       const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;

--- a/labelManager.js
+++ b/labelManager.js
@@ -205,7 +205,7 @@ export class LabelManager {
       // there.
       let scaleFactor = star.displaySize / 2;
       if (this.mapType === 'Mollweide') {
-        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 4, 7.5);
+        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 2, 8);
       } else {
         scaleFactor = THREE.MathUtils.clamp(scaleFactor, 1, 5);
       }

--- a/labelManager.js
+++ b/labelManager.js
@@ -76,7 +76,12 @@ export class LabelManager {
       const baseFontSize = (this.mapType === 'Globe'
         ? 64
         : (this.mapType === 'Mollweide' ? 72 : 24));
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = star.displaySize / 2;
+      if (this.mapType === 'Mollweide') {
+        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 4, 7.5);
+      } else {
+        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 1, 5);
+      }
       const fontSize = baseFontSize * scaleFactor;
 
       const canvas = document.createElement('canvas');
@@ -198,7 +203,12 @@ export class LabelManager {
       // larger stars get more separation from their text. Use a slightly
       // larger base distance for the Mollweide map since stars are scaled up
       // there.
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = star.displaySize / 2;
+      if (this.mapType === 'Mollweide') {
+        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 4, 7.5);
+      } else {
+        scaleFactor = THREE.MathUtils.clamp(scaleFactor, 1, 5);
+      }
       const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;
       const dist = baseDist * scaleFactor;
       return new THREE.Vector3(1, 1, 0).multiplyScalar(dist);

--- a/script.js
+++ b/script.js
@@ -561,7 +561,8 @@ class MapManager {
     if (mapType === 'Mollweide') {
       this.controls = new TwoDControls(this.camera, this.renderer.domElement, {
         rightCallback: (dx) => {
-          let lambda0 = getMollweideLambda0() - dx * 0.002;
+          const zoomScale = this.camera.zoom || 1;
+          let lambda0 = getMollweideLambda0() - dx * (0.002 / zoomScale);
           const twoPi = Math.PI * 2;
           lambda0 = ((lambda0 % twoPi) + twoPi) % twoPi;
           setMollweideLambda0(lambda0);


### PR DESCRIPTION
## Summary
- enlarge Mollweide star labels and update their offset logic
- slow Mollweide panning proportionally with zoom
- raise opacity for constellation lines and labels on all maps

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684956166da8832abe86076934dfd2c4