### PR TITLE
Add movable labels in Mollweide map

### DIFF
--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -252,6 +252,7 @@ export function createConstellationLabelsForMollweide() {
     const sprite = new THREE.Sprite(material);
     sprite.scale.set(canvas.width / 100, canvas.height / 100, 1);
     sprite.position.copy(p);
+    sprite.userData = { name: c.name, ra: c.ra, dec: c.dec };
     labels.push(sprite);
   });
   return labels;

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -349,6 +349,7 @@ export function createGalacticDirectionLabelsMollweide(R = 100) {
     const p = radToMollweide(eq.ra, eq.dec, R, lambda0);
     const sprite = createTextSprite(d.label, '#ffffff', 0.8, 450);
     sprite.position.set(p.x, p.y, 0);
+    sprite.userData = { name: d.label, ra: eq.ra, dec: eq.dec };
     labels.push(sprite);
   });
   return labels;
@@ -356,10 +357,9 @@ export function createGalacticDirectionLabelsMollweide(R = 100) {
 
 export function updateGalacticDirectionLabelsMollweide(labels, R = 100) {
   const lambda0 = getMollweideLambda0();
-  const data = galacticDirectionData();
-  labels.forEach((sprite, i) => {
-    const eq = galacticToEquatorial(data[i].l, 0);
-    const p = radToMollweide(eq.ra, eq.dec, R, lambda0);
+  labels.forEach(sprite => {
+    if (!sprite.userData) return;
+    const p = radToMollweide(sprite.userData.ra, sprite.userData.dec, R, lambda0);
     sprite.position.set(p.x, p.y, 0);
   });
 }

--- a/index.html
+++ b/index.html
@@ -246,6 +246,7 @@
             <option value="30720">32K</option>
           </select>
           <button id="export-mollweide" class="export-btn">Export</button>
+          <button id="toggle-label-editor" class="export-btn">Edit Labels</button>
         </div>
       </div>
     </section>

--- a/labelManager.js
+++ b/labelManager.js
@@ -170,7 +170,12 @@ export class LabelManager {
           ? new THREE.Vector3(star.spherePosition.x, star.spherePosition.y, star.spherePosition.z)
           : new THREE.Vector3(star.mollweidePosition.x, star.mollweidePosition.y, star.mollweidePosition.z));
 
-    const offset = this.computeLabelOffset(star, starPos);
+    let offset;
+    if (this.mapType === 'Mollweide' && star.mollLabelOffset) {
+      offset = star.mollLabelOffset.clone();
+    } else {
+      offset = this.computeLabelOffset(star, starPos);
+    }
     const labelPos = starPos.clone().add(offset);
     labelObj.position.copy(labelPos);
 

--- a/script.js
+++ b/script.js
@@ -1104,6 +1104,9 @@ function setupLabelEditor() {
   btn.addEventListener('click', () => {
     labelEditMode = !labelEditMode;
     btn.classList.toggle('active', labelEditMode);
+    if (labelEditMode) {
+      registerMollweideEditableLabels();
+    }
   });
   mollweideMap.canvas.addEventListener('pointerdown', onEditPointerDown);
   mollweideMap.canvas.addEventListener('pointermove', onEditPointerMove);

--- a/script.js
+++ b/script.js
@@ -1019,6 +1019,7 @@ function registerMollweideEditableLabels() {
     sprite.userData = sprite.userData || {};
     sprite.userData.editType = 'star';
     sprite.userData.editId = id;
+    sprite.userData.lineObj = mollweideMap.labelManager.lines.get(star);
     sprite.userData.starRef = star;
     sprite.userData.anchorFunc = () => star.mollweidePosition.clone();
     editableLabels.push(sprite);
@@ -1070,8 +1071,14 @@ function onEditPointerDown(e) {
     dragOffset.copy(pos).sub(selectedLabel.position);
     selectedLabel.userData._origScale = selectedLabel.scale.clone();
     selectedLabel.userData._origColor = selectedLabel.material.color.clone();
+    if (selectedLabel.userData.lineObj) {
+      selectedLabel.userData._origLineColor = selectedLabel.userData.lineObj.material.color.clone();
+    }
     selectedLabel.scale.multiplyScalar(1.2);
     selectedLabel.material.color.set('#ff6f61');
+    if (selectedLabel.userData.lineObj) {
+      selectedLabel.userData.lineObj.material.color.set('#ff6f61');
+    }
     mollweideMap.canvas.classList.add('dragging');
     requestRender();
     e.preventDefault();
@@ -1082,6 +1089,10 @@ function onEditPointerMove(e) {
   if (!labelEditMode || !selectedLabel) return;
   const pos = getPointerPos(e);
   selectedLabel.position.copy(pos.clone().sub(dragOffset));
+  if (selectedLabel.userData.editType === 'star' && selectedLabel.userData.lineObj) {
+    const anchor = selectedLabel.userData.anchorFunc();
+    selectedLabel.userData.lineObj.geometry.setFromPoints([anchor, selectedLabel.position]);
+  }
   requestRender();
   e.preventDefault();
 }
@@ -1095,6 +1106,9 @@ function onEditPointerUp() {
     if (selectedLabel.userData.starRef) {
       selectedLabel.userData.starRef.mollLabelOffset = offsetVec.clone();
     }
+    if (selectedLabel.userData.lineObj) {
+      selectedLabel.userData.lineObj.geometry.setFromPoints([anchor, selectedLabel.position]);
+    }
   } else if (selectedLabel.userData.editType === 'constellation') {
     constellationLabelOffsets.set(selectedLabel.userData.editId, { x: offsetVec.x, y: offsetVec.y });
     selectedLabel.userData.offset = offsetVec.clone();
@@ -1107,6 +1121,9 @@ function onEditPointerUp() {
   }
   if (selectedLabel.userData._origColor) {
     selectedLabel.material.color.copy(selectedLabel.userData._origColor);
+  }
+  if (selectedLabel.userData.lineObj && selectedLabel.userData._origLineColor) {
+    selectedLabel.userData.lineObj.material.color.copy(selectedLabel.userData._origLineColor);
   }
   mollweideMap.canvas.classList.remove('dragging');
   requestRender();

--- a/script.js
+++ b/script.js
@@ -80,6 +80,27 @@ let showGalacticPlaneFlag = false;
 let showEclipticPlaneFlag = false;
 let showCelestialEquatorFlag = false;
 
+// --- Label Editing ---
+let labelEditMode = false;
+const starLabelOffsets = new Map();
+const constellationLabelOffsets = new Map();
+const galacticLabelOffsets = new Map();
+let editableLabels = [];
+let selectedLabel = null;
+const dragOffset = new THREE.Vector3();
+const editPointer = new THREE.Vector2();
+const editRaycaster = new THREE.Raycaster();
+const editPlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+
+function getStarId(star) {
+  return (
+    star.Common_name_of_the_star ||
+    star.Common_name_of_the_star_system ||
+    star.HD ||
+    `${star.RA_in_degrees}_${star.DEC_in_degrees}`
+  );
+}
+
 function getStarTruePosition(star) {
   const R = star.distance !== undefined ? star.distance : star.Distance_from_the_Sun;
   let ra, dec;
@@ -333,6 +354,7 @@ async function buildAndApplyFilters() {
   mollweideMap.updateStarPositions(currentMollweideFilteredStars);
   mollweideMap.updateConnections(currentMollweideFilteredStars, currentMollweideConnections);
   mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
+  registerMollweideEditableLabels();
 
   removeConstellationObjectsFromGlobe();
   removeConstellationOverlayObjectsFromGlobe();
@@ -348,6 +370,7 @@ async function buildAndApplyFilters() {
     constellationLabelsGlobe.forEach(lbl => globeMap.scene.add(lbl));
     constellationLabelsMoll = createConstellationLabelsForMollweide();
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
+    registerMollweideEditableLabels();
   }
   if (showConstellationOverlay) {
     const constellationOverlay = createConstellationOverlayForGlobe();
@@ -868,6 +891,7 @@ async function updateMollweideView() {
   mollweideMap.updateStarPositions(currentMollweideFilteredStars);
   mollweideMap.updateConnectionPositions(currentMollweideFilteredStars, currentMollweideConnections);
   mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
+  registerMollweideEditableLabels();
 
   if (showConstellationBoundariesFlag) {
     if (constellationLinesMoll.length === 0) {
@@ -881,6 +905,7 @@ async function updateMollweideView() {
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.remove(lbl));
     constellationLabelsMoll = createConstellationLabelsForMollweide();
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
+    registerMollweideEditableLabels();
   }
   if (showConstellationOverlayFlag) {
     constellationOverlayMoll.forEach(mesh => mollweideMap.scene.remove(mesh));
@@ -977,6 +1002,114 @@ function setupExportControls() {
   });
 }
 
+function getPointerPos(event) {
+  const rect = mollweideMap.canvas.getBoundingClientRect();
+  editPointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  editPointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
+  const point = new THREE.Vector3();
+  editRaycaster.ray.intersectPlane(editPlane, point);
+  return point;
+}
+
+function registerMollweideEditableLabels() {
+  editableLabels = [];
+  mollweideMap.labelManager.sprites.forEach((sprite, star) => {
+    const id = getStarId(star);
+    sprite.userData = sprite.userData || {};
+    sprite.userData.editType = 'star';
+    sprite.userData.editId = id;
+    sprite.userData.starRef = star;
+    sprite.userData.anchorFunc = () => star.mollweidePosition.clone();
+    editableLabels.push(sprite);
+    if (starLabelOffsets.has(id)) {
+      const off = starLabelOffsets.get(id);
+      star.mollLabelOffset = new THREE.Vector3(off.x, off.y, 0);
+      sprite.position.copy(star.mollweidePosition.clone().add(star.mollLabelOffset));
+    }
+  });
+  constellationLabelsMoll.forEach(sprite => {
+    if (!sprite.userData) return;
+    sprite.userData.editType = 'constellation';
+    sprite.userData.editId = sprite.userData.name;
+    sprite.userData.anchorFunc = () => {
+      const p = cachedRadToMollweide(sprite.userData.ra, sprite.userData.dec, 100, getMollweideLambda0());
+      return new THREE.Vector3(p.x, p.y, 0);
+    };
+    editableLabels.push(sprite);
+    if (constellationLabelOffsets.has(sprite.userData.name)) {
+      const off = constellationLabelOffsets.get(sprite.userData.name);
+      sprite.position.add(new THREE.Vector3(off.x, off.y, 0));
+      sprite.userData.offset = new THREE.Vector3(off.x, off.y, 0);
+    }
+  });
+  galacticDirectionLabelsMoll.forEach(sprite => {
+    if (!sprite.userData) return;
+    sprite.userData.editType = 'galactic';
+    sprite.userData.editId = sprite.userData.name;
+    sprite.userData.anchorFunc = () => {
+      const p = cachedRadToMollweide(sprite.userData.ra, sprite.userData.dec, 100, getMollweideLambda0());
+      return new THREE.Vector3(p.x, p.y, 0);
+    };
+    editableLabels.push(sprite);
+    if (galacticLabelOffsets.has(sprite.userData.name)) {
+      const off = galacticLabelOffsets.get(sprite.userData.name);
+      sprite.position.add(new THREE.Vector3(off.x, off.y, 0));
+      sprite.userData.offset = new THREE.Vector3(off.x, off.y, 0);
+    }
+  });
+}
+
+function onEditPointerDown(e) {
+  if (!labelEditMode) return;
+  const pos = getPointerPos(e);
+  editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
+  const intersects = editRaycaster.intersectObjects(editableLabels, false);
+  if (intersects.length > 0) {
+    selectedLabel = intersects[0].object;
+    dragOffset.copy(pos).sub(selectedLabel.position);
+    e.preventDefault();
+  }
+}
+
+function onEditPointerMove(e) {
+  if (!labelEditMode || !selectedLabel) return;
+  const pos = getPointerPos(e);
+  selectedLabel.position.copy(pos.clone().sub(dragOffset));
+  e.preventDefault();
+}
+
+function onEditPointerUp() {
+  if (!labelEditMode || !selectedLabel) return;
+  const anchor = selectedLabel.userData.anchorFunc();
+  const offsetVec = selectedLabel.position.clone().sub(anchor);
+  if (selectedLabel.userData.editType === 'star') {
+    starLabelOffsets.set(selectedLabel.userData.editId, { x: offsetVec.x, y: offsetVec.y });
+    if (selectedLabel.userData.starRef) {
+      selectedLabel.userData.starRef.mollLabelOffset = offsetVec.clone();
+    }
+  } else if (selectedLabel.userData.editType === 'constellation') {
+    constellationLabelOffsets.set(selectedLabel.userData.editId, { x: offsetVec.x, y: offsetVec.y });
+    selectedLabel.userData.offset = offsetVec.clone();
+  } else if (selectedLabel.userData.editType === 'galactic') {
+    galacticLabelOffsets.set(selectedLabel.userData.editId, { x: offsetVec.x, y: offsetVec.y });
+    selectedLabel.userData.offset = offsetVec.clone();
+  }
+  selectedLabel = null;
+}
+
+function setupLabelEditor() {
+  const btn = document.getElementById('toggle-label-editor');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    labelEditMode = !labelEditMode;
+    btn.classList.toggle('active', labelEditMode);
+  });
+  mollweideMap.canvas.addEventListener('pointerdown', onEditPointerDown);
+  mollweideMap.canvas.addEventListener('pointermove', onEditPointerMove);
+  window.addEventListener('pointerup', onEditPointerUp);
+}
+
 async function main() {
   const loader = document.getElementById('loader');
   loader.classList.remove('hidden');
@@ -1010,6 +1143,7 @@ async function main() {
     initStarInteractions(mollweideMap);
     setupMapProjectionToggles();
     setupExportControls();
+    setupLabelEditor();
     requestRender();
     loader.classList.add('hidden');
   } catch (err) {

--- a/script.js
+++ b/script.js
@@ -1068,6 +1068,12 @@ function onEditPointerDown(e) {
   if (intersects.length > 0) {
     selectedLabel = intersects[0].object;
     dragOffset.copy(pos).sub(selectedLabel.position);
+    selectedLabel.userData._origScale = selectedLabel.scale.clone();
+    selectedLabel.userData._origColor = selectedLabel.material.color.clone();
+    selectedLabel.scale.multiplyScalar(1.2);
+    selectedLabel.material.color.set('#ff6f61');
+    mollweideMap.canvas.classList.add('dragging');
+    requestRender();
     e.preventDefault();
   }
 }
@@ -1076,6 +1082,7 @@ function onEditPointerMove(e) {
   if (!labelEditMode || !selectedLabel) return;
   const pos = getPointerPos(e);
   selectedLabel.position.copy(pos.clone().sub(dragOffset));
+  requestRender();
   e.preventDefault();
 }
 
@@ -1095,6 +1102,14 @@ function onEditPointerUp() {
     galacticLabelOffsets.set(selectedLabel.userData.editId, { x: offsetVec.x, y: offsetVec.y });
     selectedLabel.userData.offset = offsetVec.clone();
   }
+  if (selectedLabel.userData._origScale) {
+    selectedLabel.scale.copy(selectedLabel.userData._origScale);
+  }
+  if (selectedLabel.userData._origColor) {
+    selectedLabel.material.color.copy(selectedLabel.userData._origColor);
+  }
+  mollweideMap.canvas.classList.remove('dragging');
+  requestRender();
   selectedLabel = null;
 }
 
@@ -1104,9 +1119,11 @@ function setupLabelEditor() {
   btn.addEventListener('click', () => {
     labelEditMode = !labelEditMode;
     btn.classList.toggle('active', labelEditMode);
+    mollweideMap.canvas.classList.toggle('edit-mode', labelEditMode);
     if (labelEditMode) {
       registerMollweideEditableLabels();
     }
+    requestRender();
   });
   mollweideMap.canvas.addEventListener('pointerdown', onEditPointerDown);
   mollweideMap.canvas.addEventListener('pointermove', onEditPointerMove);

--- a/styles.css
+++ b/styles.css
@@ -290,6 +290,12 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   border-radius: 4px;
   touch-action: none;
 }
+.map-container canvas.edit-mode {
+  cursor: move;
+}
+.map-container canvas.edit-mode.dragging {
+  cursor: grabbing;
+}
 
 /* Fullscreen Button for Maps */
 .fullscreen-btn {

--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,10 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 .export-btn {
   cursor: pointer;
 }
+.export-btn.active {
+  background: #ff6f61;
+  color: #000;
+}
 
 /* Tooltip */
 #tooltip {


### PR DESCRIPTION
## Summary
- add label editor toggle button
- allow user-defined label offsets stored per-object
- update constellation and galactic label creation to keep metadata
- register and drag labels when editor mode is enabled
- preserve custom offsets across map updates

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684975baa284832aad4020997ba0b32b