### PR TITLE
Add selectable export area with PNG/PDF options

### DIFF
--- a/cameraControls.js
+++ b/cameraControls.js
@@ -37,6 +37,9 @@ export class ThreeDControls {
         this.lastTouch = null;
         this.touchStartDistance = 0;
 
+        // Controls can be temporarily disabled
+        this.enabled = true;
+
         // Bind event handlers
         this.onMouseDown = this.onMouseDown.bind(this);
         this.onMouseMove = this.onMouseMove.bind(this);
@@ -65,6 +68,7 @@ export class ThreeDControls {
      * @param {MouseEvent} event 
      */
     onMouseDown(event) {
+        if (!this.enabled) return;
         this.isRotating = true;
         this.previousMousePosition = {
             x: event.clientX,
@@ -77,7 +81,7 @@ export class ThreeDControls {
      * @param {MouseEvent} event 
      */
     onMouseMove(event) {
-        if (!this.isRotating) return;
+        if (!this.enabled || !this.isRotating) return;
 
         const deltaMove = {
             x: event.clientX - this.previousMousePosition.x,
@@ -116,6 +120,7 @@ export class ThreeDControls {
      * @param {MouseEvent} event 
      */
     onMouseUp(event) {
+        if (!this.enabled) return;
         this.isRotating = false;
     }
 
@@ -124,6 +129,7 @@ export class ThreeDControls {
      * @param {WheelEvent} event 
      */
     onWheel(event) {
+        if (!this.enabled) return;
         event.preventDefault();
 
         const delta = event.deltaY;
@@ -164,6 +170,7 @@ export class ThreeDControls {
      * @param {TouchEvent} event 
      */
     onTouchStart(event) {
+        if (!this.enabled) return;
         if (event.touches.length === 1) {
             // Single touch for rotation
             this.isTouchRotating = true;
@@ -181,6 +188,7 @@ export class ThreeDControls {
      * @param {TouchEvent} event 
      */
     onTouchMove(event) {
+        if (!this.enabled) return;
         event.preventDefault();
         if (this.isPinching && event.touches.length === 2) {
             // Handle pinch zoom
@@ -237,6 +245,7 @@ export class ThreeDControls {
      * @param {TouchEvent} event 
      */
     onTouchEnd(event) {
+        if (!this.enabled) return;
         if (event.touches.length === 0) {
             this.isTouchRotating = false;
             this.isPinching = false;
@@ -289,6 +298,9 @@ export class TwoDControls {
         this.isPinching = false;
         this.touchStartDistance = 0;
 
+        // Controls can be temporarily disabled
+        this.enabled = true;
+
         this.onMouseDown = this.onMouseDown.bind(this);
         this.onMouseMove = this.onMouseMove.bind(this);
         this.onMouseUp = this.onMouseUp.bind(this);
@@ -337,6 +349,7 @@ export class TwoDControls {
     }
 
     onMouseDown(event) {
+        if (!this.enabled) return;
         this.isPanning = true;
         this.button = event.button;
         if (this.button === 2) event.preventDefault();
@@ -344,7 +357,7 @@ export class TwoDControls {
     }
 
     onMouseMove(event) {
-        if (!this.isPanning) return;
+        if (!this.enabled || !this.isPanning) return;
         const dx = event.clientX - this.lastPos.x;
         const dy = event.clientY - this.lastPos.y;
         this.pan(dx, dy, this.button);
@@ -353,11 +366,13 @@ export class TwoDControls {
     }
 
     onMouseUp() {
+        if (!this.enabled) return;
         this.isPanning = false;
         this.button = 0;
     }
 
     onWheel(event) {
+        if (!this.enabled) return;
         event.preventDefault();
         const zoomFactor = event.deltaY < 0 ? 1.1 : 0.9;
         this.camera.zoom *= zoomFactor;
@@ -372,6 +387,7 @@ export class TwoDControls {
     }
 
     onTouchStart(event) {
+        if (!this.enabled) return;
         if (event.touches.length === 1) {
             this.isPanning = true;
             this.lastPos = { x: event.touches[0].clientX, y: event.touches[0].clientY };
@@ -382,6 +398,7 @@ export class TwoDControls {
     }
 
     onTouchMove(event) {
+        if (!this.enabled) return;
         event.preventDefault();
         if (this.isPinching && event.touches.length === 2) {
             const currentDistance = this.getTouchDistance(event.touches[0], event.touches[1]);
@@ -402,6 +419,7 @@ export class TwoDControls {
     }
 
     onTouchEnd() {
+        if (!this.enabled) return;
         this.isPanning = false;
         this.isPinching = false;
     }

--- a/index.html
+++ b/index.html
@@ -300,6 +300,14 @@
 
   <!-- Labels Container -->
   <div class="label-container"></div>
+  <!-- Export Selection Overlay -->
+  <div id="export-overlay">
+    <div id="export-rectangle"></div>
+    <div id="export-buttons">
+      <button id="export-png">PNG</button>
+      <button id="export-pdf">PDF</button>
+    </div>
+  </div>
 
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -108,6 +108,13 @@ let rotateInitialRotation = 0;
 let rotateCurrentRotation = 0;
 let scaleStart = null;
 
+// --- Export Selection ---
+let exportOverlayElem = null;
+let exportRectElem = null;
+let exportButtonsElem = null;
+let exportStart = null;
+let exportSelection = null;
+
 const ROTATE_SENSITIVITY = 0.3;
 
 const PRESET_KEY = 'astrography-presets';
@@ -1270,7 +1277,7 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
-function exportMollweideMap() {
+function exportMollweideMapRect(selection, format = 'png') {
   const width = 7680;
   const height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
@@ -1300,22 +1307,113 @@ function exportMollweideMap() {
     }
   }
   exportRenderer.dispose();
+  let outputCanvas = finalCanvas;
+  if (selection) {
+    const canvasRect = mollweideMap.canvas.getBoundingClientRect();
+    const scaleX = width / canvasRect.width;
+    const scaleY = height / canvasRect.height;
+    const sx = Math.round((selection.x - canvasRect.left) * scaleX);
+    const sy = Math.round((selection.y - canvasRect.top) * scaleY);
+    const sw = Math.round(selection.w * scaleX);
+    const sh = Math.round(selection.h * scaleY);
+    const crop = document.createElement('canvas');
+    crop.width = sw;
+    crop.height = sh;
+    crop.getContext('2d').drawImage(finalCanvas, sx, sy, sw, sh, 0, 0, sw, sh);
+    outputCanvas = crop;
+  }
 
-  finalCanvas.toBlob(b => {
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(b);
-    link.download = 'mollweide_map.png';
-    link.click();
-    URL.revokeObjectURL(link.href);
-  }, 'image/png');
+  if (format === 'pdf') {
+    const imgData = outputCanvas.toDataURL('image/png');
+    const orientation = outputCanvas.width >= outputCanvas.height ? 'landscape' : 'portrait';
+    const pdf = new jspdf.jsPDF({ orientation, unit: 'px', format: [outputCanvas.width, outputCanvas.height] });
+    pdf.addImage(imgData, 'PNG', 0, 0, outputCanvas.width, outputCanvas.height);
+    pdf.save('mollweide_map.pdf');
+  } else {
+    outputCanvas.toBlob(b => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(b);
+      link.download = 'mollweide_map.png';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  }
 }
 
 function setupExportControls() {
   const btn = document.getElementById('export-mollweide');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    exportMollweideMap();
-  });
+  exportOverlayElem = document.getElementById('export-overlay');
+  exportRectElem = document.getElementById('export-rectangle');
+  exportButtonsElem = document.getElementById('export-buttons');
+  if (!btn || !exportOverlayElem) return;
+  btn.addEventListener('click', startExportSelection);
+  exportOverlayElem.addEventListener('pointerdown', onExportPointerDown);
+  window.addEventListener('pointermove', onExportPointerMove);
+  window.addEventListener('pointerup', onExportPointerUp);
+  const pngBtn = document.getElementById('export-png');
+  const pdfBtn = document.getElementById('export-pdf');
+  if (pngBtn) pngBtn.addEventListener('click', () => finishExport('png'));
+  if (pdfBtn) pdfBtn.addEventListener('click', () => finishExport('pdf'));
+}
+
+function startExportSelection() {
+  exportButtonsElem.style.display = 'none';
+  exportRectElem.style.display = 'none';
+  exportOverlayElem.style.display = 'block';
+  exportOverlayElem.style.pointerEvents = 'auto';
+  exportStart = null;
+  exportSelection = null;
+  if (mollweideMap && mollweideMap.controls) {
+    mollweideMap.controls.enabled = false;
+  }
+}
+
+function onExportPointerDown(e) {
+  if (e.button !== 0) return;
+  exportStart = { x: e.clientX, y: e.clientY };
+  exportRectElem.style.display = 'block';
+  exportRectElem.style.left = `${exportStart.x}px`;
+  exportRectElem.style.top = `${exportStart.y}px`;
+  exportRectElem.style.width = '0px';
+  exportRectElem.style.height = '0px';
+}
+
+function onExportPointerMove(e) {
+  if (!exportStart) return;
+  const x = Math.min(exportStart.x, e.clientX);
+  const y = Math.min(exportStart.y, e.clientY);
+  const w = Math.abs(exportStart.x - e.clientX);
+  const h = Math.abs(exportStart.y - e.clientY);
+  exportRectElem.style.left = `${x}px`;
+  exportRectElem.style.top = `${y}px`;
+  exportRectElem.style.width = `${w}px`;
+  exportRectElem.style.height = `${h}px`;
+}
+
+function onExportPointerUp(e) {
+  if (!exportStart) return;
+  const x = Math.min(exportStart.x, e.clientX);
+  const y = Math.min(exportStart.y, e.clientY);
+  const w = Math.abs(exportStart.x - e.clientX);
+  const h = Math.abs(exportStart.y - e.clientY);
+  exportSelection = { x, y, w, h };
+  exportButtonsElem.style.left = `${x}px`;
+  exportButtonsElem.style.top = `${y + h + 10}px`;
+  exportButtonsElem.style.display = 'flex';
+  exportOverlayElem.style.pointerEvents = 'none';
+  exportStart = null;
+}
+
+function finishExport(format) {
+  if (!exportSelection) return;
+  exportMollweideMapRect(exportSelection, format);
+  exportOverlayElem.style.display = 'none';
+  exportButtonsElem.style.display = 'none';
+  exportRectElem.style.display = 'none';
+  exportSelection = null;
+  if (mollweideMap && mollweideMap.controls) {
+    mollweideMap.controls.enabled = true;
+  }
 }
 
 function downloadLabelEdits() {

--- a/styles.css
+++ b/styles.css
@@ -368,6 +368,36 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   border-radius: 4px;
   z-index: 10;
 }
+
+/* Export overlay for selecting a region */
+#export-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1500;
+}
+#export-overlay #export-rectangle {
+  position: absolute;
+  border: 2px dashed #ff6f61;
+  display: none;
+  pointer-events: none;
+}
+#export-buttons {
+  position: absolute;
+  display: none;
+  gap: 6px;
+}
+#export-buttons button {
+  background: rgba(20, 20, 20, 0.9);
+  color: #ff6f61;
+  border: 1px solid #555;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
 .export-controls select,
 .export-controls button {
   background: rgba(20, 20, 20, 0.9);


### PR DESCRIPTION
## Summary
- let camera controls be temporarily disabled
- allow selecting an export rectangle on the Mollweide map
- offer PNG/PDF export buttons for the selected area
- style export overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685666319734832aa46417c0e40c9237