### PR TITLE
Add glow effect for stars

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,30 @@ import { showTooltip, hideTooltip } from './tooltips.js';
 import { cachedRadToSphere, cachedRadToMollweide, degToRad, setMollweideLambda0, getMollweideLambda0 } from './utils/geometryUtils.js';
 import { minimalRADifference } from './utils.js';
 
+// Pre-generate a radial gradient texture used to give stars a soft glow.
+function createStarGlowTexture(size = 64) {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createRadialGradient(
+    size / 2,
+    size / 2,
+    0,
+    size / 2,
+    size / 2,
+    size / 2
+  );
+  gradient.addColorStop(0, 'rgba(255,255,255,1)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+const STAR_GLOW_TEXTURE = createStarGlowTexture();
+
 let cachedStars = null;
 let currentFilteredStars = [];
 let currentConnections = [];
@@ -786,7 +810,10 @@ class MapManager {
         color: 0xffffff,
         transparent: true,
         opacity: this.starOpacity,
-        vertexColors: true
+        vertexColors: true,
+        depthWrite: false,
+        alphaMap: STAR_GLOW_TEXTURE,
+        blending: THREE.AdditiveBlending
       });
       this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
       this.instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);


### PR DESCRIPTION
## Summary
- pre-generate a radial gradient texture
- use the gradient as an alpha map when creating star materials

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6855c829fd6c832abf20221be3c47890