### PR TITLE
Add export selection and PDF export

### DIFF
--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -22,9 +22,14 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float along;
       varying float vSide;
+      varying float vAlong;
+      varying vec2 vPos;
       void main() {
         vSide = side;
+        vAlong = along;
+        vPos = position.xy;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +37,13 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vAlong;
+      varying vec2 vPos;
       void main() {
-        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        float ellipse = (vPos.x*vPos.x)/(200.0*200.0) + (vPos.y*vPos.y)/(100.0*100.0);
+        if(ellipse > 1.0) discard;
+        float alongFade = 1.0 - abs(2.0*vAlong - 1.0);
+        float alpha = 0.5 * (1.0 - abs(vSide)) * alongFade * opacityFactor;
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,6 +54,7 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const along = [];
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
@@ -56,12 +67,15 @@ function buildWideLineGeometry(points, width) {
 
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    along.push(0, 0, 1);
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    along.push(0, 1, 1);
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('along', new THREE.Float32BufferAttribute(along, 1));
   return geom;
 }
 

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -22,9 +22,14 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float along;
       varying float vSide;
+      varying float vAlong;
+      varying vec2 vPos;
       void main() {
         vSide = side;
+        vAlong = along;
+        vPos = position.xy;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +37,13 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vAlong;
+      varying vec2 vPos;
       void main() {
-        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        float ellipse = (vPos.x*vPos.x)/(200.0*200.0) + (vPos.y*vPos.y)/(100.0*100.0);
+        if(ellipse > 1.0) discard;
+        float alongFade = 1.0 - abs(2.0*vAlong - 1.0);
+        float alpha = 0.5 * (1.0 - abs(vSide)) * alongFade * opacityFactor;
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,6 +54,7 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const along = [];
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
@@ -56,12 +67,15 @@ function buildWideLineGeometry(points, width) {
 
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    along.push(0, 0, 1);
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    along.push(0, 1, 1);
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('along', new THREE.Float32BufferAttribute(along, 1));
   return geom;
 }
 

--- a/index.html
+++ b/index.html
@@ -277,8 +277,13 @@
         <h2>Mollweide Map</h2>
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
+        <div id="mollweide-export-overlay" class="export-overlay hidden">
+          <div id="export-selection" class="export-selection"></div>
+        </div>
         <div class="export-controls">
           <button id="export-mollweide" class="export-btn">Export</button>
+          <button id="export-png" class="export-btn hidden">PNG</button>
+          <button id="export-pdf" class="export-btn hidden">PDF</button>
           <button id="toggle-label-editor" class="export-btn">Edit Labels</button>
           <button id="toggle-line-editor" class="export-btn">Edit Lines</button>
           <button id="undo-edit" class="export-btn">Undo</button>

--- a/script.js
+++ b/script.js
@@ -1270,7 +1270,7 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap() {
+function exportMollweideMap(format = 'png', cropRect = null) {
   const width = 7680;
   const height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
@@ -1301,20 +1301,120 @@ function exportMollweideMap() {
   }
   exportRenderer.dispose();
 
-  finalCanvas.toBlob(b => {
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(b);
-    link.download = 'mollweide_map.png';
-    link.click();
-    URL.revokeObjectURL(link.href);
-  }, 'image/png');
+  let outCanvas = finalCanvas;
+  if (cropRect) {
+    const scaleX = width / mollweideMap.canvas.clientWidth;
+    const scaleY = height / mollweideMap.canvas.clientHeight;
+    const cropW = Math.max(1, cropRect.width * scaleX);
+    const cropH = Math.max(1, cropRect.height * scaleY);
+    const cropX = cropRect.x * scaleX;
+    const cropY = cropRect.y * scaleY;
+    const c = document.createElement('canvas');
+    c.width = cropW;
+    c.height = cropH;
+    c.getContext('2d').drawImage(
+      finalCanvas,
+      cropX,
+      cropY,
+      cropW,
+      cropH,
+      0,
+      0,
+      cropW,
+      cropH
+    );
+    outCanvas = c;
+  }
+
+  if (format === 'pdf') {
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({
+      orientation: outCanvas.width >= outCanvas.height ? 'landscape' : 'portrait',
+      unit: 'px',
+      format: [outCanvas.width, outCanvas.height]
+    });
+    pdf.addImage(outCanvas.toDataURL('image/png'), 'PNG', 0, 0, outCanvas.width, outCanvas.height);
+    pdf.save('mollweide_map.pdf');
+  } else {
+    outCanvas.toBlob(b => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(b);
+      link.download = 'mollweide_map.png';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  }
 }
 
 function setupExportControls() {
-  const btn = document.getElementById('export-mollweide');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    exportMollweideMap();
+  const exportBtn = document.getElementById('export-mollweide');
+  const pngBtn = document.getElementById('export-png');
+  const pdfBtn = document.getElementById('export-pdf');
+  const overlay = document.getElementById('mollweide-export-overlay');
+  const selRect = document.getElementById('export-selection');
+  if (!exportBtn || !pngBtn || !pdfBtn || !overlay || !selRect) return;
+
+  let selecting = false;
+  let startX = 0, startY = 0;
+  let currentRect = null;
+
+  function reset() {
+    selecting = false;
+    currentRect = null;
+    selRect.style.display = 'none';
+    overlay.classList.add('hidden');
+    pngBtn.classList.add('hidden');
+    pdfBtn.classList.add('hidden');
+  }
+
+  overlay.addEventListener('pointerdown', e => {
+    selecting = true;
+    const r = overlay.getBoundingClientRect();
+    startX = e.clientX - r.left;
+    startY = e.clientY - r.top;
+    selRect.style.display = 'block';
+    selRect.style.left = `${startX}px`;
+    selRect.style.top = `${startY}px`;
+    selRect.style.width = '0px';
+    selRect.style.height = '0px';
+  });
+
+  overlay.addEventListener('pointermove', e => {
+    if (!selecting) return;
+    const r = overlay.getBoundingClientRect();
+    const x = e.clientX - r.left;
+    const y = e.clientY - r.top;
+    const left = Math.min(startX, x);
+    const top = Math.min(startY, y);
+    const w = Math.abs(x - startX);
+    const h = Math.abs(y - startY);
+    selRect.style.left = `${left}px`;
+    selRect.style.top = `${top}px`;
+    selRect.style.width = `${w}px`;
+    selRect.style.height = `${h}px`;
+    currentRect = { x: left, y: top, width: w, height: h };
+  });
+
+  window.addEventListener('pointerup', () => { selecting = false; });
+
+  exportBtn.addEventListener('click', () => {
+    overlay.classList.toggle('hidden');
+    pngBtn.classList.toggle('hidden');
+    pdfBtn.classList.toggle('hidden');
+    if (overlay.classList.contains('hidden')) {
+      selRect.style.display = 'none';
+      currentRect = null;
+    }
+  });
+
+  pngBtn.addEventListener('click', () => {
+    exportMollweideMap('png', currentRect);
+    reset();
+  });
+
+  pdfBtn.addEventListener('click', () => {
+    exportMollweideMap('pdf', currentRect);
+    reset();
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,30 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   color: #000;
 }
 
+/* Export selection overlay */
+.export-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+}
+
+.export-overlay.hidden {
+  display: none;
+}
+
+.export-selection {
+  position: absolute;
+  border: 2px dashed #ff6f61;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.hidden {
+  display: none !important;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- allow drawing a rectangle for mollweide export
- offer PNG or PDF export choices
- fade density/cloud lines from their centre and clip them to the map oval

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685656f4e294832ab1f72a3be5aaa176