### PR TITLE
Add line editing and undo controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,18 +235,10 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
-          <select id="export-format">
-            <option value="png">PNG</option>
-            <option value="pdf">PDF</option>
-          </select>
-          <select id="export-resolution">
-            <option value="3840">4K</option>
-            <option value="7680">8K</option>
-            <option value="15360">16K</option>
-            <option value="30720">32K</option>
-          </select>
           <button id="export-mollweide" class="export-btn">Export</button>
           <button id="toggle-label-editor" class="export-btn">Edit Labels</button>
+          <button id="toggle-line-editor" class="export-btn">Edit Lines</button>
+          <button id="undo-edit" class="export-btn">Undo</button>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1080,7 +1080,40 @@ function onLinePointerDown(e) {
   editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
   const intersects = editRaycaster.intersectObjects(editableLines, false);
   if (intersects.length > 0) {
-    const obj = intersects[0].object;
+    const intersect = intersects[0];
+    const obj = intersect.object;
+    const idx = intersect.index;
+    const posAttr = obj.geometry && obj.geometry.getAttribute('position');
+    if (posAttr && idx !== undefined) {
+      const start = obj.type === 'LineSegments' ? idx - (idx % 2) : idx;
+      const base = start * 3;
+      if (base + 5 < posAttr.array.length) {
+        const prevPos = [
+          posAttr.array[base], posAttr.array[base + 1], posAttr.array[base + 2],
+          posAttr.array[base + 3], posAttr.array[base + 4], posAttr.array[base + 5]
+        ];
+        for (let i = 0; i < 6; i++) posAttr.array[base + i] = NaN;
+        posAttr.needsUpdate = true;
+        let prevAlpha = null;
+        const alphaAttr = obj.geometry.getAttribute('alpha');
+        if (alphaAttr) {
+          prevAlpha = [alphaAttr.array[start], alphaAttr.array[start + 1]];
+          alphaAttr.array[start] = 0;
+          alphaAttr.array[start + 1] = 0;
+          alphaAttr.needsUpdate = true;
+        }
+        editHistory.push({
+          type: 'removeSegment',
+          object: obj,
+          index: start,
+          prevPos,
+          prevAlpha
+        });
+        requestRender();
+        e.preventDefault();
+        return;
+      }
+    }
     editHistory.push({ type: 'toggleVisible', object: obj, prevVisible: obj.visible });
     obj.visible = false;
     requestRender();
@@ -1211,6 +1244,21 @@ function setupUndoButton() {
     if (!action) return;
     if (action.type === 'toggleVisible') {
       action.object.visible = action.prevVisible;
+    } else if (action.type === 'removeSegment') {
+      const posAttr = action.object.geometry.getAttribute('position');
+      const base = action.index * 3;
+      action.prevPos.forEach((v, i) => {
+        posAttr.array[base + i] = v;
+      });
+      posAttr.needsUpdate = true;
+      if (action.prevAlpha) {
+        const alphaAttr = action.object.geometry.getAttribute('alpha');
+        if (alphaAttr) {
+          alphaAttr.array[action.index] = action.prevAlpha[0];
+          alphaAttr.array[action.index + 1] = action.prevAlpha[1];
+          alphaAttr.needsUpdate = true;
+        }
+      }
     } else if (action.type === 'moveLabel') {
       const label = action.label;
       const anchor = label.userData.anchorFunc();

--- a/script.js
+++ b/script.js
@@ -91,6 +91,10 @@ const dragOffset = new THREE.Vector3();
 const editPointer = new THREE.Vector2();
 const editRaycaster = new THREE.Raycaster();
 const editPlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+let lineEditMode = false;
+let editableLines = [];
+const editHistory = [];
+let initialLabelPos = null;
 
 function getStarId(star) {
   return (
@@ -945,9 +949,9 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap(format, resolution) {
-  const width = resolution;
-  const height = Math.floor(resolution / 2);
+function exportMollweideMap() {
+  const width = 7680;
+  const height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
   exportRenderer.setPixelRatio(1);
   const finalCanvas = document.createElement('canvas');
@@ -976,29 +980,20 @@ function exportMollweideMap(format, resolution) {
   }
   exportRenderer.dispose();
 
-  if (format === 'png') {
-    finalCanvas.toBlob(b => {
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(b);
-      link.download = 'mollweide_map.png';
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }, 'image/png');
-  } else {
-    const dataUrl = finalCanvas.toDataURL('image/png');
-    const pdf = new window.jspdf.jsPDF({ orientation: 'landscape', unit: 'px', format: [width, height] });
-    pdf.addImage(dataUrl, 'PNG', 0, 0, width, height);
-    pdf.save('mollweide_map.pdf');
-  }
+  finalCanvas.toBlob(b => {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(b);
+    link.download = 'mollweide_map.png';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }, 'image/png');
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    const format = document.getElementById('export-format').value;
-    const res = parseInt(document.getElementById('export-resolution').value, 10);
-    exportMollweideMap(format, res);
+    exportMollweideMap();
   });
 }
 
@@ -1061,6 +1056,38 @@ function registerMollweideEditableLabels() {
   });
 }
 
+function registerMollweideEditableLines() {
+  editableLines = [];
+  if (mollweideMap.connectionGroup) {
+    mollweideMap.connectionGroup.traverse(obj => {
+      if (obj.isLine || obj.type === 'Line' || obj.type === 'LineSegments') {
+        editableLines.push(obj);
+      }
+    });
+  }
+  constellationLinesMoll.forEach(l => editableLines.push(l));
+  if (densityOverlay && densityOverlay.adjacentLines) {
+    densityOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
+  }
+  if (isolationOverlay && isolationOverlay.adjacentLines) {
+    isolationOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
+  }
+}
+
+function onLinePointerDown(e) {
+  if (!lineEditMode) return;
+  getPointerPos(e);
+  editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
+  const intersects = editRaycaster.intersectObjects(editableLines, false);
+  if (intersects.length > 0) {
+    const obj = intersects[0].object;
+    editHistory.push({ type: 'toggleVisible', object: obj, prevVisible: obj.visible });
+    obj.visible = false;
+    requestRender();
+    e.preventDefault();
+  }
+}
+
 function onEditPointerDown(e) {
   if (!labelEditMode) return;
   const pos = getPointerPos(e);
@@ -1068,6 +1095,7 @@ function onEditPointerDown(e) {
   const intersects = editRaycaster.intersectObjects(editableLabels, false);
   if (intersects.length > 0) {
     selectedLabel = intersects[0].object;
+    initialLabelPos = selectedLabel.position.clone();
     dragOffset.copy(pos).sub(selectedLabel.position);
     selectedLabel.userData._origScale = selectedLabel.scale.clone();
     selectedLabel.userData._origColor = selectedLabel.material.color.clone();
@@ -1126,8 +1154,13 @@ function onEditPointerUp() {
     selectedLabel.userData.lineObj.material.color.copy(selectedLabel.userData._origLineColor);
   }
   mollweideMap.canvas.classList.remove('dragging');
+  if (initialLabelPos) {
+    const prevOffset = initialLabelPos.clone().sub(anchor);
+    editHistory.push({ type: 'moveLabel', label: selectedLabel, prevOffset });
+  }
   requestRender();
   selectedLabel = null;
+  initialLabelPos = null;
 }
 
 function setupLabelEditor() {
@@ -1136,7 +1169,12 @@ function setupLabelEditor() {
   btn.addEventListener('click', () => {
     labelEditMode = !labelEditMode;
     btn.classList.toggle('active', labelEditMode);
-    mollweideMap.canvas.classList.toggle('edit-mode', labelEditMode);
+    if (labelEditMode) {
+      lineEditMode = false;
+      const lbtn = document.getElementById('toggle-line-editor');
+      if (lbtn) lbtn.classList.remove('active');
+    }
+    mollweideMap.canvas.classList.toggle('edit-mode', labelEditMode || lineEditMode);
     if (labelEditMode) {
       registerMollweideEditableLabels();
     }
@@ -1145,6 +1183,53 @@ function setupLabelEditor() {
   mollweideMap.canvas.addEventListener('pointerdown', onEditPointerDown);
   mollweideMap.canvas.addEventListener('pointermove', onEditPointerMove);
   window.addEventListener('pointerup', onEditPointerUp);
+}
+
+function setupLineEditor() {
+  const btn = document.getElementById('toggle-line-editor');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    lineEditMode = !lineEditMode;
+    btn.classList.toggle('active', lineEditMode);
+    if (lineEditMode) {
+      labelEditMode = false;
+      const lbtn = document.getElementById('toggle-label-editor');
+      if (lbtn) lbtn.classList.remove('active');
+      registerMollweideEditableLines();
+    }
+    mollweideMap.canvas.classList.toggle('edit-mode', lineEditMode || labelEditMode);
+    requestRender();
+  });
+  mollweideMap.canvas.addEventListener('pointerdown', onLinePointerDown);
+}
+
+function setupUndoButton() {
+  const btn = document.getElementById('undo-edit');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const action = editHistory.pop();
+    if (!action) return;
+    if (action.type === 'toggleVisible') {
+      action.object.visible = action.prevVisible;
+    } else if (action.type === 'moveLabel') {
+      const label = action.label;
+      const anchor = label.userData.anchorFunc();
+      const newPos = anchor.clone().add(action.prevOffset);
+      label.position.copy(newPos);
+      if (label.userData.editType === 'star') {
+        starLabelOffsets.set(label.userData.editId, { x: action.prevOffset.x, y: action.prevOffset.y });
+        if (label.userData.starRef) label.userData.starRef.mollLabelOffset = action.prevOffset.clone();
+        if (label.userData.lineObj) label.userData.lineObj.geometry.setFromPoints([anchor, newPos]);
+      } else if (label.userData.editType === 'constellation') {
+        constellationLabelOffsets.set(label.userData.editId, { x: action.prevOffset.x, y: action.prevOffset.y });
+        label.userData.offset = action.prevOffset.clone();
+      } else if (label.userData.editType === 'galactic') {
+        galacticLabelOffsets.set(label.userData.editId, { x: action.prevOffset.x, y: action.prevOffset.y });
+        label.userData.offset = action.prevOffset.clone();
+      }
+    }
+    requestRender();
+  });
 }
 
 async function main() {
@@ -1181,6 +1266,8 @@ async function main() {
     setupMapProjectionToggles();
     setupExportControls();
     setupLabelEditor();
+    setupLineEditor();
+    setupUndoButton();
     requestRender();
     loader.classList.add('hidden');
   } catch (err) {

--- a/script.js
+++ b/script.js
@@ -1080,7 +1080,33 @@ function onLinePointerDown(e) {
   editRaycaster.setFromCamera(editPointer, mollweideMap.camera);
   const intersects = editRaycaster.intersectObjects(editableLines, false);
   if (intersects.length > 0) {
-    const intersect = intersects[0];
+    let intersect = null;
+    for (const intr of intersects) {
+      const obj = intr.object;
+      const idx = intr.index;
+      const posAttr = obj.geometry && obj.geometry.getAttribute('position');
+      if (posAttr && idx !== undefined) {
+        const start = obj.type === 'LineSegments' ? idx - (idx % 2) : idx;
+        const base = start * 3;
+        if (base + 5 < posAttr.array.length) {
+          let removed = true;
+          for (let i = 0; i < 6; i++) {
+            if (!Number.isNaN(posAttr.array[base + i])) {
+              removed = false;
+              break;
+            }
+          }
+          if (!removed) {
+            intersect = intr;
+            break;
+          }
+        }
+      } else {
+        intersect = intr;
+        break;
+      }
+    }
+    if (!intersect) return;
     const obj = intersect.object;
     const idx = intersect.index;
     const posAttr = obj.geometry && obj.geometry.getAttribute('position');


### PR DESCRIPTION
## Summary
- simplify Mollweide export to a fixed 8K PNG
- add line editing mode and undo functionality
- integrate line editing with existing label editor
- update export controls with new Edit Lines and Undo buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684992d284fc832a9e1222ab8ba8c00c