### PR TITLE
Improve mollweide labeling and controls

### DIFF
--- a/cameraControls.js
+++ b/cameraControls.js
@@ -311,9 +311,11 @@ export class TwoDControls {
     }
 
     getScale() {
+        // Adjust panning speed based on current zoom level
+        const zoom = this.camera.zoom || 1;
         return {
-            x: (this.camera.right - this.camera.left) / this.domElement.clientWidth,
-            y: (this.camera.top - this.camera.bottom) / this.domElement.clientHeight
+            x: (this.camera.right - this.camera.left) / (this.domElement.clientWidth * zoom),
+            y: (this.camera.top - this.camera.bottom) / (this.domElement.clientHeight * zoom)
         };
     }
 

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -190,7 +190,7 @@ export function createConstellationLabelsForGlobe() {
     const material = new THREE.ShaderMaterial({
       uniforms: {
         map: { value: texture },
-        opacity: { value: 0.5 }
+        opacity: { value: 0.7 }
       },
       vertexShader: `
         varying vec2 vUv;
@@ -248,7 +248,7 @@ export function createConstellationLabelsForMollweide() {
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);
-    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.5 });
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.7 });
     const sprite = new THREE.Sprite(material);
     sprite.scale.set(canvas.width / 100, canvas.height / 100, 1);
     sprite.position.copy(p);

--- a/labelManager.js
+++ b/labelManager.js
@@ -76,7 +76,11 @@ export class LabelManager {
       const baseFontSize = (this.mapType === 'Globe'
         ? 64
         : (this.mapType === 'Mollweide' ? 72 : 24));
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      if (this.mapType === 'Mollweide') {
+        // Ensure a larger minimum label size for the Mollweide map
+        scaleFactor = Math.max(scaleFactor, 2);
+      }
       const fontSize = baseFontSize * scaleFactor;
 
       const canvas = document.createElement('canvas');
@@ -201,6 +205,11 @@ export class LabelManager {
       const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
       const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;
       const dist = baseDist * scaleFactor;
+      if (this.mapType === 'Mollweide') {
+        // Randomize the direction to reduce label overlap
+        const angle = Math.random() * Math.PI * 2;
+        return new THREE.Vector3(Math.cos(angle), Math.sin(angle), 0).multiplyScalar(dist);
+      }
       return new THREE.Vector3(1, 1, 0).multiplyScalar(dist);
     } else {
       // For the Globe, offset tangentially around the star on the sphere

--- a/labelManager.js
+++ b/labelManager.js
@@ -76,7 +76,7 @@ export class LabelManager {
       const baseFontSize = (this.mapType === 'Globe'
         ? 64
         : (this.mapType === 'Mollweide' ? 72 : 24));
-      let scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      let scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
       if (this.mapType === 'Mollweide') {
         // Ensure a larger minimum label size for the Mollweide map
         scaleFactor = Math.max(scaleFactor, 2);
@@ -202,8 +202,8 @@ export class LabelManager {
       // larger stars get more separation from their text. Use a slightly
       // larger base distance for the Mollweide map since stars are scaled up
       // there.
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
-      const baseDist = this.mapType === 'Mollweide' ? 1 : 0.5;
+      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
+      const baseDist = this.mapType === 'Mollweide' ? 3 : 0.5;
       const dist = baseDist * scaleFactor;
       if (this.mapType === 'Mollweide') {
         // Randomize the direction to reduce label overlap
@@ -223,7 +223,7 @@ export class LabelManager {
       // Random angle around the star
       const angle = Math.random() * Math.PI * 2;
       const baseDistance = 2;
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 5);
+      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
       return tangent.clone().multiplyScalar(Math.cos(angle))
         .add(bitangent.clone().multiplyScalar(Math.sin(angle)))
         .multiplyScalar(baseDistance * scaleFactor);

--- a/labelManager.js
+++ b/labelManager.js
@@ -76,9 +76,10 @@ export class LabelManager {
       const baseFontSize = (this.mapType === 'Globe'
         ? 64
         : (this.mapType === 'Mollweide' ? 72 : 24));
-      let scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
+      let scaleFactor = THREE.MathUtils.clamp(star.displaySize, 1, 7.5);
       if (this.mapType === 'Mollweide') {
-        // Ensure a larger minimum label size for the Mollweide map
+        // Ensure a larger minimum label size for the Mollweide map while
+        // keeping the label size proportional to the star
         scaleFactor = Math.max(scaleFactor, 2);
       }
       const fontSize = baseFontSize * scaleFactor;
@@ -202,7 +203,7 @@ export class LabelManager {
       // larger stars get more separation from their text. Use a slightly
       // larger base distance for the Mollweide map since stars are scaled up
       // there.
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
+      const scaleFactor = THREE.MathUtils.clamp(star.displaySize, 1, 7.5);
       const baseDist = this.mapType === 'Mollweide' ? 3 : 0.5;
       const dist = baseDist * scaleFactor;
       if (this.mapType === 'Mollweide') {
@@ -223,7 +224,7 @@ export class LabelManager {
       // Random angle around the star
       const angle = Math.random() * Math.PI * 2;
       const baseDistance = 2;
-      const scaleFactor = THREE.MathUtils.clamp(star.displaySize / 2, 1, 7.5);
+      const scaleFactor = THREE.MathUtils.clamp(star.displaySize, 1, 7.5);
       return tangent.clone().multiplyScalar(Math.cos(angle))
         .add(bitangent.clone().multiplyScalar(Math.sin(angle)))
         .multiplyScalar(baseDistance * scaleFactor);


### PR DESCRIPTION
## Summary
- enlarge minimum star label size on the Mollweide map
- randomize Mollweide label offset directions
- adapt 2D panning speed to zoom level
- increase constellation label opacity

## Testing
- `node --check labelManager.js`
- `node --check cameraControls.js`
- `node --check filters/constellationFilter.js`


------
https://chatgpt.com/codex/tasks/task_e_684961cc9998832a9db49f9a35afcd26