### PR TITLE
Enhance star rendering with glowing sprites

### DIFF
--- a/script.js
+++ b/script.js
@@ -701,24 +701,28 @@ function createStarTexture() {
   return texture;
 }
 
-function createStarMaterial(texture, opacity, sizeAttenuation) {
+function createStarMaterial(texture, opacity, sizeAttenuation, cameraZoom) {
   return new THREE.ShaderMaterial({
     uniforms: {
       map: { value: texture },
       opacity: { value: opacity },
-      sizeAttenuation: { value: sizeAttenuation ? 1.0 : 0.0 }
+      sizeAttenuation: { value: sizeAttenuation ? 1.0 : 0.0 },
+      cameraZoom: { value: cameraZoom }
     },
     vertexShader: `
       attribute float size;
       attribute vec3 customColor;
       varying vec3 vColor;
       uniform float sizeAttenuation;
+      uniform float cameraZoom;
       void main() {
         vColor = customColor;
         vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
         float s = size;
         if (sizeAttenuation > 0.5) {
           s *= 300.0 / -mvPosition.z;
+        } else {
+          s *= cameraZoom;
         }
         gl_PointSize = s;
         gl_Position = projectionMatrix * mvPosition;
@@ -838,7 +842,13 @@ class MapManager {
     geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
 
     const texture = createStarTexture();
-    const material = createStarMaterial(texture, this.starOpacity, !this.camera.isOrthographicCamera);
+    const zoomVal = this.camera.isOrthographicCamera ? this.camera.zoom : 1.0;
+    const material = createStarMaterial(
+      texture,
+      this.starOpacity,
+      !this.camera.isOrthographicCamera,
+      zoomVal
+    );
 
     this.points = new THREE.Points(geometry, material);
     this.starGroup.add(this.points);
@@ -954,12 +964,20 @@ class MapManager {
       this.camera.aspect = w / h;
     }
     this.camera.updateProjectionMatrix();
+    if (this.points && this.points.material.uniforms.cameraZoom) {
+      const zoomVal = this.camera.isOrthographicCamera ? this.camera.zoom : 1.0;
+      this.points.material.uniforms.cameraZoom.value = zoomVal;
+    }
     this.renderer.setSize(w, h);
     if (window.requestRender) window.requestRender();
   }
 
   render() {
     if (!this.canvas.isConnected) return;
+    if (this.points && this.points.material.uniforms.cameraZoom) {
+      const zoomVal = this.camera.isOrthographicCamera ? this.camera.zoom : 1.0;
+      this.points.material.uniforms.cameraZoom.value = zoomVal;
+    }
     this.renderer.render(this.scene, this.camera);
   }
 }

--- a/script.js
+++ b/script.js
@@ -684,6 +684,63 @@ function applyGlobeSurface(isOpaque) {
   }
 }
 
+function createStarTexture() {
+  const size = 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  gradient.addColorStop(0, 'rgba(255,255,255,1)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  return texture;
+}
+
+function createStarMaterial(texture, opacity, sizeAttenuation) {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      map: { value: texture },
+      opacity: { value: opacity },
+      sizeAttenuation: { value: sizeAttenuation ? 1.0 : 0.0 }
+    },
+    vertexShader: `
+      attribute float size;
+      attribute vec3 customColor;
+      varying vec3 vColor;
+      uniform float sizeAttenuation;
+      void main() {
+        vColor = customColor;
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        float s = size;
+        if (sizeAttenuation > 0.5) {
+          s *= 300.0 / -mvPosition.z;
+        }
+        gl_PointSize = s;
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `,
+    fragmentShader: `
+      uniform sampler2D map;
+      uniform float opacity;
+      varying vec3 vColor;
+      void main() {
+        vec4 tex = texture2D(map, gl_PointCoord);
+        vec3 col = vColor * tex.a;
+        gl_FragColor = vec4(col, tex.a * opacity);
+        if (gl_FragColor.a < 0.01) discard;
+      }
+    `,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending
+  });
+}
+
 class MapManager {
   constructor({ canvasId, mapType }) {
     this.canvas = document.getElementById(canvasId);
@@ -762,43 +819,37 @@ class MapManager {
 
   addStars(stars) {
     const count = stars.length;
-    if (!this.instancedMesh || this.instancedMesh.count !== count) {
-      while (this.starGroup.children.length > 0) {
-        const child = this.starGroup.children[0];
-        this.starGroup.remove(child);
-        if (child.geometry) child.geometry.dispose();
-        if (child.material) child.material.dispose();
-      }
-      if (count === 0) {
-        this.instancedMesh = null;
-        return;
-      }
-      const baseGeometry = new THREE.SphereGeometry(1, 12, 12);
-      const vertexCount = baseGeometry.attributes.position.count;
-      const dummyColors = new Float32Array(vertexCount * 3);
-      for (let i = 0; i < vertexCount; i++) {
-        dummyColors[i * 3] = 1;
-        dummyColors[i * 3 + 1] = 1;
-        dummyColors[i * 3 + 2] = 1;
-      }
-      baseGeometry.setAttribute('color', new THREE.BufferAttribute(dummyColors, 3));
-      const material = new THREE.MeshBasicMaterial({
-        color: 0xffffff,
-        transparent: true,
-        opacity: this.starOpacity,
-        vertexColors: true
-      });
-      this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
-      this.instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);
-      this.starGroup.add(this.instancedMesh);
+    while (this.starGroup.children.length > 0) {
+      const child = this.starGroup.children[0];
+      this.starGroup.remove(child);
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) child.material.dispose();
     }
+    if (count === 0) {
+      this.points = null;
+      return;
+    }
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    const sizes = new Float32Array(count);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('customColor', new THREE.BufferAttribute(colors, 3));
+    geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+
+    const texture = createStarTexture();
+    const material = createStarMaterial(texture, this.starOpacity, !this.camera.isOrthographicCamera);
+
+    this.points = new THREE.Points(geometry, material);
+    this.starGroup.add(this.points);
     this.updateStarPositions(stars);
   }
 
   updateStarPositions(stars) {
-    if (!this.instancedMesh) return;
-    const dummy = new THREE.Object3D();
-    const colors = this.instancedMesh.instanceColor.array;
+    if (!this.points) return;
+    const positions = this.points.geometry.attributes.position.array;
+    const colors = this.points.geometry.attributes.customColor.array;
+    const sizes = this.points.geometry.attributes.size.array;
     for (let i = 0; i < stars.length; i++) {
       const star = stars[i];
       let pos;
@@ -811,18 +862,19 @@ class MapManager {
       }
       const size = star.displaySize !== undefined ? star.displaySize : 1;
       const baseScale = this.mapType === 'Mollweide' ? 0.4 : 0.2;
-      const scale = size * baseScale;
-      dummy.position.copy(pos);
-      dummy.scale.set(scale, scale, scale);
-      dummy.updateMatrix();
-      this.instancedMesh.setMatrixAt(i, dummy.matrix);
+      const scale = size * baseScale * 25.0;
+      positions[i * 3] = pos.x;
+      positions[i * 3 + 1] = pos.y;
+      positions[i * 3 + 2] = pos.z;
+      sizes[i] = scale;
       const color = new THREE.Color(star.displayColor || '#ffffff');
       colors[i * 3] = color.r;
       colors[i * 3 + 1] = color.g;
       colors[i * 3 + 2] = color.b;
     }
-    this.instancedMesh.instanceMatrix.needsUpdate = true;
-    this.instancedMesh.instanceColor.needsUpdate = true;
+    this.points.geometry.attributes.position.needsUpdate = true;
+    this.points.geometry.attributes.customColor.needsUpdate = true;
+    this.points.geometry.attributes.size.needsUpdate = true;
     this.starObjects = stars;
     if (window.requestRender) window.requestRender();
   }
@@ -861,9 +913,9 @@ class MapManager {
 
   setStarOpacity(opacity) {
     this.starOpacity = opacity;
-    if (this.instancedMesh) {
-      this.instancedMesh.material.opacity = opacity;
-      this.instancedMesh.material.needsUpdate = true;
+    if (this.points) {
+      this.points.material.uniforms.opacity.value = opacity;
+      this.points.material.needsUpdate = true;
     }
   }
 
@@ -970,7 +1022,9 @@ function initStarInteractions(map) {
     if (intersects.length > 0) {
       const intersect = intersects[0];
       let index;
-      if (intersect.object instanceof THREE.InstancedMesh) {
+      if (intersect.object instanceof THREE.Points) {
+        index = intersect.index;
+      } else if (intersect.object instanceof THREE.InstancedMesh) {
         index = intersect.instanceId;
       } else {
         index = map.starGroup.children.indexOf(intersect.object);
@@ -1001,7 +1055,9 @@ function initStarInteractions(map) {
     if (intersects.length > 0) {
       const intersect = intersects[0];
       let index;
-      if (intersect.object instanceof THREE.InstancedMesh) {
+      if (intersect.object instanceof THREE.Points) {
+        index = intersect.index;
+      } else if (intersect.object instanceof THREE.InstancedMesh) {
         index = intersect.instanceId;
       } else {
         index = map.starGroup.children.indexOf(intersect.object);

--- a/script.js
+++ b/script.js
@@ -759,6 +759,8 @@ class MapManager {
     this.starOpacity = 1.0;
     this.connectionOpacity = 0.5;
     this.labelOpacity = 1.0;
+    this.points = null;
+    this.instancedMesh = null;
     if (mapType === 'Mollweide') {
       const aspect = this.canvas.clientWidth / this.canvas.clientHeight;
       // Use a larger frustum so the entire Mollweide projection fits on screen
@@ -823,68 +825,131 @@ class MapManager {
 
   addStars(stars) {
     const count = stars.length;
-    while (this.starGroup.children.length > 0) {
-      const child = this.starGroup.children[0];
-      this.starGroup.remove(child);
-      if (child.geometry) child.geometry.dispose();
-      if (child.material) child.material.dispose();
+    if (this.mapType === 'Mollweide') {
+      if (!this.points || this.points.geometry.getAttribute('position').count !== count) {
+        while (this.starGroup.children.length > 0) {
+          const child = this.starGroup.children[0];
+          this.starGroup.remove(child);
+          if (child.geometry) child.geometry.dispose();
+          if (child.material) child.material.dispose();
+        }
+        if (count === 0) {
+          this.points = null;
+          return;
+        }
+        const positions = new Float32Array(count * 3);
+        const colors = new Float32Array(count * 3);
+        const sizes = new Float32Array(count);
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.setAttribute('customColor', new THREE.BufferAttribute(colors, 3));
+        geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+        const texture = createStarTexture();
+        const zoomVal = this.camera.isOrthographicCamera ? this.camera.zoom : 1.0;
+        const material = createStarMaterial(
+          texture,
+          this.starOpacity,
+          !this.camera.isOrthographicCamera,
+          zoomVal
+        );
+        this.points = new THREE.Points(geometry, material);
+        this.starGroup.add(this.points);
+      }
+    } else {
+      if (!this.instancedMesh || this.instancedMesh.count !== count) {
+        while (this.starGroup.children.length > 0) {
+          const child = this.starGroup.children[0];
+          this.starGroup.remove(child);
+          if (child.geometry) child.geometry.dispose();
+          if (child.material) child.material.dispose();
+        }
+        if (count === 0) {
+          this.instancedMesh = null;
+          return;
+        }
+        const baseGeometry = new THREE.SphereGeometry(1, 12, 12);
+        const vertexCount = baseGeometry.attributes.position.count;
+        const dummyColors = new Float32Array(vertexCount * 3);
+        for (let i = 0; i < vertexCount; i++) {
+          dummyColors[i * 3] = 1;
+          dummyColors[i * 3 + 1] = 1;
+          dummyColors[i * 3 + 2] = 1;
+        }
+        baseGeometry.setAttribute('color', new THREE.BufferAttribute(dummyColors, 3));
+        const material = new THREE.MeshBasicMaterial({
+          color: 0xffffff,
+          transparent: true,
+          opacity: this.starOpacity,
+          vertexColors: true
+        });
+        this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
+        this.instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);
+        this.starGroup.add(this.instancedMesh);
+      }
     }
-    if (count === 0) {
-      this.points = null;
-      return;
-    }
-    const positions = new Float32Array(count * 3);
-    const colors = new Float32Array(count * 3);
-    const sizes = new Float32Array(count);
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geometry.setAttribute('customColor', new THREE.BufferAttribute(colors, 3));
-    geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
-
-    const texture = createStarTexture();
-    const zoomVal = this.camera.isOrthographicCamera ? this.camera.zoom : 1.0;
-    const material = createStarMaterial(
-      texture,
-      this.starOpacity,
-      !this.camera.isOrthographicCamera,
-      zoomVal
-    );
-
-    this.points = new THREE.Points(geometry, material);
-    this.starGroup.add(this.points);
     this.updateStarPositions(stars);
   }
 
   updateStarPositions(stars) {
-    if (!this.points) return;
-    const positions = this.points.geometry.attributes.position.array;
-    const colors = this.points.geometry.attributes.customColor.array;
-    const sizes = this.points.geometry.attributes.size.array;
-    for (let i = 0; i < stars.length; i++) {
-      const star = stars[i];
-      let pos;
-      if (this.mapType === 'TrueCoordinates') {
-        pos = star.truePosition ? star.truePosition.clone() : new THREE.Vector3(star.x_coordinate, star.y_coordinate, star.z_coordinate);
-      } else if (this.mapType === 'Globe') {
-        pos = star.spherePosition ? star.spherePosition.clone() : new THREE.Vector3(0, 0, 0);
-      } else {
-        pos = star.mollweidePosition ? star.mollweidePosition.clone() : new THREE.Vector3(0, 0, 0);
+    if (this.mapType === 'Mollweide') {
+      if (!this.points) return;
+      const positions = this.points.geometry.attributes.position.array;
+      const colors = this.points.geometry.attributes.customColor.array;
+      const sizes = this.points.geometry.attributes.size.array;
+      for (let i = 0; i < stars.length; i++) {
+        const star = stars[i];
+        let pos;
+        if (this.mapType === 'TrueCoordinates') {
+          pos = star.truePosition ? star.truePosition.clone() : new THREE.Vector3(star.x_coordinate, star.y_coordinate, star.z_coordinate);
+        } else if (this.mapType === 'Globe') {
+          pos = star.spherePosition ? star.spherePosition.clone() : new THREE.Vector3(0, 0, 0);
+        } else {
+          pos = star.mollweidePosition ? star.mollweidePosition.clone() : new THREE.Vector3(0, 0, 0);
+        }
+        const size = star.displaySize !== undefined ? star.displaySize : 1;
+        const baseScale = this.mapType === 'Mollweide' ? 0.4 : 0.2;
+        const scale = size * baseScale * 25.0;
+        positions[i * 3] = pos.x;
+        positions[i * 3 + 1] = pos.y;
+        positions[i * 3 + 2] = pos.z;
+        sizes[i] = scale;
+        const color = new THREE.Color(star.displayColor || '#ffffff');
+        colors[i * 3] = color.r;
+        colors[i * 3 + 1] = color.g;
+        colors[i * 3 + 2] = color.b;
       }
-      const size = star.displaySize !== undefined ? star.displaySize : 1;
-      const baseScale = this.mapType === 'Mollweide' ? 0.4 : 0.2;
-      const scale = size * baseScale * 25.0;
-      positions[i * 3] = pos.x;
-      positions[i * 3 + 1] = pos.y;
-      positions[i * 3 + 2] = pos.z;
-      sizes[i] = scale;
-      const color = new THREE.Color(star.displayColor || '#ffffff');
-      colors[i * 3] = color.r;
-      colors[i * 3 + 1] = color.g;
-      colors[i * 3 + 2] = color.b;
+      this.points.geometry.attributes.position.needsUpdate = true;
+      this.points.geometry.attributes.customColor.needsUpdate = true;
+      this.points.geometry.attributes.size.needsUpdate = true;
+    } else {
+      if (!this.instancedMesh) return;
+      const dummy = new THREE.Object3D();
+      const colors = this.instancedMesh.instanceColor.array;
+      for (let i = 0; i < stars.length; i++) {
+        const star = stars[i];
+        let pos;
+        if (this.mapType === 'TrueCoordinates') {
+          pos = star.truePosition ? star.truePosition.clone() : new THREE.Vector3(star.x_coordinate, star.y_coordinate, star.z_coordinate);
+        } else if (this.mapType === 'Globe') {
+          pos = star.spherePosition ? star.spherePosition.clone() : new THREE.Vector3(0, 0, 0);
+        } else {
+          pos = star.mollweidePosition ? star.mollweidePosition.clone() : new THREE.Vector3(0, 0, 0);
+        }
+        const size = star.displaySize !== undefined ? star.displaySize : 1;
+        const baseScale = 0.2;
+        const scale = size * baseScale;
+        dummy.position.copy(pos);
+        dummy.scale.set(scale, scale, scale);
+        dummy.updateMatrix();
+        this.instancedMesh.setMatrixAt(i, dummy.matrix);
+        const color = new THREE.Color(star.displayColor || '#ffffff');
+        colors[i * 3] = color.r;
+        colors[i * 3 + 1] = color.g;
+        colors[i * 3 + 2] = color.b;
+      }
+      this.instancedMesh.instanceMatrix.needsUpdate = true;
+      this.instancedMesh.instanceColor.needsUpdate = true;
     }
-    this.points.geometry.attributes.position.needsUpdate = true;
-    this.points.geometry.attributes.customColor.needsUpdate = true;
-    this.points.geometry.attributes.size.needsUpdate = true;
     this.starObjects = stars;
     if (window.requestRender) window.requestRender();
   }
@@ -923,9 +988,14 @@ class MapManager {
 
   setStarOpacity(opacity) {
     this.starOpacity = opacity;
-    if (this.points) {
-      this.points.material.uniforms.opacity.value = opacity;
-      this.points.material.needsUpdate = true;
+    if (this.mapType === 'Mollweide') {
+      if (this.points) {
+        this.points.material.uniforms.opacity.value = opacity;
+        this.points.material.needsUpdate = true;
+      }
+    } else if (this.instancedMesh) {
+      this.instancedMesh.material.opacity = opacity;
+      this.instancedMesh.material.needsUpdate = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- add shader-based sprite material for stars
- render stars as `THREE.Points` with per-star size and color
- update raycasting logic for new Points objects

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6855cb30db98832aaa1e3eaa1a1a65b7