### PR TITLE
Improve star visuals and label styling

### DIFF
--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -177,12 +177,12 @@ export function createConstellationLabelsForGlobe(opacity = 0.8) {
     const baseFontSize = 300; // Very large base font size
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    ctx.font = `${baseFontSize}px Arial`;
+    ctx.font = `${baseFontSize}px Oswald`;
     const textWidth = ctx.measureText(c.name).width;
     canvas.width = textWidth + 20;
     canvas.height = baseFontSize * 1.2;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.font = `${baseFontSize}px Arial`;
+    ctx.font = `${baseFontSize}px Oswald`;
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);
@@ -239,12 +239,12 @@ export function createConstellationLabelsForMollweide(opacity = 0.8) {
     const baseFontSize = 300;
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    ctx.font = `${baseFontSize}px Arial`;
+    ctx.font = `${baseFontSize}px Oswald`;
     const textWidth = ctx.measureText(c.name).width;
     canvas.width = textWidth + 20;
     canvas.height = baseFontSize * 1.2;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.font = `${baseFontSize}px Arial`;
+    ctx.font = `${baseFontSize}px Oswald`;
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -244,11 +244,11 @@ export function updateCelestialEquatorMollweide(line) {
 function createTextSprite(text, color = '#ffffff', opacity = 0.8, fontSize = 150) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
-  ctx.font = `${fontSize}px Arial`;
+  ctx.font = `${fontSize}px Oswald`;
   const textWidth = ctx.measureText(text).width;
   canvas.width = textWidth + 20;
   canvas.height = fontSize * 1.2;
-  ctx.font = `${fontSize}px Arial`;
+  ctx.font = `${fontSize}px Oswald`;
   ctx.fillStyle = color;
   ctx.fillText(text, 10, fontSize);
   const texture = new THREE.CanvasTexture(canvas);
@@ -262,11 +262,11 @@ function createTextSprite(text, color = '#ffffff', opacity = 0.8, fontSize = 150
 function createTextPlane(text, color = '#ffffff', opacity = 0.8, fontSize = 150) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
-  ctx.font = `${fontSize}px Arial`;
+  ctx.font = `${fontSize}px Oswald`;
   const textWidth = ctx.measureText(text).width;
   canvas.width = textWidth + 20;
   canvas.height = fontSize * 1.2;
-  ctx.font = `${fontSize}px Arial`;
+  ctx.font = `${fontSize}px Oswald`;
   ctx.fillStyle = color;
   ctx.fillText(text, 10, fontSize);
   const texture = new THREE.CanvasTexture(canvas);

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Starmap Visualization</title>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/labelManager.js
+++ b/labelManager.js
@@ -3,6 +3,23 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { hexToRGBA } from './utils.js';
 
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return { r, g, b };
+}
+
+function mixWithWhite(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  const nr = Math.round((r + 255) / 2);
+  const ng = Math.round((g + 255) / 2);
+  const nb = Math.round((b + 255) / 2);
+  return `rgb(${nr}, ${ng}, ${nb})`;
+}
+
 /**
  * Returns a ShaderMaterial that renders a texture double‑sided without mirroring.
  */
@@ -95,7 +112,7 @@ export class LabelManager {
 
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      ctx.font = `${fontSize}px Arial`;
+      ctx.font = `${fontSize}px Oswald`;
 
       const textMetrics = ctx.measureText(displayName);
       const textWidth = textMetrics.width;
@@ -106,10 +123,13 @@ export class LabelManager {
       canvas.height = textHeight + paddingY * 2;
 
       // Draw background rectangle (semi-transparent) and text
-      ctx.font = `${fontSize}px Arial`;
-      ctx.fillStyle = hexToRGBA(starColor, 0.05);
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = '#ffffff';
+      ctx.font = `${fontSize}px Oswald`;
+      if (this.mapType !== 'Mollweide') {
+        ctx.fillStyle = hexToRGBA(starColor, 0.05);
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      }
+      const labelColor = mixWithWhite(starColor);
+      ctx.fillStyle = labelColor;
       ctx.textBaseline = 'middle';
       ctx.fillText(displayName, paddingX, canvas.height / 2);
 

--- a/script.js
+++ b/script.js
@@ -35,6 +35,31 @@ import { showTooltip, hideTooltip } from './tooltips.js';
 import { cachedRadToSphere, cachedRadToMollweide, degToRad, setMollweideLambda0, getMollweideLambda0 } from './utils/geometryUtils.js';
 import { minimalRADifference } from './utils.js';
 
+function createStarTexture() {
+  const size = 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createRadialGradient(
+    size / 2,
+    size / 2,
+    0,
+    size / 2,
+    size / 2,
+    size / 2
+  );
+  gradient.addColorStop(0, 'rgba(255,255,255,1)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+const starTexture = createStarTexture();
+
 let cachedStars = null;
 let currentFilteredStars = [];
 let currentConnections = [];
@@ -783,9 +808,12 @@ class MapManager {
       }
       baseGeometry.setAttribute('color', new THREE.BufferAttribute(dummyColors, 3));
       const material = new THREE.MeshBasicMaterial({
+        map: starTexture,
         color: 0xffffff,
         transparent: true,
         opacity: this.starOpacity,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
         vertexColors: true
       });
       this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);

--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ import { cachedRadToSphere, cachedRadToMollweide, degToRad, setMollweideLambda0,
 import { minimalRADifference } from './utils.js';
 
 function createStarTexture() {
-  const size = 64;
+  const size = 128;
   const canvas = document.createElement('canvas');
   canvas.width = size;
   canvas.height = size;
@@ -50,11 +50,15 @@ function createStarTexture() {
     size / 2
   );
   gradient.addColorStop(0, 'rgba(255,255,255,1)');
+  gradient.addColorStop(0.2, 'rgba(255,255,255,0.8)');
+  gradient.addColorStop(0.4, 'rgba(255,255,255,0.4)');
   gradient.addColorStop(1, 'rgba(255,255,255,0)');
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, size, size);
   const texture = new THREE.CanvasTexture(canvas);
   texture.needsUpdate = true;
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
   return texture;
 }
 

--- a/script.js
+++ b/script.js
@@ -49,9 +49,11 @@ function createStarTexture() {
     size / 2,
     size / 2
   );
+  // Highest opacity at the center fading smoothly outward
   gradient.addColorStop(0, 'rgba(255,255,255,1)');
-  gradient.addColorStop(0.2, 'rgba(255,255,255,0.8)');
-  gradient.addColorStop(0.4, 'rgba(255,255,255,0.4)');
+  gradient.addColorStop(0.1, 'rgba(255,255,255,0.9)');
+  gradient.addColorStop(0.3, 'rgba(255,255,255,0.6)');
+  gradient.addColorStop(0.6, 'rgba(255,255,255,0.2)');
   gradient.addColorStop(1, 'rgba(255,255,255,0)');
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, size, size);

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
 
 /* Body, Loader */
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-family: 'Oswald', sans-serif;
   background-color: #0d0d0d;
   color: #e0e0e0;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- import Oswald font and use it globally
- change all canvas text drawing to Oswald font
- lighten label text and remove background on Mollweide map
- add glowing star texture for all star meshes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6855be237ba0832aa0b981203447bb3b