### PR TITLE
Improve Mollweide map outline

### DIFF
--- a/script.js
+++ b/script.js
@@ -340,21 +340,68 @@ function createGlobeGrid(R = 100, options = {}) {
   return gridGroup;
 }
 
+function createBorderAlphaTexture() {
+  const size = 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, 0, size);
+  gradient.addColorStop(0, 'rgba(255,255,255,1)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, 1, size);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.minFilter = THREE.LinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  return tex;
+}
+
 function createMollweideBorder(R = 100) {
   const segments = 512;
-  const borderWidth = R * 0.05 / 6; // half as thick
+  const borderWidth = R * 0.05; // thicker outline
 
-  const shape = new THREE.Shape();
-  shape.absellipse(0, 0, 2 * R + borderWidth, R + borderWidth, 0, Math.PI * 2, false, 0);
-  const hole = new THREE.Path();
-  hole.absellipse(0, 0, 2 * R - borderWidth, R - borderWidth, 0, Math.PI * 2, true, 0);
-  shape.holes.push(hole);
+  const innerA = 2 * R - borderWidth;
+  const innerB = R - borderWidth;
+  const outerA = 2 * R + borderWidth;
+  const outerB = R + borderWidth;
 
-  const geom = new THREE.ShapeGeometry(shape, segments);
+  const positions = [];
+  const uvs = [];
+  const indices = [];
+
+  for (let i = 0; i <= segments; i++) {
+    const t = (i / segments) * Math.PI * 2;
+    const cos = Math.cos(t);
+    const sin = Math.sin(t);
+
+    positions.push(innerA * cos, innerB * sin, 0);
+    uvs.push(i / segments, 0);
+
+    positions.push(outerA * cos, outerB * sin, 0);
+    uvs.push(i / segments, 1);
+
+    if (i < segments) {
+      const a = i * 2;
+      const b = a + 1;
+      const c = a + 2;
+      const d = a + 3;
+      indices.push(a, b, c);
+      indices.push(b, d, c);
+    }
+  }
+
+  const geom = new THREE.BufferGeometry();
+  geom.setIndex(indices);
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+
+  const alphaMap = createBorderAlphaTexture();
   const mat = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
+    alphaMap,
     opacity: 1,
-    transparent: false,
+    transparent: true,
     depthTest: false,
     depthWrite: false
   });

--- a/script.js
+++ b/script.js
@@ -340,26 +340,11 @@ function createGlobeGrid(R = 100, options = {}) {
   return gridGroup;
 }
 
-function createBorderAlphaTexture() {
-  const size = 64;
-  const canvas = document.createElement('canvas');
-  canvas.width = 1;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  const gradient = ctx.createLinearGradient(0, 0, 0, size);
-  gradient.addColorStop(0, 'rgba(255,255,255,1)');
-  gradient.addColorStop(1, 'rgba(255,255,255,0)');
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, 1, size);
-  const tex = new THREE.CanvasTexture(canvas);
-  tex.minFilter = THREE.LinearFilter;
-  tex.magFilter = THREE.LinearFilter;
-  return tex;
-}
+
 
 function createMollweideBorder(R = 100) {
-  const segments = 512;
-  const borderWidth = R * 0.05; // thicker outline
+  const segments = 1024; // higher resolution for smoother ellipse
+  const borderWidth = R * 0.15; // much thicker outline
 
   const innerA = 2 * R - borderWidth;
   const innerB = R - borderWidth;
@@ -367,7 +352,6 @@ function createMollweideBorder(R = 100) {
   const outerB = R + borderWidth;
 
   const positions = [];
-  const uvs = [];
   const indices = [];
 
   for (let i = 0; i <= segments; i++) {
@@ -376,10 +360,7 @@ function createMollweideBorder(R = 100) {
     const sin = Math.sin(t);
 
     positions.push(innerA * cos, innerB * sin, 0);
-    uvs.push(i / segments, 0);
-
     positions.push(outerA * cos, outerB * sin, 0);
-    uvs.push(i / segments, 1);
 
     if (i < segments) {
       const a = i * 2;
@@ -394,14 +375,11 @@ function createMollweideBorder(R = 100) {
   const geom = new THREE.BufferGeometry();
   geom.setIndex(indices);
   geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-  geom.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
 
-  const alphaMap = createBorderAlphaTexture();
   const mat = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
-    alphaMap,
     opacity: 1,
-    transparent: true,
+    transparent: false,
     depthTest: false,
     depthWrite: false
   });
@@ -420,7 +398,7 @@ function createMollweideMask(R = 100) {
   shape.lineTo(-outer / 2, outer / 2);
   shape.lineTo(-outer / 2, -outer / 2);
 
-  const segments = 512;
+  const segments = 1024; // smoother mask curve
   const hole = new THREE.Path();
   hole.absellipse(0, 0, 2 * R, R, 0, Math.PI * 2, false, 0);
   shape.holes.push(hole);

--- a/script.js
+++ b/script.js
@@ -341,15 +341,16 @@ function createGlobeGrid(R = 100, options = {}) {
 }
 
 function createMollweideBorder(R = 100) {
-  const points = [];
-  for (let i = 0; i <= 64; i++) {
-    const theta = (i / 64) * 2 * Math.PI;
-    const x = 2 * R * Math.cos(theta);
-    const y = R * Math.sin(theta);
-    points.push(new THREE.Vector3(x, y, 0));
-  }
+  const segments = 256;
+  const curve = new THREE.EllipseCurve(0, 0, 2 * R, R, 0, Math.PI * 2);
+  const points = curve.getPoints(segments);
   const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0xaaaaaa, opacity: 0.5, transparent: true });
+  const mat = new THREE.LineBasicMaterial({
+    color: 0xaaaaaa,
+    opacity: 0.5,
+    transparent: true,
+    linewidth: 2
+  });
   return new THREE.LineLoop(geom, mat);
 }
 
@@ -362,16 +363,11 @@ function createMollweideMask(R = 100) {
   shape.lineTo(-outer / 2, outer / 2);
   shape.lineTo(-outer / 2, -outer / 2);
 
+  const segments = 256;
   const hole = new THREE.Path();
-  for (let i = 0; i <= 64; i++) {
-    const theta = (i / 64) * 2 * Math.PI;
-    const x = 2 * R * Math.cos(theta);
-    const y = R * Math.sin(theta);
-    if (i === 0) hole.moveTo(x, y);
-    else hole.lineTo(x, y);
-  }
+  hole.absellipse(0, 0, 2 * R, R, 0, Math.PI * 2, false, 0);
   shape.holes.push(hole);
-  const geom = new THREE.ShapeGeometry(shape);
+  const geom = new THREE.ShapeGeometry(shape, segments);
   const mat = new THREE.MeshBasicMaterial({
     color: 0x000000,
     side: THREE.DoubleSide,

--- a/script.js
+++ b/script.js
@@ -341,17 +341,27 @@ function createGlobeGrid(R = 100, options = {}) {
 }
 
 function createMollweideBorder(R = 100) {
-  const segments = 256;
-  const curve = new THREE.EllipseCurve(0, 0, 2 * R, R, 0, Math.PI * 2);
-  const points = curve.getPoints(segments);
-  const geom = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({
+  const segments = 512;
+  const borderWidth = R * 0.05; // 5% of radius for a thick outline
+
+  const shape = new THREE.Shape();
+  shape.absellipse(0, 0, 2 * R + borderWidth, R + borderWidth, 0, Math.PI * 2, false, 0);
+  const hole = new THREE.Path();
+  hole.absellipse(0, 0, 2 * R - borderWidth, R - borderWidth, 0, Math.PI * 2, true, 0);
+  shape.holes.push(hole);
+
+  const geom = new THREE.ShapeGeometry(shape, segments);
+  const mat = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
     opacity: 0.5,
     transparent: true,
-    linewidth: 2
+    depthTest: false,
+    depthWrite: false
   });
-  return new THREE.LineLoop(geom, mat);
+
+  const mesh = new THREE.Mesh(geom, mat);
+  mesh.renderOrder = 1001; // ensure border draws above the mask
+  return mesh;
 }
 
 function createMollweideMask(R = 100) {
@@ -363,7 +373,7 @@ function createMollweideMask(R = 100) {
   shape.lineTo(-outer / 2, outer / 2);
   shape.lineTo(-outer / 2, -outer / 2);
 
-  const segments = 256;
+  const segments = 512;
   const hole = new THREE.Path();
   hole.absellipse(0, 0, 2 * R, R, 0, Math.PI * 2, false, 0);
   shape.holes.push(hole);
@@ -847,10 +857,10 @@ class MapManager {
         panCameraLeft: true,
         panCameraRight: false
       });
-      const border = createMollweideBorder(100);
-      this.scene.add(border);
       const mask = createMollweideMask(100);
       this.scene.add(mask);
+      const border = createMollweideBorder(100);
+      this.scene.add(border);
     } else {
       this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
     }

--- a/script.js
+++ b/script.js
@@ -342,7 +342,7 @@ function createGlobeGrid(R = 100, options = {}) {
 
 function createMollweideBorder(R = 100) {
   const segments = 512;
-  const borderWidth = R * 0.05; // 5% of radius for a thick outline
+  const borderWidth = R * 0.05 / 3; // thinner outline
 
   const shape = new THREE.Shape();
   shape.absellipse(0, 0, 2 * R + borderWidth, R + borderWidth, 0, Math.PI * 2, false, 0);
@@ -353,8 +353,8 @@ function createMollweideBorder(R = 100) {
   const geom = new THREE.ShapeGeometry(shape, segments);
   const mat = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
-    opacity: 0.5,
-    transparent: true,
+    opacity: 1,
+    transparent: false,
     depthTest: false,
     depthWrite: false
   });

--- a/script.js
+++ b/script.js
@@ -342,7 +342,7 @@ function createGlobeGrid(R = 100, options = {}) {
 
 function createMollweideBorder(R = 100) {
   const segments = 512;
-  const borderWidth = R * 0.05 / 3; // thinner outline
+  const borderWidth = R * 0.05 / 6; // half as thick
 
   const shape = new THREE.Shape();
   shape.absellipse(0, 0, 2 * R + borderWidth, R + borderWidth, 0, Math.PI * 2, false, 0);


### PR DESCRIPTION
## Summary
- smooth out Mollweide border and mask
- make the border thicker

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859499dfac8832aa4812155c841db3d