### PR TITLE
UI tweaks and line wrap toggling

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -191,7 +191,7 @@ export function updateMollweideConnectionSegments(lineSegs) {
  * @param {string} mapType - 'Globe' or other.
  * @returns {Array} - Array of THREE.Line objects.
  */
-export function createConnectionLines(stars, pairs, mapType) {
+export function createConnectionLines(stars, pairs, mapType, handleWrap = true) {
   if (!pairs || pairs.length === 0) return [];
   
   const largestPairDistance = pairs.reduce((max, p) => Math.max(max, p.distance), 0);
@@ -208,22 +208,34 @@ export function createConnectionLines(stars, pairs, mapType) {
       posB = new THREE.Vector3(starB.spherePosition.x, starB.spherePosition.y, starB.spherePosition.z);
     } else if (mapType === 'Mollweide') {
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
-      const segments = splitMollweideWrap(
-        starA.mollweidePosition,
-        starB.mollweidePosition
+      const pts = greatCircleToMollweide(
+        starA.spherePosition,
+        starB.spherePosition,
+        100,
+        GC_SEGMENTS,
+        getMollweideLambda0()
       );
+      const segments = [];
+      for (let j = 0; j < pts.length - 1; j++) {
+        const segs = handleWrap ? splitMollweideWrap(pts[j], pts[j + 1]) : [[pts[j], pts[j + 1]]];
+        segs.forEach(s => segments.push(s));
+      }
+      const positions = [];
       segments.forEach(([s1, s2]) => {
-        const points = [s1, s2];
-        const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
-        const materialLine = new THREE.LineBasicMaterial({
-          color: c1.clone().lerp(c2, 0.5),
-          transparent: true,
-          opacity: THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)),
-          linewidth: THREE.MathUtils.lerp(5, 1, distance / (largestPairDistance || distance))
-        });
-        const line = new THREE.Line(geometryLine, materialLine);
-        lines.push(line);
+        positions.push(s1.x, s1.y, s1.z, s2.x, s2.y, s2.z);
       });
+      const geometryLine = new THREE.BufferGeometry();
+      geometryLine.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+      const materialLine = new THREE.LineBasicMaterial({
+        color: c1.clone().lerp(c2, 0.5),
+        transparent: true,
+        opacity: THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)),
+        linewidth: THREE.MathUtils.lerp(5, 1, distance / (largestPairDistance || distance))
+      });
+      const line = new THREE.LineSegments(geometryLine, materialLine);
+      line.computeLineDistances();
+      line.userData = { type: 'connection', starA, starB, distance, mapType, largestPairDistance, handleWrap };
+      lines.push(line);
       return;
     } else {
       // Use the computed truePosition if available
@@ -260,6 +272,52 @@ export function createConnectionLines(stars, pairs, mapType) {
     lines.push(line);
   });
   return lines;
+}
+
+export function updateConnectionLine(line) {
+  const {
+    starA,
+    starB,
+    distance,
+    mapType,
+    largestPairDistance,
+    handleWrap
+  } = line.userData || {};
+  if (!starA || !starB) return;
+  const c1 = new THREE.Color(starA.displayColor || '#ffffff');
+  const c2 = new THREE.Color(starB.displayColor || '#ffffff');
+  const positions = [];
+  if (mapType === 'Mollweide') {
+    const pts = greatCircleToMollweide(
+      starA.spherePosition,
+      starB.spherePosition,
+      100,
+      GC_SEGMENTS,
+      getMollweideLambda0()
+    );
+    for (let j = 0; j < pts.length - 1; j++) {
+      const segs = handleWrap ? splitMollweideWrap(pts[j], pts[j + 1]) : [[pts[j], pts[j + 1]]];
+      segs.forEach(([s1, s2]) => {
+        positions.push(s1.x, s1.y, s1.z, s2.x, s2.y, s2.z);
+      });
+    }
+  } else if (mapType === 'Globe') {
+    const curve = new THREE.CatmullRomCurve3(getGreatCirclePoints(starA.spherePosition, starB.spherePosition, 100, 32));
+    const pts = curve.getPoints(32);
+    for (let i = 0; i < pts.length - 1; i++) {
+      positions.push(pts[i].x, pts[i].y, pts[i].z, pts[i + 1].x, pts[i + 1].y, pts[i + 1].z);
+    }
+  } else {
+    positions.push(starA.truePosition.x, starA.truePosition.y, starA.truePosition.z);
+    positions.push(starB.truePosition.x, starB.truePosition.y, starB.truePosition.z);
+  }
+  line.geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  line.computeLineDistances();
+  line.material.color.copy(c1.clone().lerp(c2, 0.5));
+  const normDist = distance / (largestPairDistance || distance);
+  line.material.opacity = THREE.MathUtils.lerp(1.0, 0.3, normDist);
+  line.material.linewidth = THREE.MathUtils.lerp(5, 1, normDist);
+  line.geometry.attributes.position.needsUpdate = true;
 }
 
 /**

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -111,7 +111,15 @@ export function createConstellationBoundariesForGlobe() {
 }
 
 export function createConstellationBoundariesForMollweide() {
-  const R = 100;
+  const lines = [];
+  boundaryData.forEach(seg => {
+    const line = createConstellationBoundaryLine(seg);
+    lines.push(line);
+  });
+  return lines;
+}
+
+export function createConstellationBoundaryLine(seg, handleWrap = true) {
   const material = new THREE.LineDashedMaterial({
     color: 0x888888,
     dashSize: 2,
@@ -120,47 +128,29 @@ export function createConstellationBoundariesForMollweide() {
     transparent: true,
     opacity: 0.4
   });
-  const maxSegments = boundaryData.length * 32; // 16 segments per boundary, each may wrap
-  const positions = new Float32Array(maxSegments * 2 * 3); // 2 vertices per segment
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  const lineSegs = new THREE.LineSegments(geometry, material);
-  lineSegs.computeLineDistances();
-  lineSegs.userData.boundaryData = boundaryData;
-  lineSegs.userData.R = R;
-  updateConstellationBoundariesForMollweide(lineSegs);
-  return [lineSegs];
+  const line = new THREE.LineSegments(geometry, material);
+  line.userData = { seg, R: 100, handleWrap, type: 'constellation' };
+  updateConstellationBoundaryLine(line);
+  return line;
 }
 
-export function updateConstellationBoundariesForMollweide(lineSegs) {
-  const R = lineSegs.userData.R || 100;
+export function updateConstellationBoundaryLine(line) {
+  const { seg, R = 100, handleWrap } = line.userData;
   const lambda0 = getMollweideLambda0();
-  const data = lineSegs.userData.boundaryData || [];
-  const posAttr = lineSegs.geometry.getAttribute('position');
-  const array = posAttr.array;
-  let idx = 0;
-  data.forEach(seg => {
-    const pStart = radToSphere(seg.ra1, seg.dec1, R);
-    const pEnd   = radToSphere(seg.ra2, seg.dec2, R);
-    const arcPts  = greatCircleToMollweide(pStart, pEnd, R, 16, lambda0);
-    for (let j = 0; j < arcPts.length - 1; j++) {
-      const splits = splitMollweideWrap(arcPts[j], arcPts[j + 1]);
-      for (let s = 0; s < 2; s++) {
-        if (s < splits.length) {
-          const a = splits[s][0];
-          const b = splits[s][1];
-          array[idx++] = a.x; array[idx++] = a.y; array[idx++] = 0;
-          array[idx++] = b.x; array[idx++] = b.y; array[idx++] = 0;
-        } else {
-          array[idx++] = 0; array[idx++] = 0; array[idx++] = 0;
-          array[idx++] = 0; array[idx++] = 0; array[idx++] = 0;
-        }
-      }
-    }
-  });
-  for (; idx < array.length; idx++) array[idx] = 0;
-  posAttr.needsUpdate = true;
-  lineSegs.computeLineDistances();
+  const pStart = radToSphere(seg.ra1, seg.dec1, R);
+  const pEnd = radToSphere(seg.ra2, seg.dec2, R);
+  const arcPts = greatCircleToMollweide(pStart, pEnd, R, 16, lambda0);
+  const positions = [];
+  for (let j = 0; j < arcPts.length - 1; j++) {
+    const splits = handleWrap ? splitMollweideWrap(arcPts[j], arcPts[j + 1]) : [[arcPts[j], arcPts[j + 1]]];
+    splits.forEach(([a, b]) => {
+      positions.push(a.x, a.y, 0, b.x, b.y, 0);
+    });
+  }
+  line.geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  line.computeLineDistances();
+  line.geometry.attributes.position.needsUpdate = true;
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -235,18 +235,8 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
-          <select id="export-format">
-            <option value="png">PNG</option>
-            <option value="pdf">PDF</option>
-          </select>
-          <select id="export-resolution">
-            <option value="3840">4K</option>
-            <option value="7680">8K</option>
-            <option value="15360">16K</option>
-            <option value="30720">32K</option>
-          </select>
           <button id="export-mollweide" class="export-btn">Export</button>
-          <button id="toggle-label-editor" class="export-btn">Edit Labels</button>
+          <button id="toggle-label-editor" class="export-btn">Edit</button>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI } from './filters/index.js';
-import { createConnectionLines, mergeConnectionLines, createMollweideConnectionSegments, updateMollweideConnectionSegments } from './filters/connectionsFilter.js';
-import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
+import { createConnectionLines, mergeConnectionLines, updateConnectionLine } from './filters/connectionsFilter.js';
+import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, createConstellationBoundaryLine, updateConstellationBoundaryLine, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
@@ -86,6 +86,7 @@ const starLabelOffsets = new Map();
 const constellationLabelOffsets = new Map();
 const galacticLabelOffsets = new Map();
 let editableLabels = [];
+let toggleableLines = [];
 let selectedLabel = null;
 const dragOffset = new THREE.Vector3();
 const editPointer = new THREE.Vector2();
@@ -355,6 +356,8 @@ async function buildAndApplyFilters() {
   mollweideMap.updateConnections(currentMollweideFilteredStars, currentMollweideConnections);
   mollweideMap.labelManager.refreshLabels(currentMollweideFilteredStars);
   registerMollweideEditableLabels();
+  registerMollweideToggleableLines();
+  registerMollweideToggleableLines();
 
   removeConstellationObjectsFromGlobe();
   removeConstellationOverlayObjectsFromGlobe();
@@ -371,6 +374,7 @@ async function buildAndApplyFilters() {
     constellationLabelsMoll = createConstellationLabelsForMollweide();
     constellationLabelsMoll.forEach(lbl => mollweideMap.scene.add(lbl));
     registerMollweideEditableLabels();
+    registerMollweideToggleableLines();
   }
   if (showConstellationOverlay) {
     const constellationOverlay = createConstellationOverlayForGlobe();
@@ -686,8 +690,8 @@ class MapManager {
       const linesArray = createConnectionLines(stars, connectionObjs, 'Globe');
       linesArray.forEach(line => this.connectionGroup.add(line));
     } else if (this.mapType === 'Mollweide') {
-      const merged = createMollweideConnectionSegments(connectionObjs);
-      this.connectionGroup.add(merged);
+      const linesArray = createConnectionLines(stars, connectionObjs, 'Mollweide');
+      linesArray.forEach(line => this.connectionGroup.add(line));
     } else {
       const merged = mergeConnectionLines(connectionObjs, this.mapType);
       this.connectionGroup.add(merged);
@@ -699,8 +703,9 @@ class MapManager {
   updateConnectionPositions(stars, connectionObjs) {
     if (!this.connectionGroup) return;
     if (this.mapType === 'Mollweide') {
-      const segs = this.connectionGroup.children[0];
-      if (segs) updateMollweideConnectionSegments(segs);
+      this.connectionGroup.children.forEach(line => {
+        updateConnectionLine(line);
+      });
     } else {
       this.updateConnections(stars, connectionObjs);
     }
@@ -898,7 +903,7 @@ async function updateMollweideView() {
       constellationLinesMoll = createConstellationBoundariesForMollweide();
       constellationLinesMoll.forEach(l => mollweideMap.scene.add(l));
     } else {
-      constellationLinesMoll.forEach(l => updateConstellationBoundariesForMollweide(l));
+      constellationLinesMoll.forEach(l => updateConstellationBoundaryLine(l));
     }
   }
   if (showConstellationNamesFlag) {
@@ -941,6 +946,7 @@ async function updateMollweideView() {
   if (showCelestialEquatorFlag && celestialEquatorMoll) {
     updateCelestialEquatorMollweide(celestialEquatorMoll);
   }
+  registerMollweideToggleableLines();
   if (window.requestRender) window.requestRender();
 }
 window.updateMollweideView = updateMollweideView;
@@ -996,9 +1002,7 @@ function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    const format = document.getElementById('export-format').value;
-    const res = parseInt(document.getElementById('export-resolution').value, 10);
-    exportMollweideMap(format, res);
+    exportMollweideMap('png', 7680);
   });
 }
 
@@ -1061,6 +1065,31 @@ function registerMollweideEditableLabels() {
   });
 }
 
+function registerMollweideToggleableLines() {
+  toggleableLines = [];
+  mollweideMap.scene.traverse(obj => {
+    if ((obj.type === 'Line' || obj.type === 'LineSegments') && obj.userData && obj.userData.type) {
+      toggleableLines.push(obj);
+    }
+  });
+}
+
+function toggleLineWrap(line) {
+  if (!line || !line.userData) return;
+  line.userData.handleWrap = !line.userData.handleWrap;
+  const origColor = line.material.color.clone();
+  line.material.color.set('#ff6f61');
+  setTimeout(() => {
+    line.material.color.copy(origColor);
+  }, 250);
+  if (line.userData.type === 'connection') {
+    updateConnectionLine(line);
+  } else if (line.userData.type === 'constellation') {
+    updateConstellationBoundaryLine(line);
+  }
+  requestRender();
+}
+
 function onEditPointerDown(e) {
   if (!labelEditMode) return;
   const pos = getPointerPos(e);
@@ -1082,6 +1111,12 @@ function onEditPointerDown(e) {
     mollweideMap.canvas.classList.add('dragging');
     requestRender();
     e.preventDefault();
+  } else {
+    const lineHits = editRaycaster.intersectObjects(toggleableLines, false);
+    if (lineHits.length > 0) {
+      toggleLineWrap(lineHits[0].object);
+      e.preventDefault();
+    }
   }
 }
 
@@ -1139,6 +1174,7 @@ function setupLabelEditor() {
     mollweideMap.canvas.classList.toggle('edit-mode', labelEditMode);
     if (labelEditMode) {
       registerMollweideEditableLabels();
+      registerMollweideToggleableLines();
     }
     requestRender();
   });


### PR DESCRIPTION
## Summary
- simplify Mollweide export options and rename edit button
- add per-line wrap toggle support in edit mode
- update connection and constellation line creation for editing
- refresh toggleable objects after updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68498fa32944832a988abb2f0c6f8cd8