### PR TITLE
Add old map style option for density filter

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -75,6 +75,12 @@ class DensityGridOverlay {
     this.maxDensity = 0;
     this.mollLineWidth = 30; // width of connection lines on the Mollweide map
     this.opacityFactor = 1.0;
+    this.style = 'default';
+    this.minAlpha = 0.05; // minimum opacity for old map style
+  }
+
+  setStyle(newStyle) {
+    this.style = newStyle === 'old' ? 'old' : 'default';
   }
 
   createGrid(stars) {
@@ -280,30 +286,68 @@ class DensityGridOverlay {
       const scale = THREE.MathUtils.lerp(20.0, 0.1, Math.min(1, ratio));
       let color = new THREE.Color(0xffffff);
       let alpha = 0;
-      if (cell.density <= bottomThr) {
-        const t = bottomThr === minD ? 0 : (cell.density - minD) / (bottomThr - minD);
-        color = new THREE.Color(0x0000ff).lerp(new THREE.Color(0xffffff), t);
-        alpha = 0.5 * (1 - t);
-        cell.active = true;
-      } else if (cell.density >= topThr) {
-        const t = topThr === maxD ? 0 : (cell.density - topThr) / (maxD - topThr);
-        const baseRed = new THREE.Color(0xff0000);
-        const lightRed = lightenColor(baseRed.clone(), 0.4);
-        color = lightRed.lerp(baseRed, t);
-        alpha = 0.5 * t;
-        cell.active = true;
+
+      if (this.style === 'old') {
+        const bottomCol = new THREE.Color(0xcad2d1); // light blueish beige
+        const topCol = new THREE.Color(0xbfa77a);   // darkish beige
+        const midCol = new THREE.Color(0xf5f1e3);   // whitish beige
+
+        if (cell.density <= bottomThr) {
+          const t = bottomThr === minD ? 0 : (cell.density - minD) / (bottomThr - minD);
+          color = bottomCol;
+          alpha = 0.5 * (1 - t);
+          cell.active = true;
+        } else if (cell.density >= topThr) {
+          const t = topThr === maxD ? 0 : (cell.density - topThr) / (maxD - topThr);
+          color = topCol;
+          alpha = 0.5 * t;
+          cell.active = true;
+        } else {
+          color = midCol;
+          alpha = 0.125;
+          cell.active = true;
+        }
+
+        let finalAlpha;
+        if (color.equals(midCol)) {
+          finalAlpha = Math.max(this.minAlpha / 4, alpha * this.opacityFactor);
+        } else {
+          finalAlpha = Math.max(this.minAlpha, alpha * this.opacityFactor);
+        }
+        cell.tcMesh.material.opacity = finalAlpha;
+        cell.globeMesh.material.opacity = finalAlpha;
+        cell.mollweideMesh.material.opacity = finalAlpha;
+        cell.tcMesh.material.color.copy(color);
+        cell.globeMesh.material.color.copy(color);
+        cell.mollweideMesh.material.color.copy(color);
+        cell.tcMesh.visible = true;
       } else {
-        cell.active = false;
+        if (cell.density <= bottomThr) {
+          const t = bottomThr === minD ? 0 : (cell.density - minD) / (bottomThr - minD);
+          color = new THREE.Color(0x0000ff).lerp(new THREE.Color(0xffffff), t);
+          alpha = 0.5 * (1 - t);
+          cell.active = true;
+        } else if (cell.density >= topThr) {
+          const t = topThr === maxD ? 0 : (cell.density - topThr) / (maxD - topThr);
+          const baseRed = new THREE.Color(0xff0000);
+          const lightRed = lightenColor(baseRed.clone(), 0.4);
+          color = lightRed.lerp(baseRed, t);
+          alpha = 0.5 * t;
+          cell.active = true;
+        } else {
+          cell.active = false;
+        }
+
+        const finalAlpha = alpha * this.opacityFactor;
+        cell.tcMesh.material.opacity = finalAlpha;
+        cell.globeMesh.material.opacity = finalAlpha;
+        cell.mollweideMesh.material.opacity = finalAlpha;
+        cell.tcMesh.material.color.copy(color);
+        cell.globeMesh.material.color.copy(color);
+        cell.mollweideMesh.material.color.copy(color);
+        cell.tcMesh.visible = cell.active;
       }
 
-      const finalAlpha = alpha * this.opacityFactor;
-      cell.tcMesh.material.opacity = finalAlpha;
-      cell.globeMesh.material.opacity = finalAlpha;
-      cell.mollweideMesh.material.opacity = finalAlpha;
-      cell.tcMesh.material.color.copy(color);
-      cell.globeMesh.material.color.copy(color);
-      cell.mollweideMesh.material.color.copy(color);
-      cell.tcMesh.visible = cell.active;
       cell.globeMesh.scale.set(scale, scale, 1);
       cell.mollweideMesh.scale.set(scale, scale, 1);
     });

--- a/index.html
+++ b/index.html
@@ -238,6 +238,9 @@
               <input type="number" id="density-opacity-number" name="density-opacity" min="0" max="100" value="100" step="1" disabled />
               <span id="density-opacity-value">100</span>%
             </div>
+            <div class="filter-item">
+              <button type="button" id="density-style-btn">Switch to Old Map Style</button>
+            </div>
           </div>
         </fieldset>
         <!-- Save Presets Fieldset -->

--- a/script.js
+++ b/script.js
@@ -444,6 +444,7 @@ async function buildAndApplyFilters() {
   // store overlay references for external refresh calls
   isolationOverlay = returnedIsolationOverlay;
   densityOverlay = returnedDensityOverlay;
+  window.densityOverlay = densityOverlay;
 
   currentFilteredStars = filteredStars;
   currentConnections = connections;
@@ -1924,6 +1925,7 @@ async function main() {
   loader.classList.remove('hidden');
   try {
     cachedStars = await loadStarData();
+    window.cachedStars = cachedStars;
     if (!cachedStars.length) throw new Error('No star data available');
     await setupFilterUI(cachedStars);
     const form = document.getElementById('filters-form');

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -81,6 +81,8 @@ export function initFilterUI() {
   const densityGridNumber = document.getElementById('density-grid-number');
   const densityOpacitySlider = document.getElementById('density-opacity-slider');
   const densityOpacityNumber = document.getElementById('density-opacity-number');
+  const densityStyleBtn = document.getElementById('density-style-btn');
+  if (densityStyleBtn) densityStyleBtn.dataset.style = 'default';
   const starOpacitySlider = document.getElementById('star-opacity-slider');
   const starOpacityNumber = document.getElementById('star-opacity-number');
   const starNameOpacitySlider = document.getElementById('star-name-opacity-slider');
@@ -139,6 +141,19 @@ export function initFilterUI() {
   densityOpacityNumber.addEventListener('input', function () {
     densityOpacitySlider.value = this.value;
     document.getElementById('density-opacity-value').textContent = this.value;
+  });
+
+  densityStyleBtn.addEventListener('click', function () {
+    const old = this.dataset.style === 'old';
+    const newStyle = old ? 'default' : 'old';
+    this.dataset.style = newStyle;
+    this.textContent = newStyle === 'old' ? 'Switch to Default Style' : 'Switch to Old Map Style';
+    if (window.densityOverlay && typeof window.densityOverlay.setStyle === 'function') {
+      window.densityOverlay.setStyle(newStyle);
+      if (window.cachedStars) {
+        window.densityOverlay.update(window.cachedStars, window.trueCoordinatesMap.scene, window.globeMap.scene, window.mollweideMap.scene);
+      }
+    }
   });
 
   starOpacitySlider.addEventListener('input', function () {


### PR DESCRIPTION
## Summary
- add new "Switch to Old Map Style" button for density filter
- store density overlay globally and expose loaded stars
- support style toggling in the UI
- implement old map color/opacity rules in density filter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855dfe042c8832aa1095416b1d1d6ab