### PR TITLE
Add selection export and density circle overlay

### DIFF
--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -65,6 +65,30 @@ function buildWideLineGeometry(points, width) {
   return geom;
 }
 
+function createCircleTexture() {
+  const size = 128;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const grad = ctx.createRadialGradient(
+    size / 2,
+    size / 2,
+    0,
+    size / 2,
+    size / 2,
+    size / 2
+  );
+  grad.addColorStop(0, 'rgba(255,255,255,1)');
+  grad.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  return texture;
+}
+
 class DensityGridOverlay {
   constructor(minDistance, maxDistance, gridSize = 2) {
     this.minDistance = parseFloat(minDistance);
@@ -75,6 +99,7 @@ class DensityGridOverlay {
     this.maxDensity = 0;
     this.mollLineWidth = 30; // width of connection lines on the Mollweide map
     this.opacityFactor = 1.0;
+    this.circleTexture = createCircleTexture();
   }
 
   createGrid(stars) {
@@ -106,6 +131,13 @@ class DensityGridOverlay {
           planeMat.side = THREE.DoubleSide;
           const squareGlobe = new THREE.Mesh(planeGeom, planeMat.clone());
           const squareMoll = new THREE.Mesh(planeGeom.clone(), planeMat.clone());
+          const circleSprite = new THREE.Sprite(new THREE.SpriteMaterial({
+            map: this.circleTexture,
+            transparent: true,
+            opacity: 0
+          }));
+          circleSprite.position.copy(squareMoll.position);
+          circleSprite.scale.set(this.gridSize * 10, this.gridSize * 10, 1);
 
           let projectedPos;
           let ra, dec;
@@ -160,6 +192,7 @@ class DensityGridOverlay {
             decRad: dec,
             mollXFactor: mollXFactor,
             mollY: mollY,
+            mollCircle: circleSprite,
             density: 0
           };
           cell.id = this.cubesData.length;
@@ -300,12 +333,15 @@ class DensityGridOverlay {
       cell.tcMesh.material.opacity = finalAlpha;
       cell.globeMesh.material.opacity = finalAlpha;
       cell.mollweideMesh.material.opacity = finalAlpha;
+      cell.mollCircle.material.opacity = finalAlpha;
       cell.tcMesh.material.color.copy(color);
       cell.globeMesh.material.color.copy(color);
       cell.mollweideMesh.material.color.copy(color);
+      cell.mollCircle.material.color.copy(color);
       cell.tcMesh.visible = cell.active;
       cell.globeMesh.scale.set(scale, scale, 1);
       cell.mollweideMesh.scale.set(scale, scale, 1);
+      cell.mollCircle.scale.set(scale * 10, scale * 10, 1);
     });
     this.adjacentLines.forEach(obj => {
       const { line, lineM, cell1, cell2 } = obj;
@@ -333,7 +369,7 @@ class DensityGridOverlay {
       this.adjacentLines.forEach(o => { sceneGlobe.add(o.line); });
     }
     if (sceneMoll) {
-      this.adjacentLines.forEach(o => { sceneMoll.add(o.lineM); });
+      this.cubesData.forEach(c => { sceneMoll.add(c.mollCircle); });
     }
   }
 
@@ -345,6 +381,7 @@ class DensityGridOverlay {
         cell.mollY,
         0
       );
+      cell.mollCircle.position.copy(cell.mollweideMesh.position);
     });
     this.adjacentLines.forEach(obj => {
       const gcPts = getGreatCirclePoints(obj.cell1.globeMesh.position,

--- a/filters/index.js
+++ b/filters/index.js
@@ -496,7 +496,9 @@ export function applyFilters(allStars) {
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.add(obj.line);
-        window.mollweideMap.scene.add(obj.lineM);
+      });
+      densityOverlay.cubesData.forEach(cell => {
+        window.mollweideMap.scene.add(cell.mollCircle);
       });
     }
     updateDensityFilter(allStars, densityOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene, window.mollweideMap.scene);
@@ -507,7 +509,9 @@ export function applyFilters(allStars) {
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.remove(obj.line);
-        window.mollweideMap.scene.remove(obj.lineM);
+      });
+      densityOverlay.cubesData.forEach(cell => {
+        window.mollweideMap.scene.remove(cell.mollCircle);
       });
       densityOverlay = null;
     }

--- a/script.js
+++ b/script.js
@@ -108,6 +108,12 @@ let rotateInitialRotation = 0;
 let rotateCurrentRotation = 0;
 let scaleStart = null;
 
+// --- Export Selection ---
+let exportOverlay = null;
+let exportRect = null;
+let exportButtons = null;
+let exportStart = null;
+
 const ROTATE_SENSITIVITY = 0.3;
 
 const PRESET_KEY = 'astrography-presets';
@@ -1270,9 +1276,22 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap() {
-  const width = 7680;
-  const height = 3840;
+function exportMollweideMap(crop = null, format = 'png') {
+  const widthFull = 7680;
+  const heightFull = 3840;
+  let width = widthFull;
+  let height = heightFull;
+  let offsetX = 0;
+  let offsetY = 0;
+  if (crop) {
+    const rect = mollweideMap.canvas.getBoundingClientRect();
+    const scaleX = widthFull / rect.width;
+    const scaleY = heightFull / rect.height;
+    width = Math.round(crop.width * scaleX);
+    height = Math.round(crop.height * scaleY);
+    offsetX = Math.round(crop.x * scaleX);
+    offsetY = Math.round((rect.height - crop.y - crop.height) * scaleY);
+  }
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
   exportRenderer.setPixelRatio(1);
   const finalCanvas = document.createElement('canvas');
@@ -1287,35 +1306,134 @@ function exportMollweideMap() {
       const tileH = Math.min(tile, height - y);
       exportRenderer.setSize(tileW, tileH);
       const cam = mollweideMap.camera.clone();
-      const aspect = width / height;
+      const aspect = widthFull / heightFull;
       cam.left = (-mollweideMap.frustumSize * aspect) / 2;
       cam.right = (mollweideMap.frustumSize * aspect) / 2;
       cam.top = mollweideMap.frustumSize / 2;
       cam.bottom = -mollweideMap.frustumSize / 2;
       cam.updateProjectionMatrix();
-      cam.setViewOffset(width, height, x, y, tileW, tileH);
+      cam.setViewOffset(widthFull, heightFull, offsetX + x, offsetY + y, tileW, tileH);
       exportRenderer.render(mollweideMap.scene, cam);
       cam.clearViewOffset();
       ctx.drawImage(exportRenderer.domElement, x, height - y - tileH, tileW, tileH);
     }
   }
   exportRenderer.dispose();
-
-  finalCanvas.toBlob(b => {
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(b);
-    link.download = 'mollweide_map.png';
-    link.click();
-    URL.revokeObjectURL(link.href);
-  }, 'image/png');
+  if (format === 'png') {
+    finalCanvas.toBlob(b => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(b);
+      link.download = 'mollweide_map.png';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  } else {
+    const dataUrl = finalCanvas.toDataURL('image/png');
+    const pdf = new jspdf.jsPDF({
+      orientation: width >= height ? 'landscape' : 'portrait',
+      unit: 'px',
+      format: [width, height]
+    });
+    pdf.addImage(dataUrl, 'PNG', 0, 0, width, height);
+    pdf.save('mollweide_map.pdf');
+  }
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    exportMollweideMap();
+    startExportSelection();
   });
+}
+
+function startExportSelection() {
+  if (!exportOverlay) {
+    const container = document.querySelector('#mollweideMap').parentElement;
+    exportOverlay = document.createElement('div');
+    exportOverlay.id = 'export-selection-overlay';
+    exportRect = document.createElement('div');
+    exportRect.id = 'export-selection-rect';
+    exportButtons = document.createElement('div');
+    exportButtons.id = 'export-selection-buttons';
+    const pngBtn = document.createElement('button');
+    pngBtn.textContent = 'PNG';
+    pngBtn.className = 'export-btn';
+    const pdfBtn = document.createElement('button');
+    pdfBtn.textContent = 'PDF';
+    pdfBtn.className = 'export-btn';
+    exportButtons.appendChild(pngBtn);
+    exportButtons.appendChild(pdfBtn);
+    exportOverlay.appendChild(exportRect);
+    exportOverlay.appendChild(exportButtons);
+    container.appendChild(exportOverlay);
+    pngBtn.addEventListener('click', () => finishExport('png'));
+    pdfBtn.addEventListener('click', () => finishExport('pdf'));
+  }
+  exportOverlay.classList.add('active');
+  exportButtons.style.display = 'none';
+  exportRect.style.display = 'none';
+  const rect = mollweideMap.canvas.getBoundingClientRect();
+  exportOverlay.style.left = rect.left + 'px';
+  exportOverlay.style.top = rect.top + 'px';
+  exportOverlay.style.width = rect.width + 'px';
+  exportOverlay.style.height = rect.height + 'px';
+  exportOverlay.addEventListener('pointerdown', onExportDown);
+}
+
+function onExportDown(e) {
+  exportStart = { x: e.clientX, y: e.clientY };
+  exportRect.style.display = 'block';
+  const r = exportOverlay.getBoundingClientRect();
+  exportRect.style.left = (exportStart.x - r.left) + 'px';
+  exportRect.style.top = (exportStart.y - r.top) + 'px';
+  exportRect.style.width = '0px';
+  exportRect.style.height = '0px';
+  document.addEventListener('pointermove', onExportMove);
+  document.addEventListener('pointerup', onExportUp);
+  e.preventDefault();
+}
+
+function onExportMove(e) {
+  const r = exportOverlay.getBoundingClientRect();
+  const x = Math.max(r.left, Math.min(e.clientX, r.right)) - r.left;
+  const y = Math.max(r.top, Math.min(e.clientY, r.bottom)) - r.top;
+  const sx = exportStart.x - r.left;
+  const sy = exportStart.y - r.top;
+  const left = Math.min(sx, x);
+  const top = Math.min(sy, y);
+  const width = Math.abs(x - sx);
+  const height = Math.abs(y - sy);
+  exportRect.style.left = left + 'px';
+  exportRect.style.top = top + 'px';
+  exportRect.style.width = width + 'px';
+  exportRect.style.height = height + 'px';
+}
+
+function onExportUp() {
+  document.removeEventListener('pointermove', onExportMove);
+  document.removeEventListener('pointerup', onExportUp);
+  exportButtons.style.display = 'flex';
+  const r = exportRect.getBoundingClientRect();
+  const ov = exportOverlay.getBoundingClientRect();
+  exportButtons.style.left = (r.left - ov.left) + 'px';
+  exportButtons.style.top = (r.top - ov.top + r.height + 6) + 'px';
+}
+
+function finishExport(fmt) {
+  const r = exportRect.getBoundingClientRect();
+  const ov = exportOverlay.getBoundingClientRect();
+  const crop = {
+    x: r.left - ov.left,
+    y: r.top - ov.top,
+    width: r.width,
+    height: r.height
+  };
+  exportOverlay.classList.remove('active');
+  exportOverlay.removeEventListener('pointerdown', onExportDown);
+  exportButtons.style.display = 'none';
+  exportRect.style.display = 'none';
+  exportMollweideMap(crop, fmt);
 }
 
 function downloadLabelEdits() {

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,31 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   color: #000;
 }
 
+#export-selection-overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1200;
+}
+#export-selection-overlay.active {
+  pointer-events: all;
+  cursor: crosshair;
+}
+#export-selection-rect {
+  position: absolute;
+  border: 2px dashed #ff6f61;
+  background: rgba(255, 255, 255, 0.1);
+}
+#export-selection-buttons {
+  position: absolute;
+  display: none;
+  gap: 6px;
+  margin-top: 4px;
+}
+
 /* Tooltip */
 #tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- allow selection rectangle export with PNG or PDF option
- swap mollweide density lines for radial circle sprites
- style export selection overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685663ce8f94832a9503743bc6f9be2f