### PR TITLE
Update export and editing controls

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -142,6 +142,7 @@ export function createMollweideConnectionSegments(pairs) {
     segments: GC_SEGMENTS,
     editableLine: true,
     wrap: true,
+    noWrapSet: new Set(),
     type: 'connection'
   };
   updateMollweideConnectionSegments(lineSegs);
@@ -153,16 +154,18 @@ export function updateMollweideConnectionSegments(lineSegs) {
   const segsCount = lineSegs.userData.segments || GC_SEGMENTS;
   const posAttr = lineSegs.geometry.getAttribute('position');
   const colorAttr = lineSegs.geometry.getAttribute('color');
+  const noWrapSet = lineSegs.userData.noWrapSet || new Set();
   let idx = 0;
-  pairs.forEach(pair => {
+  pairs.forEach((pair, pairIdx) => {
     const p1 = pair.starA.spherePosition;
     const p2 = pair.starB.spherePosition;
     if (!p1 || !p2) return;
     const pts = greatCircleToMollweide(p1, p2, 100, segsCount, getMollweideLambda0());
     const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
     const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
+    const wrap = lineSegs.userData.wrap !== false && !noWrapSet.has(pairIdx);
     for (let j = 0; j < pts.length - 1; j++) {
-      const segs = lineSegs.userData.wrap === false ? [[pts[j], pts[j + 1]]] : splitMollweideWrap(pts[j], pts[j + 1]);
+      const segs = wrap ? splitMollweideWrap(pts[j], pts[j + 1]) : [[pts[j], pts[j + 1]]];
       segs.forEach(([s, e]) => {
         if (idx + 6 > posAttr.array.length) return;
         posAttr.array[idx] = s.x; posAttr.array[idx+1] = s.y; posAttr.array[idx+2] = s.z;

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -137,7 +137,13 @@ export function createMollweideConnectionSegments(pairs) {
     linewidth: 1
   });
   const lineSegs = new THREE.LineSegments(geometry, material);
-  lineSegs.userData = { pairs, segments: GC_SEGMENTS };
+  lineSegs.userData = {
+    pairs,
+    segments: GC_SEGMENTS,
+    editableLine: true,
+    wrap: true,
+    type: 'connection'
+  };
   updateMollweideConnectionSegments(lineSegs);
   return lineSegs;
 }
@@ -156,7 +162,7 @@ export function updateMollweideConnectionSegments(lineSegs) {
     const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
     const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
     for (let j = 0; j < pts.length - 1; j++) {
-      const segs = splitMollweideWrap(pts[j], pts[j + 1]);
+      const segs = lineSegs.userData.wrap === false ? [[pts[j], pts[j + 1]]] : splitMollweideWrap(pts[j], pts[j + 1]);
       segs.forEach(([s, e]) => {
         if (idx + 6 > posAttr.array.length) return;
         posAttr.array[idx] = s.x; posAttr.array[idx+1] = s.y; posAttr.array[idx+2] = s.z;

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -130,6 +130,7 @@ export function createConstellationBoundariesForMollweide() {
   lineSegs.userData.R = R;
   lineSegs.userData.editableLine = true;
   lineSegs.userData.wrap = true;
+  lineSegs.userData.noWrapSet = new Set();
   lineSegs.userData.type = 'constellation';
   updateConstellationBoundariesForMollweide(lineSegs);
   return [lineSegs];
@@ -141,13 +142,15 @@ export function updateConstellationBoundariesForMollweide(lineSegs) {
   const data = lineSegs.userData.boundaryData || [];
   const posAttr = lineSegs.geometry.getAttribute('position');
   const array = posAttr.array;
+  const noWrapSet = lineSegs.userData.noWrapSet || new Set();
   let idx = 0;
-  data.forEach(seg => {
+  data.forEach((seg, segIdx) => {
     const pStart = radToSphere(seg.ra1, seg.dec1, R);
     const pEnd   = radToSphere(seg.ra2, seg.dec2, R);
     const arcPts  = greatCircleToMollweide(pStart, pEnd, R, 16, lambda0);
+    const wrap = lineSegs.userData.wrap !== false && !noWrapSet.has(segIdx);
     for (let j = 0; j < arcPts.length - 1; j++) {
-      const segs = lineSegs.userData.wrap === false ? [[arcPts[j], arcPts[j + 1]]] : splitMollweideWrap(arcPts[j], arcPts[j + 1]);
+      const segs = wrap ? splitMollweideWrap(arcPts[j], arcPts[j + 1]) : [[arcPts[j], arcPts[j + 1]]];
       for (let s = 0; s < 2; s++) {
         if (s < segs.length) {
           const a = segs[s][0];

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -128,6 +128,9 @@ export function createConstellationBoundariesForMollweide() {
   lineSegs.computeLineDistances();
   lineSegs.userData.boundaryData = boundaryData;
   lineSegs.userData.R = R;
+  lineSegs.userData.editableLine = true;
+  lineSegs.userData.wrap = true;
+  lineSegs.userData.type = 'constellation';
   updateConstellationBoundariesForMollweide(lineSegs);
   return [lineSegs];
 }
@@ -144,11 +147,11 @@ export function updateConstellationBoundariesForMollweide(lineSegs) {
     const pEnd   = radToSphere(seg.ra2, seg.dec2, R);
     const arcPts  = greatCircleToMollweide(pStart, pEnd, R, 16, lambda0);
     for (let j = 0; j < arcPts.length - 1; j++) {
-      const splits = splitMollweideWrap(arcPts[j], arcPts[j + 1]);
+      const segs = lineSegs.userData.wrap === false ? [[arcPts[j], arcPts[j + 1]]] : splitMollweideWrap(arcPts[j], arcPts[j + 1]);
       for (let s = 0; s < 2; s++) {
-        if (s < splits.length) {
-          const a = splits[s][0];
-          const b = splits[s][1];
+        if (s < segs.length) {
+          const a = segs[s][0];
+          const b = segs[s][1];
           array[idx++] = a.x; array[idx++] = a.y; array[idx++] = 0;
           array[idx++] = b.x; array[idx++] = b.y; array[idx++] = 0;
         } else {

--- a/index.html
+++ b/index.html
@@ -235,18 +235,8 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
-          <select id="export-format">
-            <option value="png">PNG</option>
-            <option value="pdf">PDF</option>
-          </select>
-          <select id="export-resolution">
-            <option value="3840">4K</option>
-            <option value="7680">8K</option>
-            <option value="15360">16K</option>
-            <option value="30720">32K</option>
-          </select>
           <button id="export-mollweide" class="export-btn">Export</button>
-          <button id="toggle-label-editor" class="export-btn">Edit Labels</button>
+          <button id="toggle-label-editor" class="export-btn">Edit</button>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -704,6 +704,7 @@ class MapManager {
       const segs = this.connectionGroup.children[0];
       if (segs) {
         segs.userData.wrap = true;
+        segs.userData.noWrapSet = new Set();
         updateMollweideConnectionSegments(segs);
       }
     } else {
@@ -903,11 +904,13 @@ async function updateMollweideView() {
       constellationLinesMoll = createConstellationBoundariesForMollweide();
       constellationLinesMoll.forEach(l => {
         l.userData.wrap = true;
+        l.userData.noWrapSet = new Set();
         mollweideMap.scene.add(l);
       });
     } else {
       constellationLinesMoll.forEach(l => {
         l.userData.wrap = true;
+        l.userData.noWrapSet = new Set();
         updateConstellationBoundariesForMollweide(l);
       });
     }
@@ -1073,9 +1076,17 @@ function registerEditableLines() {
   });
 }
 
-function toggleLineWrap(line) {
+function toggleLineWrap(line, segIdx = 0) {
   if (!line.userData) return;
-  line.userData.wrap = !line.userData.wrap;
+  const segsPerLine = (line.userData.segments || GC_SEGMENTS) * 2;
+  const noWrap = line.userData.noWrapSet || new Set();
+  const lineIndex = Math.floor(segIdx / segsPerLine);
+  if (noWrap.has(lineIndex)) {
+    noWrap.delete(lineIndex);
+  } else {
+    noWrap.add(lineIndex);
+  }
+  line.userData.noWrapSet = noWrap;
   if (line.userData._origColor === undefined) {
     line.userData._origColor = line.material.color.clone();
   }
@@ -1120,7 +1131,8 @@ function onEditPointerDown(e) {
   } else {
     intersects = editRaycaster.intersectObjects(editableLines, false);
     if (intersects.length > 0) {
-      toggleLineWrap(intersects[0].object);
+      const hit = intersects[0];
+      toggleLineWrap(hit.object, hit.index || 0);
       e.preventDefault();
     }
   }

--- a/script.js
+++ b/script.js
@@ -86,6 +86,7 @@ const starLabelOffsets = new Map();
 const constellationLabelOffsets = new Map();
 const galacticLabelOffsets = new Map();
 let editableLabels = [];
+let editableLines = [];
 let selectedLabel = null;
 const dragOffset = new THREE.Vector3();
 const editPointer = new THREE.Vector2();
@@ -355,6 +356,7 @@ async function buildAndApplyFilters() {
   mollweideMap.updateConnections(currentMollweideFilteredStars, currentMollweideConnections);
   mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
   registerMollweideEditableLabels();
+  registerEditableLines();
 
   removeConstellationObjectsFromGlobe();
   removeConstellationOverlayObjectsFromGlobe();
@@ -700,7 +702,10 @@ class MapManager {
     if (!this.connectionGroup) return;
     if (this.mapType === 'Mollweide') {
       const segs = this.connectionGroup.children[0];
-      if (segs) updateMollweideConnectionSegments(segs);
+      if (segs) {
+        segs.userData.wrap = true;
+        updateMollweideConnectionSegments(segs);
+      }
     } else {
       this.updateConnections(stars, connectionObjs);
     }
@@ -896,9 +901,15 @@ async function updateMollweideView() {
   if (showConstellationBoundariesFlag) {
     if (constellationLinesMoll.length === 0) {
       constellationLinesMoll = createConstellationBoundariesForMollweide();
-      constellationLinesMoll.forEach(l => mollweideMap.scene.add(l));
+      constellationLinesMoll.forEach(l => {
+        l.userData.wrap = true;
+        mollweideMap.scene.add(l);
+      });
     } else {
-      constellationLinesMoll.forEach(l => updateConstellationBoundariesForMollweide(l));
+      constellationLinesMoll.forEach(l => {
+        l.userData.wrap = true;
+        updateConstellationBoundariesForMollweide(l);
+      });
     }
   }
   if (showConstellationNamesFlag) {
@@ -941,13 +952,14 @@ async function updateMollweideView() {
   if (showCelestialEquatorFlag && celestialEquatorMoll) {
     updateCelestialEquatorMollweide(celestialEquatorMoll);
   }
+  registerEditableLines();
   if (window.requestRender) window.requestRender();
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap(format, resolution) {
-  const width = resolution;
-  const height = Math.floor(resolution / 2);
+function exportMollweideMap() {
+  const width = 7680;
+  const height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
   exportRenderer.setPixelRatio(1);
   const finalCanvas = document.createElement('canvas');
@@ -976,29 +988,20 @@ function exportMollweideMap(format, resolution) {
   }
   exportRenderer.dispose();
 
-  if (format === 'png') {
-    finalCanvas.toBlob(b => {
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(b);
-      link.download = 'mollweide_map.png';
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }, 'image/png');
-  } else {
-    const dataUrl = finalCanvas.toDataURL('image/png');
-    const pdf = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [width, height] });
-    pdf.addImage(dataUrl, 'PNG', 0, 0, width, height);
-    pdf.save('mollweide_map.pdf');
-  }
+  finalCanvas.toBlob(b => {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(b);
+    link.download = 'mollweide_map.png';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }, 'image/png');
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    const format = document.getElementById('export-format').value;
-    const res = parseInt(document.getElementById('export-resolution').value, 10);
-    exportMollweideMap(format, res);
+    exportMollweideMap();
   });
 }
 
@@ -1061,11 +1064,43 @@ function registerMollweideEditableLabels() {
   });
 }
 
+function registerEditableLines() {
+  editableLines = [];
+  mollweideMap.scene.traverse(obj => {
+    if (obj.userData && obj.userData.editableLine) {
+      editableLines.push(obj);
+    }
+  });
+}
+
+function toggleLineWrap(line) {
+  if (!line.userData) return;
+  line.userData.wrap = !line.userData.wrap;
+  if (line.userData._origColor === undefined) {
+    line.userData._origColor = line.material.color.clone();
+  }
+  line.material.color.set('#ff6f61');
+  setTimeout(() => {
+    if (line.material && line.userData._origColor) {
+      line.material.color.copy(line.userData._origColor);
+      requestRender();
+    }
+  }, 200);
+  if (line.userData.type === 'constellation') {
+    updateConstellationBoundariesForMollweide(line);
+  } else if (line.userData.type === 'connection') {
+    updateMollweideConnectionSegments(line);
+  } else if (line.userData.refreshFn) {
+    line.userData.refreshFn(line);
+  }
+  requestRender();
+}
+
 function onEditPointerDown(e) {
   if (!labelEditMode) return;
   const pos = getPointerPos(e);
   editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
-  const intersects = editRaycaster.intersectObjects(editableLabels, false);
+  let intersects = editRaycaster.intersectObjects(editableLabels, false);
   if (intersects.length > 0) {
     selectedLabel = intersects[0].object;
     dragOffset.copy(pos).sub(selectedLabel.position);
@@ -1082,6 +1117,12 @@ function onEditPointerDown(e) {
     mollweideMap.canvas.classList.add('dragging');
     requestRender();
     e.preventDefault();
+  } else {
+    intersects = editRaycaster.intersectObjects(editableLines, false);
+    if (intersects.length > 0) {
+      toggleLineWrap(intersects[0].object);
+      e.preventDefault();
+    }
   }
 }
 
@@ -1139,6 +1180,7 @@ function setupLabelEditor() {
     mollweideMap.canvas.classList.toggle('edit-mode', labelEditMode);
     if (labelEditMode) {
       registerMollweideEditableLabels();
+      registerEditableLines();
     }
     requestRender();
   });


### PR DESCRIPTION
## Summary
- simplify Mollweide export to one-click PNG 8K
- rename label edit button and support editing map lines
- allow toggling line wrapping on click in edit mode
- ensure wrapping resets on map rotation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68497d792fb0832ab20b15554e9f379e