### PR TITLE
Add dust cloud density visualization

### DIFF
--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -1,0 +1,291 @@
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
+import { lightenColor } from './densityColorUtils.js';
+
+function createWideLineMaterial(color) {
+  return new THREE.ShaderMaterial({
+    uniforms: { color: { value: new THREE.Color(color) }, opacityFactor: { value: 1.0 } },
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    vertexShader: `
+      attribute float side;
+      varying float vSide;
+      void main() {
+        vSide = side;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }`,
+    fragmentShader: `
+      uniform vec3 color;
+      uniform float opacityFactor;
+      varying float vSide;
+      void main() {
+        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        if(alpha <= 0.0) discard;
+        gl_FragColor = vec4(color, alpha);
+      }`
+  });
+}
+
+function buildWideLineGeometry(points, width) {
+  const vertices = [];
+  const sides = [];
+  for (let i = 0; i < points.length; i += 2) {
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const dir = new THREE.Vector2(p2.x - p1.x, p2.y - p1.y).normalize();
+    const perp = new THREE.Vector2(-dir.y, dir.x).multiplyScalar(width / 2);
+    const a1 = new THREE.Vector3(p1.x + perp.x, p1.y + perp.y, p1.z);
+    const a2 = new THREE.Vector3(p1.x - perp.x, p1.y - perp.y, p1.z);
+    const b1 = new THREE.Vector3(p2.x + perp.x, p2.y + perp.y, p2.z);
+    const b2 = new THREE.Vector3(p2.x - perp.x, p2.y - perp.y, p2.z);
+    vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
+    sides.push(1, -1, -1);
+    vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
+    sides.push(1, -1, 1);
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  return geom;
+}
+
+class CloudDensityGridOverlay {
+  constructor(minDistance, maxDistance, gridSize = 2) {
+    this.minDistance = parseFloat(minDistance);
+    this.maxDistance = parseFloat(maxDistance);
+    this.gridSize = gridSize;
+    this.cubesData = [];
+    this.adjacentLines = [];
+    this.mollLineWidth = 30;
+    this.opacityFactor = 1.0;
+  }
+
+  createGrid() {
+    const halfExt = Math.ceil(this.maxDistance / this.gridSize) * this.gridSize;
+    this.cubesData = [];
+    for (let x = -halfExt; x <= halfExt; x += this.gridSize) {
+      for (let y = -halfExt; y <= halfExt; y += this.gridSize) {
+        for (let z = -halfExt; z <= halfExt; z += this.gridSize) {
+          const posTC = new THREE.Vector3(
+            x + this.gridSize / 2,
+            y + this.gridSize / 2,
+            z + this.gridSize / 2
+          );
+          const dist = posTC.length();
+          if (dist < this.minDistance || dist > this.maxDistance) continue;
+          const geometry = new THREE.BoxGeometry(this.gridSize, this.gridSize, this.gridSize);
+          const material = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.0, depthWrite: false });
+          const cubeTC = new THREE.Mesh(geometry, material);
+          cubeTC.position.copy(posTC);
+
+          const planeGeom = new THREE.PlaneGeometry(this.gridSize, this.gridSize);
+          const planeMat = material.clone();
+          planeMat.side = THREE.DoubleSide;
+          const squareGlobe = new THREE.Mesh(planeGeom, planeMat.clone());
+          const squareMoll = new THREE.Mesh(planeGeom.clone(), planeMat.clone());
+
+          let ra = 0, dec = 0;
+          if (dist >= 1e-6) {
+            ra = Math.atan2(-posTC.z, -posTC.x);
+            dec = Math.asin(posTC.y / dist);
+            const projM = cachedRadToMollweide(ra, dec, 100, getMollweideLambda0());
+            squareMoll.position.copy(projM);
+            const R = 100;
+            const proj = new THREE.Vector3(
+              -R * Math.cos(dec) * Math.cos(ra),
+               R * Math.sin(dec),
+              -R * Math.cos(dec) * Math.sin(ra)
+            );
+            squareGlobe.position.copy(proj);
+            const nrm = proj.clone().normalize();
+            let right = new THREE.Vector3().crossVectors(new THREE.Vector3(0,1,0), nrm);
+            if (right.lengthSq() < 1e-6) right.set(1,0,0);
+            right.normalize();
+            const upVec = new THREE.Vector3().crossVectors(nrm, right).normalize();
+            const mat4 = new THREE.Matrix4().makeBasis(right, upVec, nrm);
+            squareGlobe.setRotationFromMatrix(mat4);
+          }
+          let theta = dec;
+          for (let i = 0; i < 10; i++) {
+            const delta = (2 * theta + Math.sin(2 * theta) - Math.PI * Math.sin(dec)) /(2 + 2 * Math.cos(2 * theta));
+            theta -= delta;
+            if (Math.abs(delta) < 1e-10) break;
+          }
+          const cosT = Math.cos(theta);
+          const mollXFactor = (2 * 100 / Math.PI) * cosT;
+          const mollY = 100 * Math.sin(theta);
+
+          const cell = {
+            tcMesh: cubeTC,
+            globeMesh: squareGlobe,
+            mollweideMesh: squareMoll,
+            tcPos: posTC,
+            grid: { ix: Math.round(x / this.gridSize), iy: Math.round(y / this.gridSize), iz: Math.round(z / this.gridSize) },
+            raRad: ra,
+            decRad: dec,
+            mollXFactor,
+            mollY,
+            scores: {}
+          };
+          cell.id = this.cubesData.length;
+          this.cubesData.push(cell);
+        }
+      }
+    }
+    this.computeAdjacentLines();
+  }
+
+  computeAdjacentLines() {
+    this.adjacentLines = [];
+    const cellMap = new Map();
+    this.cubesData.forEach(cell => {
+      const key = `${cell.grid.ix},${cell.grid.iy},${cell.grid.iz}`;
+      cellMap.set(key, cell);
+    });
+    const dirs = [];
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dz = -1; dz <= 1; dz++) {
+          if (dx === 0 && dy === 0 && dz === 0) continue;
+          if (dx > 0 || (dx === 0 && dy > 0) || (dx === 0 && dy === 0 && dz > 0)) dirs.push({dx,dy,dz});
+        }
+      }
+    }
+    dirs.forEach(dir => {
+      this.cubesData.forEach(cell => {
+        const nbKey = `${cell.grid.ix + dir.dx},${cell.grid.iy + dir.dy},${cell.grid.iz + dir.dz}`;
+        if (cellMap.has(nbKey)) {
+          const neighbor = cellMap.get(nbKey);
+          const pts = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 16);
+          const positions = [];
+          const mollPts = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 16).map(v => {
+            const raDec = {
+              ra: Math.atan2(-v.z, -v.x),
+              dec: Math.asin(v.y / 100)
+            };
+            return cachedRadToMollweide(raDec.ra, raDec.dec, 100, getMollweideLambda0());
+          });
+          const ptsM = [];
+          for (let m = 0; m < mollPts.length - 1; m++) {
+            const segs = splitMollweideWrap(mollPts[m], mollPts[m+1]);
+            segs.forEach(([s,e]) => { ptsM.push(s,e); });
+          }
+          const geomM = buildWideLineGeometry(ptsM, this.mollLineWidth);
+          for (let i = 0; i < pts.length; i++) positions.push(pts[i].x, pts[i].y, pts[i].z);
+          const geom = new THREE.BufferGeometry();
+          geom.setAttribute('position', new THREE.Float32BufferAttribute(positions,3));
+          const mat = new THREE.LineBasicMaterial({ color: 0xffffff, transparent:true, opacity:0.3, linewidth:2 });
+          const line = new THREE.Line(geom, mat); line.renderOrder=1;
+          const mollMat = createWideLineMaterial(0xffffff); const lineM=new THREE.Mesh(geomM, mollMat); lineM.renderOrder=1;
+          this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
+        }
+      });
+    });
+  }
+
+  computeCellScores(cell, cloudMap, radius) {
+    for (const [name, points] of cloudMap.entries()) {
+      let sum = 0;
+      points.forEach(p => {
+        const d = cell.tcPos.distanceTo(p);
+        if (d > radius) return;
+        const w = 1 - d / radius;
+        sum += w;
+      });
+      cell.scores[name] = sum;
+    }
+  }
+
+  update(cloudMap, sceneTC, sceneGlobe, sceneMoll, topPercent, radius, colors) {
+    const opacitySlider = document.getElementById('cloud-density-opacity-slider');
+    this.opacityFactor = opacitySlider ? parseFloat(opacitySlider.value)/100 : 1.0;
+    this.cubesData.forEach(c => this.computeCellScores(c, cloudMap, radius));
+    const thresholds = new Map();
+    const maxScores = new Map();
+    cloudMap.forEach((_, name) => {
+      const arr = this.cubesData.map(c => c.scores[name] || 0);
+      const sorted = arr.slice().sort((a,b)=>a-b);
+      const idx = Math.floor(sorted.length * (1 - topPercent/100));
+      thresholds.set(name, sorted[Math.max(idx,0)] || 0);
+      maxScores.set(name, sorted[sorted.length-1] || 0);
+    });
+    this.cubesData.forEach(cell => {
+      const ratio = cell.tcPos.length()/this.maxDistance;
+      const scale = THREE.MathUtils.lerp(20.0,0.1,Math.min(1,ratio));
+      let finalColor = new THREE.Color(1,1,1);
+      let totalW = 0;
+      colors.forEach((color,name) => {
+        const score = cell.scores[name]||0;
+        const thr = thresholds.get(name)||0;
+        const max = maxScores.get(name)||1;
+        if (score >= thr && max>thr) {
+          const w = (score - thr)/(max - thr);
+          finalColor = finalColor.lerp(color, w);
+          totalW += w;
+        }
+      });
+      const alpha = 0.5 * Math.min(1,totalW) * this.opacityFactor;
+      cell.tcMesh.material.opacity = alpha;
+      cell.globeMesh.material.opacity = alpha;
+      cell.mollweideMesh.material.opacity = alpha;
+      cell.tcMesh.material.color.copy(finalColor);
+      cell.globeMesh.material.color.copy(finalColor);
+      cell.mollweideMesh.material.color.copy(finalColor);
+      cell.tcMesh.visible = alpha > 0;
+      cell.globeMesh.scale.set(scale,scale,1);
+      cell.mollweideMesh.scale.set(scale,scale,1);
+    });
+    this.adjacentLines.forEach(obj => {
+      const { line, lineM, cell1, cell2 } = obj;
+      const visible = cell1.tcMesh.visible && cell2.tcMesh.visible;
+      line.visible = visible;
+      lineM.visible = visible;
+      if (visible) {
+        const c1 = cell1.tcMesh.material.color;
+        const c2 = cell2.tcMesh.material.color;
+        const avgColor = c1.clone().lerp(c2,0.5);
+        const avgOpacity = (cell1.tcMesh.material.opacity + cell2.tcMesh.material.opacity)/2;
+        line.material.color.copy(avgColor);
+        line.material.opacity = avgOpacity;
+        lineM.material.uniforms.color.value.copy(avgColor);
+        lineM.material.uniforms.opacityFactor.value = avgOpacity;
+      }
+    });
+    if (sceneTC) this.cubesData.forEach(c=>{ sceneTC.add(c.tcMesh); });
+    if (sceneGlobe) this.adjacentLines.forEach(o=>{ sceneGlobe.add(o.line); });
+    if (sceneMoll) this.adjacentLines.forEach(o=>{ sceneMoll.add(o.lineM); });
+  }
+
+  refreshMollweide(lambda0=getMollweideLambda0()) {
+    this.cubesData.forEach(cell => {
+      const lambda = cell.raRad - lambda0;
+      cell.mollweideMesh.position.set(cell.mollXFactor*lambda, cell.mollY, 0);
+    });
+    this.adjacentLines.forEach(obj => {
+      const gcPts = getGreatCirclePoints(obj.cell1.globeMesh.position, obj.cell2.globeMesh.position, 100, 16).map(v => {
+        const ra = Math.atan2(-v.z, -v.x);
+        const dec = Math.asin(v.y / 100);
+        return cachedRadToMollweide(ra, dec, 100, lambda0);
+      });
+      const pts = [];
+      for (let i=0;i<gcPts.length-1;i++) {
+        const segs = splitMollweideWrap(gcPts[i], gcPts[i+1]);
+        segs.forEach(([s,e])=>{ pts.push(s,e); });
+      }
+      obj.lineM.geometry.dispose();
+      obj.lineM.geometry = buildWideLineGeometry(pts, this.mollLineWidth);
+    });
+  }
+}
+
+export function initCloudDensityFilter(minDistance, maxDistance, gridSize=2) {
+  const overlay = new CloudDensityGridOverlay(minDistance, maxDistance, gridSize);
+  overlay.createGrid();
+  return overlay;
+}
+
+export function updateCloudDensityFilter(overlay, cloudMap, sceneTC, sceneGlobe, sceneMoll, topPercent, radius, colors) {
+  if (!overlay) return;
+  overlay.update(cloudMap, sceneTC, sceneGlobe, sceneMoll, topPercent, radius, colors);
+}

--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -175,7 +175,7 @@ export async function createCloudOverlay(
  * @param {string} name 
  * @returns {THREE.Color}
  */
-function uniqueColorFromName(name) {
+export function uniqueColorFromName(name) {
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);

--- a/filters/index.js
+++ b/filters/index.js
@@ -1,5 +1,6 @@
 // /filters/index.js
 
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { loadStellarClassData } from './stellarClassData.js';
 import { applySizeFilter } from './sizeFilter.js';
 import { applyColorFilter } from './colorFilter.js';
@@ -15,11 +16,14 @@ import { applyDistanceFilter } from './distanceFilter.js';
 // Import the new Isolation and Density Filter modules.
 import { initIsolationFilter, updateIsolationFilter } from './isolationFilter.js';
 import { initDensityFilter, updateDensityFilter } from './densityFilter.js';
+import { initCloudDensityFilter, updateCloudDensityFilter } from './cloudDensityFilter.js';
+import { uniqueColorFromName } from './cloudsFilter.js';
 import { bindAdditionalOpacitySliders } from '../ui/filterUI.js';
 
 let filterForm = null;
 let isolationOverlay = null;
 let densityOverlay = null;
+let cloudDensityOverlay = null;
 
 // Helper to compute a grid size from the isolationGridSize slider value.
 function computeIsolationGridSize(sliderValue) {
@@ -305,7 +309,7 @@ function addPlanesFieldset() {
   filterForm.appendChild(fs);
 }
 
-export function applyFilters(allStars) {
+export async function applyFilters(allStars) {
   if (!filterForm) {
     filterForm = document.getElementById('filters-form');
     if (!filterForm) {
@@ -330,6 +334,11 @@ export function applyFilters(allStars) {
         densityBottomPercent: 10,
         densityTolerance: 0,
         densityOpacity: 100,
+        enableCloudDensityFilter: false,
+        cloudDensity: 10,
+        cloudDensityTopPercent: 10,
+        cloudDensityGridSize: 1,
+        cloudDensityOpacity: 100,
         cloudOpacity: 100,
         starOpacity: 100,
         starNameOpacity: 100,
@@ -375,9 +384,14 @@ export function applyFilters(allStars) {
     minDistance: formData.get('min-distance'),
     maxDistance: formData.get('max-distance'),
     isolationGridSize: parseFloat(formData.get('isolation-grid-size')) || 1,
-    densityGridSize: parseFloat(formData.get('density-grid-size')) || 1,
-    densityOpacity: parseFloat(formData.get('density-opacity')) || 100,
-    cloudOpacity: parseFloat(formData.get('cloud-opacity')) || 100,
+   densityGridSize: parseFloat(formData.get('density-grid-size')) || 1,
+   densityOpacity: parseFloat(formData.get('density-opacity')) || 100,
+    enableCloudDensityFilter: (formData.get('enable-cloud-density-filter') !== null),
+    cloudDensity: parseFloat(formData.get('cloud-density')) || 10,
+    cloudDensityTopPercent: parseFloat(formData.get('cloud-density-top-percent')) || 10,
+    cloudDensityGridSize: parseFloat(formData.get('cloud-density-grid-size')) || 1,
+    cloudDensityOpacity: parseFloat(formData.get('cloud-density-opacity')) || 100,
+   cloudOpacity: parseFloat(formData.get('cloud-opacity')) || 100,
     starOpacity: parseFloat(formData.get('star-opacity')) || 100,
     starNameOpacity: parseFloat(formData.get('star-name-opacity')) || 100,
     connectionOpacity: parseFloat(formData.get('connection-opacity')) || 50,
@@ -513,6 +527,77 @@ export function applyFilters(allStars) {
     }
   }
 
+  // --- Cloud Density Filter Handling ---
+  if (filters.enableCloudDensityFilter) {
+    const gridSize = computeIsolationGridSize(filters.cloudDensityGridSize);
+    if (
+      !cloudDensityOverlay ||
+      cloudDensityOverlay.minDistance !== parseFloat(filters.minDistance) ||
+      cloudDensityOverlay.maxDistance !== parseFloat(filters.maxDistance) ||
+      cloudDensityOverlay.gridSize !== gridSize
+    ) {
+      if (cloudDensityOverlay) {
+        cloudDensityOverlay.cubesData.forEach(cell => {
+          window.trueCoordinatesMap.scene.remove(cell.tcMesh);
+        });
+        cloudDensityOverlay.adjacentLines.forEach(obj => {
+          window.globeMap.scene.remove(obj.line);
+          window.mollweideMap.scene.remove(obj.lineM);
+        });
+      }
+      cloudDensityOverlay = initCloudDensityFilter(filters.minDistance, filters.maxDistance, gridSize);
+      cloudDensityOverlay.cubesData.forEach(cell => {
+        window.trueCoordinatesMap.scene.add(cell.tcMesh);
+      });
+      cloudDensityOverlay.adjacentLines.forEach(obj => {
+        window.globeMap.scene.add(obj.line);
+        window.mollweideMap.scene.add(obj.lineM);
+      });
+    }
+    const form = document.getElementById('filters-form');
+    const checked = new FormData(form).getAll('dust-density-clouds');
+    const cloudMap = new Map();
+    const colorMap = new Map();
+    for (const file of checked) {
+      const data = await fetch(file).then(r=>r.json()).catch(()=>[]);
+      const name = file.split('/').pop().replace('_cloud_data.json','').replace('_',' ');
+      const points = data.map(d => {
+        const ra = d.RA * Math.PI/180;
+        const dec = d.DEC * Math.PI/180;
+        const dist = (d['d (pc)']||0)*3.26156;
+        return new THREE.Vector3(
+          -dist*Math.cos(dec)*Math.cos(ra),
+           dist*Math.sin(dec),
+          -dist*Math.cos(dec)*Math.sin(ra)
+        );
+      });
+      cloudMap.set(name, points);
+      const color = uniqueColorFromName(name);
+      colorMap.set(name, color);
+    }
+    updateCloudDensityFilter(
+      cloudDensityOverlay,
+      cloudMap,
+      window.trueCoordinatesMap.scene,
+      window.globeMap.scene,
+      window.mollweideMap.scene,
+      filters.cloudDensityTopPercent,
+      filters.cloudDensity,
+      colorMap
+    );
+  } else {
+    if (cloudDensityOverlay) {
+      cloudDensityOverlay.cubesData.forEach(cell => {
+        window.trueCoordinatesMap.scene.remove(cell.tcMesh);
+      });
+      cloudDensityOverlay.adjacentLines.forEach(obj => {
+        window.globeMap.scene.remove(obj.line);
+        window.mollweideMap.scene.remove(obj.lineM);
+      });
+      cloudDensityOverlay = null;
+    }
+  }
+
   return {
     filteredStars,
     connections: pairs,
@@ -540,6 +625,11 @@ export function applyFilters(allStars) {
     isolationGridSize: filters.isolationGridSize,
     densityGridSize: filters.densityGridSize,
     densityOpacity: filters.densityOpacity,
+    enableCloudDensityFilter: filters.enableCloudDensityFilter,
+    cloudDensity: filters.cloudDensity,
+    cloudDensityTopPercent: filters.cloudDensityTopPercent,
+    cloudDensityGridSize: filters.cloudDensityGridSize,
+    cloudDensityOpacity: filters.cloudDensityOpacity,
     cloudOpacity: filters.cloudOpacity,
     starOpacity: filters.starOpacity,
     starNameOpacity: filters.starNameOpacity,
@@ -552,7 +642,8 @@ export function applyFilters(allStars) {
     showEclipticPlane: filters.showEclipticPlane,
     showCelestialEquator: filters.showCelestialEquator,
     isolationOverlay,
-    densityOverlay
+    densityOverlay,
+    cloudDensityOverlay
   };
 }
 

--- a/script.js
+++ b/script.js
@@ -58,6 +58,7 @@ let constellationOverlayMoll = [];
 let globeSurfaceSphere = null;
 let isolationOverlay = null;
 let densityOverlay = null;
+let cloudDensityOverlay = null;
 let galacticPlaneTrue = null;
 let eclipticPlaneTrue = null;
 let celestialEquatorTrue = null;
@@ -75,6 +76,7 @@ let showConstellationNamesFlag = false;
 let showConstellationOverlayFlag = false;
 let enableIsolationFilterFlag = false;
 let enableDensityFilterFlag = false;
+let enableCloudDensityFilterFlag = false;
 let showCloudsFlag = false;
 let showGalacticPlaneFlag = false;
 let showEclipticPlaneFlag = false;
@@ -391,7 +393,7 @@ function scheduleMollweideUpdate() {
 
 async function buildAndApplyFilters() {
   if (!cachedStars) return;
-  const filters = applyFilters(cachedStars);
+  const filters = await applyFilters(cachedStars);
   const {
     filteredStars,
     connections,
@@ -428,7 +430,13 @@ async function buildAndApplyFilters() {
     showEclipticPlane,
     showCelestialEquator,
     isolationOverlay: returnedIsolationOverlay,
-    densityOverlay: returnedDensityOverlay
+    densityOverlay: returnedDensityOverlay,
+    cloudDensityOverlay: returnedCloudDensityOverlay,
+    enableCloudDensityFilter,
+    cloudDensity,
+    cloudDensityTopPercent,
+    cloudDensityOpacity,
+    cloudDensityGridSize
   } = filters;
 
   showConstellationBoundariesFlag = showConstellationBoundaries;
@@ -436,6 +444,7 @@ async function buildAndApplyFilters() {
   showConstellationOverlayFlag = showConstellationOverlay;
   enableIsolationFilterFlag = enableIsolationFilter;
   enableDensityFilterFlag = enableDensityFilter;
+  enableCloudDensityFilterFlag = enableCloudDensityFilter;
   showCloudsFlag = showClouds;
   showGalacticPlaneFlag = showGalacticPlane;
   showEclipticPlaneFlag = showEclipticPlane;
@@ -444,6 +453,7 @@ async function buildAndApplyFilters() {
   // store overlay references for external refresh calls
   isolationOverlay = returnedIsolationOverlay;
   densityOverlay = returnedDensityOverlay;
+  cloudDensityOverlay = returnedCloudDensityOverlay;
 
   currentFilteredStars = filteredStars;
   currentConnections = connections;
@@ -1110,6 +1120,11 @@ async function updateMollweideView() {
       densityOverlay.refreshMollweide();
     }
   }
+  if (enableCloudDensityFilterFlag && cloudDensityOverlay) {
+    if (typeof cloudDensityOverlay.refreshMollweide === 'function') {
+      cloudDensityOverlay.refreshMollweide();
+    }
+  }
   if (showGalacticPlaneFlag && galacticPlaneMoll) {
     updateGalacticPlaneMollweide(galacticPlaneMoll);
     if (galacticDirectionLabelsMoll.length > 0) {
@@ -1303,6 +1318,9 @@ function registerMollweideEditableLines() {
   constellationLinesMoll.forEach(l => editableLines.push(l));
   if (densityOverlay && densityOverlay.adjacentLines) {
     densityOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
+  }
+  if (cloudDensityOverlay && cloudDensityOverlay.adjacentLines) {
+    cloudDensityOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
   }
   if (isolationOverlay && isolationOverlay.adjacentLines) {
     isolationOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -2,6 +2,10 @@
 // Manages the UI for the filter form.
 
 export function initFilterUI() {
+  // Insert cloud-related categories before binding events so elements exist.
+  addCloudsFieldset();
+  addCloudDensityFieldset();
+
   // Toggle sidebar menu on mobile.
   document.getElementById('menu-toggle').addEventListener('click', function () {
     document.querySelector('.sidebar').classList.toggle('open');
@@ -218,9 +222,6 @@ export function initFilterUI() {
     maxDistanceSlider.value = this.value;
   });
 
-  // Add Dust Clouds fieldset.
-  addCloudsFieldset();
-  addCloudDensityFieldset();
 
   // Fullscreen button listeners.
   document.querySelectorAll('.fullscreen-btn').forEach(btn => {

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -158,6 +158,47 @@ export function initFilterUI() {
     document.getElementById('star-name-opacity-value').textContent = this.value;
   });
 
+  const enableCloudDensityChk = document.getElementById('enable-cloud-density-filter');
+  const cloudDensitySlider = document.getElementById('cloud-density-slider');
+  const cloudDensityNumber = document.getElementById('cloud-density-number');
+  const cloudDensityTopSlider = document.getElementById('cloud-density-top-slider');
+  const cloudDensityTopNumber = document.getElementById('cloud-density-top-number');
+  const cloudDensityOpacitySlider = document.getElementById('cloud-density-opacity-slider');
+  const cloudDensityOpacityNumber = document.getElementById('cloud-density-opacity-number');
+  enableCloudDensityChk.addEventListener('change', function() {
+    const en = this.checked;
+    cloudDensitySlider.disabled = !en;
+    cloudDensityNumber.disabled = !en;
+    cloudDensityTopSlider.disabled = !en;
+    cloudDensityTopNumber.disabled = !en;
+    cloudDensityOpacitySlider.disabled = !en;
+    cloudDensityOpacityNumber.disabled = !en;
+  });
+  cloudDensitySlider.addEventListener('input', function(){
+    cloudDensityNumber.value = this.value;
+    document.getElementById('cloud-density-value').textContent = this.value;
+  });
+  cloudDensityNumber.addEventListener('input', function(){
+    cloudDensitySlider.value = this.value;
+    document.getElementById('cloud-density-value').textContent = this.value;
+  });
+  cloudDensityTopSlider.addEventListener('input', function(){
+    cloudDensityTopNumber.value = this.value;
+    document.getElementById('cloud-density-top-value').textContent = this.value;
+  });
+  cloudDensityTopNumber.addEventListener('input', function(){
+    cloudDensityTopSlider.value = this.value;
+    document.getElementById('cloud-density-top-value').textContent = this.value;
+  });
+  cloudDensityOpacitySlider.addEventListener('input', function(){
+    cloudDensityOpacityNumber.value = this.value;
+    document.getElementById('cloud-density-opacity-value').textContent = this.value;
+  });
+  cloudDensityOpacityNumber.addEventListener('input', function(){
+    cloudDensityOpacitySlider.value = this.value;
+    document.getElementById('cloud-density-opacity-value').textContent = this.value;
+  });
+
 
   // Distance slider sync.
   const minDistanceSlider = document.getElementById('min-distance-slider');
@@ -179,6 +220,7 @@ export function initFilterUI() {
 
   // Add Dust Clouds fieldset.
   addCloudsFieldset();
+  addCloudDensityFieldset();
 
   // Fullscreen button listeners.
   document.querySelectorAll('.fullscreen-btn').forEach(btn => {
@@ -316,6 +358,181 @@ function addCloudsFieldset() {
     opSpan.textContent = opNumber.value;
   });
   
+  fs.appendChild(contentDiv);
+  filterForm.appendChild(fs);
+}
+
+function addCloudDensityFieldset() {
+  const filterForm = document.getElementById('filters-form');
+  const fs = document.createElement('fieldset');
+  const legend = document.createElement('legend');
+  legend.classList.add('collapsible');
+  legend.textContent = 'Dust Density';
+  fs.appendChild(legend);
+  const contentDiv = document.createElement('div');
+  contentDiv.classList.add('filter-content', 'scrollable-category');
+  contentDiv.style.maxHeight = '0px';
+  legend.addEventListener('click', () => {
+    legend.classList.toggle('active');
+    const act = legend.classList.contains('active');
+    legend.setAttribute('aria-expanded', act);
+    if (act) {
+      setTimeout(() => { contentDiv.style.maxHeight = contentDiv.scrollHeight + 'px'; },0);
+      contentDiv.style.overflowY = 'auto';
+    } else {
+      contentDiv.style.maxHeight = '0px';
+      contentDiv.style.overflowY = 'hidden';
+    }
+  });
+  const dustClouds = [
+    { name: 'Aquila', file: 'data/Aquila_cloud_data.json' },
+    { name: 'Auriga', file: 'data/Auriga_cloud_data.json' },
+    { name: 'Blue', file: 'data/Blue_cloud_data.json' },
+    { name: 'Ceti', file: 'data/Ceti_cloud_data.json' },
+    { name: 'Dorado', file: 'data/Dorado_cloud_data.json' },
+    { name: 'Eridani', file: 'data/Eridani_cloud_data.json' },
+    { name: 'Galactic', file: 'data/Galactic_cloud_data.json' },
+    { name: 'Gemini', file: 'data/Gemini_cloud_data.json' },
+    { name: 'Hyades', file: 'data/Hyades_cloud_data.json' },
+    { name: 'Leo', file: 'data/Leo_cloud_data.json' },
+    { name: 'Local Interstellar', file: 'data/Local_interstellar_cloud.json' },
+    { name: 'Microscopi', file: 'data/Microscopi_cloud_data.json' },
+    { name: 'North Galactic Pole', file: 'data/North_Galactic_Pole_cloud_data.json' },
+    { name: 'Ophiucus', file: 'data/Ophiucus_cloud_data.json' },
+    { name: 'Vela', file: 'data/Vela_cloud_data.json' }
+  ];
+  dustClouds.forEach(cloud => {
+    const div = document.createElement('div');
+    div.classList.add('filter-item');
+    const chk = document.createElement('input');
+    chk.type = 'checkbox';
+    chk.id = 'dust-density-' + cloud.name.replace(/\s+/g,'-').toLowerCase();
+    chk.name = 'dust-density-clouds';
+    chk.value = cloud.file;
+    chk.checked = false;
+    const lbl = document.createElement('label');
+    lbl.htmlFor = chk.id;
+    lbl.textContent = cloud.name;
+    div.appendChild(chk);
+    div.appendChild(lbl);
+    contentDiv.appendChild(div);
+  });
+  const enableDiv = document.createElement('div');
+  enableDiv.classList.add('filter-item');
+  const enableChk = document.createElement('input');
+  enableChk.type = 'checkbox';
+  enableChk.id = 'enable-cloud-density-filter';
+  enableChk.name = 'enable-cloud-density-filter';
+  enableDiv.appendChild(enableChk);
+  const enableLbl = document.createElement('label');
+  enableLbl.htmlFor = 'enable-cloud-density-filter';
+  enableLbl.textContent = 'Enable Dust Density';
+  enableDiv.appendChild(enableLbl);
+  contentDiv.appendChild(enableDiv);
+  const radiusDiv = document.createElement('div');
+  radiusDiv.classList.add('filter-item');
+  const rLabel = document.createElement('label');
+  rLabel.htmlFor = 'cloud-density-slider';
+  rLabel.textContent = 'Radius (LY):';
+  const rSlider = document.createElement('input');
+  rSlider.type = 'range';
+  rSlider.id = 'cloud-density-slider';
+  rSlider.name = 'cloud-density';
+  rSlider.min = '1';
+  rSlider.max = '20';
+  rSlider.value = '10';
+  rSlider.step = '1';
+  const rNumber = document.createElement('input');
+  rNumber.type = 'number';
+  rNumber.id = 'cloud-density-number';
+  rNumber.name = 'cloud-density';
+  rNumber.min = '1';
+  rNumber.max = '20';
+  rNumber.value = '10';
+  rNumber.step = '1';
+  const rSpan = document.createElement('span');
+  rSpan.id = 'cloud-density-value';
+  rSpan.textContent = '10';
+  radiusDiv.appendChild(rLabel);
+  radiusDiv.appendChild(rSlider);
+  radiusDiv.appendChild(rNumber);
+  radiusDiv.appendChild(rSpan);
+  radiusDiv.appendChild(document.createTextNode(' LY'));
+  contentDiv.appendChild(radiusDiv);
+  const topDiv = document.createElement('div');
+  topDiv.classList.add('filter-item');
+  const tLabel = document.createElement('label');
+  tLabel.htmlFor = 'cloud-density-top-slider';
+  tLabel.textContent = 'Top Cells %:';
+  const tSlider = document.createElement('input');
+  tSlider.type = 'range';
+  tSlider.id = 'cloud-density-top-slider';
+  tSlider.name = 'cloud-density-top-percent';
+  tSlider.min = '1';
+  tSlider.max = '50';
+  tSlider.value = '10';
+  tSlider.step = '1';
+  const tNumber = document.createElement('input');
+  tNumber.type = 'number';
+  tNumber.id = 'cloud-density-top-number';
+  tNumber.name = 'cloud-density-top-percent';
+  tNumber.min = '1';
+  tNumber.max = '50';
+  tNumber.value = '10';
+  tNumber.step = '1';
+  const tSpan = document.createElement('span');
+  tSpan.id = 'cloud-density-top-value';
+  tSpan.textContent = '10';
+  topDiv.appendChild(tLabel);
+  topDiv.appendChild(tSlider);
+  topDiv.appendChild(tNumber);
+  topDiv.appendChild(tSpan);
+  topDiv.appendChild(document.createTextNode('%'));
+  contentDiv.appendChild(topDiv);
+  const opDiv = document.createElement('div');
+  opDiv.classList.add('filter-item');
+  const opLabel = document.createElement('label');
+  opLabel.htmlFor = 'cloud-density-opacity-slider';
+  opLabel.textContent = 'Overlay Opacity:';
+  const opSlider = document.createElement('input');
+  opSlider.type = 'range';
+  opSlider.id = 'cloud-density-opacity-slider';
+  opSlider.name = 'cloud-density-opacity';
+  opSlider.min = '0';
+  opSlider.max = '100';
+  opSlider.value = '100';
+  opSlider.step = '1';
+  const opNumber = document.createElement('input');
+  opNumber.type = 'number';
+  opNumber.id = 'cloud-density-opacity-number';
+  opNumber.name = 'cloud-density-opacity';
+  opNumber.min = '0';
+  opNumber.max = '100';
+  opNumber.value = '100';
+  opNumber.step = '1';
+  const opSpan = document.createElement('span');
+  opSpan.id = 'cloud-density-opacity-value';
+  opSpan.textContent = '100';
+  opDiv.appendChild(opLabel);
+  opDiv.appendChild(opSlider);
+  opDiv.appendChild(opNumber);
+  opDiv.appendChild(opSpan);
+  opDiv.appendChild(document.createTextNode('%'));
+  contentDiv.appendChild(opDiv);
+
+  enableChk.addEventListener('change', () => {
+    const en = enableChk.checked;
+    rSlider.disabled = !en; rNumber.disabled = !en;
+    tSlider.disabled = !en; tNumber.disabled = !en;
+    opSlider.disabled = !en; opNumber.disabled = !en;
+  });
+  rSlider.addEventListener('input', ()=>{rNumber.value=rSlider.value;rSpan.textContent=rSlider.value;});
+  rNumber.addEventListener('input', ()=>{rSlider.value=rNumber.value;rSpan.textContent=rNumber.value;});
+  tSlider.addEventListener('input', ()=>{tNumber.value=tSlider.value;tSpan.textContent=tSlider.value;});
+  tNumber.addEventListener('input', ()=>{tSlider.value=tNumber.value;tSpan.textContent=tNumber.value;});
+  opSlider.addEventListener('input', ()=>{opNumber.value=opSlider.value;opSpan.textContent=opSlider.value;});
+  opNumber.addEventListener('input', ()=>{opSlider.value=opNumber.value;opSpan.textContent=opNumber.value;});
+
   fs.appendChild(contentDiv);
   filterForm.appendChild(fs);
 }


### PR DESCRIPTION
## Summary
- create a new `cloudDensityFilter` overlay to display dust cloud densities
- export `uniqueColorFromName` utility
- integrate cloud density overlay into filter pipeline and UI
- update main script to handle new overlay
- add a new dust density category in filter UI

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a9483a314832abe0d61f0a3950a12