### PR TITLE
Add export area selection and PDF support

### DIFF
--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -22,9 +22,12 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float centerFade;
       varying float vSide;
+      varying float vCenterFade;
       void main() {
         vSide = side;
+        vCenterFade = centerFade;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +35,11 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vCenterFade;
       void main() {
-        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        float alphaSide = 1.0 - abs(vSide);
+        float alphaCenter = 1.0 - vCenterFade;
+        float alpha = 0.5 * alphaSide * alphaCenter * opacityFactor;
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,9 +50,19 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const centerFades = [];
+
+  let totalLength = 0;
+  for (let i = 0; i < points.length; i += 2) {
+    totalLength += points[i].distanceTo(points[i + 1]);
+  }
+  let accLength = 0;
+  const halfLength = totalLength / 2;
+
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
+    const segLen = p1.distanceTo(p2);
     const dir = new THREE.Vector2(p2.x - p1.x, p2.y - p1.y).normalize();
     const perp = new THREE.Vector2(-dir.y, dir.x).multiplyScalar(width / 2);
     const a1 = new THREE.Vector3(p1.x + perp.x, p1.y + perp.y, p1.z);
@@ -54,14 +70,23 @@ function buildWideLineGeometry(points, width) {
     const b1 = new THREE.Vector3(p2.x + perp.x, p2.y + perp.y, p2.z);
     const b2 = new THREE.Vector3(p2.x - perp.x, p2.y - perp.y, p2.z);
 
+    const startFade = Math.abs(accLength - halfLength) / halfLength;
+    const endFade = Math.abs(accLength + segLen - halfLength) / halfLength;
+
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    centerFades.push(startFade, startFade, endFade);
+
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    centerFades.push(startFade, endFade, endFade);
+
+    accLength += segLen;
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('centerFade', new THREE.Float32BufferAttribute(centerFades, 1));
   return geom;
 }
 

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -22,9 +22,12 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float centerFade;
       varying float vSide;
+      varying float vCenterFade;
       void main() {
         vSide = side;
+        vCenterFade = centerFade;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +35,11 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vCenterFade;
       void main() {
-        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        float alphaSide = 1.0 - abs(vSide);
+        float alphaCenter = 1.0 - vCenterFade;
+        float alpha = 0.5 * alphaSide * alphaCenter * opacityFactor;
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,9 +50,19 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const centerFades = [];
+
+  let totalLength = 0;
+  for (let i = 0; i < points.length; i += 2) {
+    totalLength += points[i].distanceTo(points[i + 1]);
+  }
+  let accLength = 0;
+  const halfLength = totalLength / 2;
+
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
+    const segLen = p1.distanceTo(p2);
     const dir = new THREE.Vector2(p2.x - p1.x, p2.y - p1.y).normalize();
     const perp = new THREE.Vector2(-dir.y, dir.x).multiplyScalar(width / 2);
     const a1 = new THREE.Vector3(p1.x + perp.x, p1.y + perp.y, p1.z);
@@ -54,14 +70,23 @@ function buildWideLineGeometry(points, width) {
     const b1 = new THREE.Vector3(p2.x + perp.x, p2.y + perp.y, p2.z);
     const b2 = new THREE.Vector3(p2.x - perp.x, p2.y - perp.y, p2.z);
 
+    const startFade = Math.abs(accLength - halfLength) / halfLength;
+    const endFade = Math.abs(accLength + segLen - halfLength) / halfLength;
+
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    centerFades.push(startFade, startFade, endFade);
+
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    centerFades.push(startFade, endFade, endFade);
+
+    accLength += segLen;
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('centerFade', new THREE.Float32BufferAttribute(centerFades, 1));
   return geom;
 }
 

--- a/index.html
+++ b/index.html
@@ -277,6 +277,7 @@
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
+        <div id="export-select-overlay" class="hidden"></div>
         <div class="export-controls">
           <button id="export-mollweide" class="export-btn">Export</button>
           <button id="toggle-label-editor" class="export-btn">Edit Labels</button>

--- a/script.js
+++ b/script.js
@@ -1270,9 +1270,9 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap() {
-  const width = 7680;
-  const height = 3840;
+function exportMollweideMap(format = 'png', rect = { x: 0, y: 0, w: 1, h: 1 }) {
+  let width = 7680;
+  let height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
   exportRenderer.setPixelRatio(1);
   const finalCanvas = document.createElement('canvas');
@@ -1301,21 +1301,112 @@ function exportMollweideMap() {
   }
   exportRenderer.dispose();
 
-  finalCanvas.toBlob(b => {
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(b);
-    link.download = 'mollweide_map.png';
-    link.click();
-    URL.revokeObjectURL(link.href);
-  }, 'image/png');
+  ctx.save();
+  ctx.globalCompositeOperation = 'destination-in';
+  ctx.beginPath();
+  ctx.ellipse(width / 2, height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  if (rect.x !== 0 || rect.y !== 0 || rect.w !== 1 || rect.h !== 1) {
+    const cropCanvas = document.createElement('canvas');
+    const sx = Math.round(rect.x * width);
+    const sy = Math.round(rect.y * height);
+    const sw = Math.round(rect.w * width);
+    const sh = Math.round(rect.h * height);
+    cropCanvas.width = sw;
+    cropCanvas.height = sh;
+    cropCanvas.getContext('2d').drawImage(finalCanvas, sx, sy, sw, sh, 0, 0, sw, sh);
+    width = sw;
+    height = sh;
+    finalCanvas.width = sw;
+    finalCanvas.height = sh;
+    finalCanvas.getContext('2d').drawImage(cropCanvas, 0, 0);
+  }
+
+  if (format === 'pdf') {
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({
+      orientation: width >= height ? 'landscape' : 'portrait',
+      unit: 'px',
+      format: [width, height]
+    });
+    const imgData = finalCanvas.toDataURL('image/png');
+    pdf.addImage(imgData, 'PNG', 0, 0, width, height);
+    pdf.save('mollweide_map.pdf');
+  } else {
+    finalCanvas.toBlob(b => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(b);
+      link.download = 'mollweide_map.png';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  }
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
-  btn.addEventListener('click', () => {
-    exportMollweideMap();
-  });
+  btn.addEventListener('click', startExportSelection);
+}
+
+function startExportSelection() {
+  const canvas = document.getElementById('mollweideMap');
+  const overlay = document.getElementById('export-select-overlay');
+  if (!canvas || !overlay) return;
+  let startX = 0, startY = 0;
+  const rect = canvas.getBoundingClientRect();
+  canvas.style.cursor = 'crosshair';
+
+  function onDown(e) {
+    overlay.classList.remove('hidden');
+    startX = e.clientX - rect.left;
+    startY = e.clientY - rect.top;
+    overlay.style.left = `${startX}px`;
+    overlay.style.top = `${startY}px`;
+    overlay.style.width = '0px';
+    overlay.style.height = '0px';
+    canvas.addEventListener('pointermove', onMove);
+    canvas.addEventListener('pointerup', onUp);
+  }
+
+  function onMove(e) {
+    const currX = e.clientX - rect.left;
+    const currY = e.clientY - rect.top;
+    const left = Math.min(startX, currX);
+    const top = Math.min(startY, currY);
+    const width = Math.abs(currX - startX);
+    const height = Math.abs(currY - startY);
+    overlay.style.left = `${left}px`;
+    overlay.style.top = `${top}px`;
+    overlay.style.width = `${width}px`;
+    overlay.style.height = `${height}px`;
+  }
+
+  function onUp(e) {
+    const endX = e.clientX - rect.left;
+    const endY = e.clientY - rect.top;
+    canvas.removeEventListener('pointermove', onMove);
+    canvas.removeEventListener('pointerup', onUp);
+    overlay.classList.add('hidden');
+    canvas.style.cursor = '';
+    const left = Math.min(startX, endX);
+    const top = Math.min(startY, endY);
+    const width = Math.abs(endX - startX);
+    const height = Math.abs(endY - startY);
+    const norm = {
+      x: left / rect.width,
+      y: top / rect.height,
+      w: width / rect.width,
+      h: height / rect.height
+    };
+    const fmt = prompt('Export format (png/pdf)?', 'png');
+    exportMollweideMap(fmt === 'pdf' ? 'pdf' : 'png', norm);
+    canvas.removeEventListener('pointerdown', onDown);
+  }
+
+  canvas.addEventListener('pointerdown', onDown);
 }
 
 function downloadLabelEdits() {

--- a/styles.css
+++ b/styles.css
@@ -300,6 +300,20 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   border-radius: 4px;
   touch-action: none;
 }
+#mollweideMap {
+  clip-path: ellipse(50% 50% at 50% 50%);
+}
+
+#export-select-overlay {
+  position: absolute;
+  border: 2px dashed #ff6f61;
+  pointer-events: none;
+  display: none;
+  z-index: 20;
+}
+#export-select-overlay.hidden {
+  display: none;
+}
 .map-container canvas.edit-mode {
   cursor: move;
 }


### PR DESCRIPTION
## Summary
- implement PDF export and clipping to ellipse when exporting
- add rectangle selection overlay for partial export
- clip mollweide canvas and overlays to oval shape
- fade density lines from center to ends

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685654a771d4832aab8cf81febe4d5b2