### PR TITLE
Add Mollweide map clipping mask

### DIFF
--- a/script.js
+++ b/script.js
@@ -353,6 +353,26 @@ function createMollweideBorder(R = 100) {
   return new THREE.LineLoop(geom, mat);
 }
 
+function createMollweideMask(R = 100) {
+  const size = 600;
+  const shape = new THREE.Shape();
+  shape.moveTo(-size, -size);
+  shape.lineTo(size, -size);
+  shape.lineTo(size, size);
+  shape.lineTo(-size, size);
+  shape.lineTo(-size, -size);
+  const hole = new THREE.Path();
+  hole.absellipse(0, 0, 2 * R, R, 0, Math.PI * 2, false, 0);
+  shape.holes.push(hole);
+  const geom = new THREE.ShapeGeometry(shape);
+  const mat = new THREE.MeshBasicMaterial({ color: 0x000000 });
+  mat.depthWrite = false;
+  mat.depthTest = false;
+  const mesh = new THREE.Mesh(geom, mat);
+  mesh.renderOrder = 1;
+  return mesh;
+}
+
 async function loadStarData() {
   const manifestUrl = 'data/manifest.json';
   try {
@@ -822,6 +842,9 @@ class MapManager {
       });
       const border = createMollweideBorder(100);
       this.scene.add(border);
+      const mask = createMollweideMask(100);
+      this.scene.add(mask);
+      this.mask = mask;
     } else {
       this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
     }


### PR DESCRIPTION
## Summary
- add `createMollweideMask` to hide anything outside the Mollweide projection
- apply this mask in `MapManager` when creating the Mollweide map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68590896b180832a9d41ef5965119998