### PR TITLE
Update star styles and smoother connections

### DIFF
--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -22,9 +22,12 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float linePos;
       varying float vSide;
+      varying float vPos;
       void main() {
         vSide = side;
+        vPos = linePos;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +35,10 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vPos;
       void main() {
         float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        alpha *= smoothstep(0.0, 0.1, vPos) * smoothstep(1.0, 0.9, vPos);
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,6 +49,7 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const linePos = [];
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
@@ -56,12 +62,15 @@ function buildWideLineGeometry(points, width) {
 
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    linePos.push(0, 0, 1);
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    linePos.push(0, 1, 1);
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('linePos', new THREE.Float32BufferAttribute(linePos, 1));
   return geom;
 }
 

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -5,17 +5,21 @@ import { adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide, getMol
 
 const GC_SEGMENTS = 32;
 
-function createFadingLineMaterial(opacity = 1.0, lineWidth = 1) {
+function createFadingLineMaterial(opacity = 1.0) {
   return new THREE.ShaderMaterial({
     uniforms: { opacity: { value: opacity } },
     transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
     vertexColors: true,
-    linewidth: lineWidth,
     vertexShader: `
+      attribute float side;
       attribute float linePos;
+      varying float vSide;
       varying float vPos;
       varying vec3 vColor;
       void main() {
+        vSide = side;
         vPos = linePos;
         vColor = color;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
@@ -23,15 +27,54 @@ function createFadingLineMaterial(opacity = 1.0, lineWidth = 1) {
     `,
     fragmentShader: `
       uniform float opacity;
+      varying float vSide;
       varying float vPos;
       varying vec3 vColor;
       void main() {
-        float fade = smoothstep(0.0, 0.1, vPos) * smoothstep(1.0, 0.9, vPos);
-        gl_FragColor = vec4(vColor, opacity * fade);
-        if(gl_FragColor.a <= 0.0) discard;
+        float alpha = 0.5 * (1.0 - abs(vSide)) * opacity;
+        alpha *= smoothstep(0.0, 0.1, vPos) * smoothstep(1.0, 0.9, vPos);
+        if(alpha <= 0.0) discard;
+        gl_FragColor = vec4(vColor, alpha);
       }
     `
   });
+}
+
+function buildWideLineGeometry(points, width, colorStart, colorEnd) {
+  const vertices = [];
+  const sides = [];
+  const linePos = [];
+  const colors = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const dir = new THREE.Vector2(p2.x - p1.x, p2.y - p1.y).normalize();
+    const perp = new THREE.Vector2(-dir.y, dir.x).multiplyScalar(width / 2);
+    const a1 = new THREE.Vector3(p1.x + perp.x, p1.y + perp.y, p1.z);
+    const a2 = new THREE.Vector3(p1.x - perp.x, p1.y - perp.y, p1.z);
+    const b1 = new THREE.Vector3(p2.x + perp.x, p2.y + perp.y, p2.z);
+    const b2 = new THREE.Vector3(p2.x - perp.x, p2.y - perp.y, p2.z);
+    const t1 = i / (points.length - 1);
+    const t2 = (i + 1) / (points.length - 1);
+    const c1 = colorStart.clone().lerp(colorEnd, t1);
+    const c2 = colorStart.clone().lerp(colorEnd, t2);
+
+    vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
+    sides.push(1, -1, -1);
+    linePos.push(t1, t1, t2);
+    colors.push(c1.r, c1.g, c1.b, c1.r, c1.g, c1.b, c2.r, c2.g, c2.b);
+
+    vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
+    sides.push(1, -1, 1);
+    linePos.push(t1, t2, t2);
+    colors.push(c1.r, c1.g, c1.b, c2.r, c2.g, c2.b, c2.r, c2.g, c2.b);
+  }
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('linePos', new THREE.Float32BufferAttribute(linePos, 1));
+  geom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  return geom;
 }
 
 /**
@@ -102,115 +145,127 @@ export function computeConnectionPairs(stars, maxDistance) {
  * @returns {THREE.LineSegments} - The merged connection lines.
  */
 export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates', opacity = 0.5) {
-  const positions = [];
-  const colors = [];
+  const vertices = [];
+  const sides = [];
   const linePositions = [];
+  const colors = [];
+  const largest = connectionObjs.reduce((m, p) => Math.max(m, p.distance), 0);
 
   connectionObjs.forEach(pair => {
-    const { starA, starB } = pair;
-    let posA, posB;
+    const { starA, starB, distance } = pair;
     const c1 = new THREE.Color(starA.displayColor || '#ffffff');
     const c2 = new THREE.Color(starB.displayColor || '#ffffff');
+    let segments;
     if (mapType === 'Globe') {
-      posA = starA.spherePosition;
-      posB = starB.spherePosition;
+      segments = [[starA.spherePosition, starB.spherePosition]];
     } else if (mapType === 'Mollweide') {
-      const segments = splitMollweideWrap(
+      segments = splitMollweideWrap(
         starA.mollweidePosition,
         starB.mollweidePosition
       );
-      segments.forEach(([s1, s2]) => {
-        positions.push(s1.x, s1.y, s1.z, s2.x, s2.y, s2.z);
-        const cA = new THREE.Color(starA.displayColor || '#ffffff');
-        const cB = new THREE.Color(starB.displayColor || '#ffffff');
-        colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
-          linePositions.push(0, 1);
-      });
-      return; // continue to next pair
     } else {
-      posA = getPosition(starA);
-      posB = getPosition(starB);
+      segments = [[getPosition(starA), getPosition(starB)]];
     }
-    positions.push(posA.x, posA.y, posA.z);
-    positions.push(posB.x, posB.y, posB.z);
-
-    linePositions.push(0, 1);
-    const cA = new THREE.Color(starA.displayColor || '#ffffff');
-    const cB = new THREE.Color(starB.displayColor || '#ffffff');
-    colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
+    segments.forEach(([s1, s2]) => {
+      const width = THREE.MathUtils.lerp(10, 1, distance / (largest || distance));
+      const geom = buildWideLineGeometry([s1, s2], width, c1, c2);
+      vertices.push(...geom.getAttribute('position').array);
+      sides.push(...geom.getAttribute('side').array);
+      linePositions.push(...geom.getAttribute('linePos').array);
+      colors.push(...geom.getAttribute('color').array);
+    });
   });
-  
-  const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions,3));
-  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
-  geometry.setAttribute('linePos', new THREE.Float32BufferAttribute(linePositions,1));
 
-  const material = createFadingLineMaterial(opacity, 1);
-  
-  const mergedLines = new THREE.LineSegments(geometry, material);
-  return mergedLines;
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geometry.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geometry.setAttribute('linePos', new THREE.Float32BufferAttribute(linePositions, 1));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+
+  const material = createFadingLineMaterial(opacity);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.userData = { pairs, segments: GC_SEGMENTS };
+  return mesh;
 }
 
 export function createMollweideConnectionSegments(pairs, opacity = 0.5) {
-  const segCount = pairs.length * GC_SEGMENTS * 2; // each GC segment may wrap
-  const positions = new Float32Array(segCount * 2 * 3);
-  const colors = new Float32Array(segCount * 2 * 3);
-  const linePosArr = new Float32Array(segCount * 2);
+  const vertices = [];
+  const sides = [];
+  const linePos = [];
+  const colors = [];
+  const largest = pairs.reduce((m, p) => Math.max(m, p.distance), 0);
+  pairs.forEach(pair => {
+    const c1 = new THREE.Color(pair.starA.displayColor || '#ffffff');
+    const c2 = new THREE.Color(pair.starB.displayColor || '#ffffff');
+    const gcPts = greatCircleToMollweide(
+      pair.starA.spherePosition,
+      pair.starB.spherePosition,
+      100,
+      GC_SEGMENTS,
+      getMollweideLambda0()
+    );
+    for (let j = 0; j < gcPts.length - 1; j++) {
+      const segs = splitMollweideWrap(gcPts[j], gcPts[j + 1]);
+      segs.forEach(([s, e]) => {
+        const width = THREE.MathUtils.lerp(10, 1, pair.distance / (largest || pair.distance));
+        const geom = buildWideLineGeometry([s, e], width, c1, c2);
+        vertices.push(...geom.getAttribute('position').array);
+        sides.push(...geom.getAttribute('side').array);
+        linePos.push(...geom.getAttribute('linePos').array);
+        colors.push(...geom.getAttribute('color').array);
+      });
+    }
+  });
+
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-  geometry.setAttribute('linePos', new THREE.BufferAttribute(linePosArr, 1));
-  const material = createFadingLineMaterial(opacity, 1);
-  const lineSegs = new THREE.LineSegments(geometry, material);
-  lineSegs.userData = { pairs, segments: GC_SEGMENTS };
-  updateMollweideConnectionSegments(lineSegs);
-  return lineSegs;
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geometry.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geometry.setAttribute('linePos', new THREE.Float32BufferAttribute(linePos, 1));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+
+  const material = createFadingLineMaterial(opacity);
+  const mesh = new THREE.Mesh(geometry, material);
+  return mesh;
 }
 
 export function updateMollweideConnectionSegments(lineSegs) {
   const pairs = lineSegs.userData.pairs || [];
-  const segsCount = lineSegs.userData.segments || GC_SEGMENTS;
-  const posAttr = lineSegs.geometry.getAttribute('position');
-  const colorAttr = lineSegs.geometry.getAttribute('color');
-  const linePosAttr = lineSegs.geometry.getAttribute('linePos');
-  let idx = 0;
+  const vertices = [];
+  const sides = [];
+  const linePos = [];
+  const colors = [];
+  const largest = pairs.reduce((m, p) => Math.max(m, p.distance), 0);
   pairs.forEach(pair => {
-    const p1 = pair.starA.spherePosition;
-    const p2 = pair.starB.spherePosition;
-    if (!p1 || !p2) return;
-    const pts = greatCircleToMollweide(p1, p2, 100, segsCount, getMollweideLambda0());
-    const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
-    const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
+    const c1 = new THREE.Color(pair.starA.displayColor || '#ffffff');
+    const c2 = new THREE.Color(pair.starB.displayColor || '#ffffff');
+    const pts = greatCircleToMollweide(
+      pair.starA.spherePosition,
+      pair.starB.spherePosition,
+      100,
+      lineSegs.userData.segments || GC_SEGMENTS,
+      getMollweideLambda0()
+    );
     for (let j = 0; j < pts.length - 1; j++) {
       const segs = splitMollweideWrap(pts[j], pts[j + 1]);
       segs.forEach(([s, e]) => {
-        if (idx + 6 > posAttr.array.length) return;
-        posAttr.array[idx] = s.x; posAttr.array[idx+1] = s.y; posAttr.array[idx+2] = s.z;
-        posAttr.array[idx+3] = e.x; posAttr.array[idx+4] = e.y; posAttr.array[idx+5] = e.z;
-        const t1 = j / (pts.length - 1);
-        const t2 = (j + 1) / (pts.length - 1);
-        colorAttr.array[idx]   = THREE.MathUtils.lerp(cA.r, cB.r, t1);
-        colorAttr.array[idx+1] = THREE.MathUtils.lerp(cA.g, cB.g, t1);
-        colorAttr.array[idx+2] = THREE.MathUtils.lerp(cA.b, cB.b, t1);
-        colorAttr.array[idx+3] = THREE.MathUtils.lerp(cA.r, cB.r, t2);
-        colorAttr.array[idx+4] = THREE.MathUtils.lerp(cA.g, cB.g, t2);
-        colorAttr.array[idx+5] = THREE.MathUtils.lerp(cA.b, cB.b, t2);
-        linePosAttr.array[idx/3] = t1;
-        linePosAttr.array[idx/3 + 1] = t2;
-        idx += 6;
+        const width = THREE.MathUtils.lerp(10, 1, pair.distance / (largest || pair.distance));
+        const geom = buildWideLineGeometry([s, e], width, c1, c2);
+        vertices.push(...geom.getAttribute('position').array);
+        sides.push(...geom.getAttribute('side').array);
+        linePos.push(...geom.getAttribute('linePos').array);
+        colors.push(...geom.getAttribute('color').array);
       });
     }
   });
-  // zero out remaining
-  for (; idx < posAttr.array.length; idx++) {
-    posAttr.array[idx] = 0;
-    colorAttr.array[idx] = 0;
-    linePosAttr.array[idx/3] = 0;
-  }
-  linePosAttr.needsUpdate = true;
-  posAttr.needsUpdate = true;
-  colorAttr.needsUpdate = true;
-  lineSegs.computeLineDistances();
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geometry.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geometry.setAttribute('linePos', new THREE.Float32BufferAttribute(linePos, 1));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+
+  lineSegs.geometry.dispose();
+  lineSegs.geometry = geometry;
 }
 
 /**
@@ -244,15 +299,13 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       );
       segments.forEach(([s1, s2]) => {
         const points = [s1, s2];
-        const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
-        geometryLine.setAttribute("linePos", new THREE.Float32BufferAttribute([0,1],1));
-        const col = c1.clone().lerp(c2, 0.5);
-        geometryLine.setAttribute("color", new THREE.Float32BufferAttribute([col.r,col.g,col.b,col.r,col.g,col.b],3));
-        const op = THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)) * opacityFactor;
+        const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)) * opacityFactor;
         const width = THREE.MathUtils.lerp(10, 1, distance / (largestPairDistance || distance));
-        const materialLine = createFadingLineMaterial(op, width);
-        const line = new THREE.Line(geometryLine, materialLine);
-        lines.push(line);
+        const geom = buildWideLineGeometry(points, width, c1, c2);
+        const material = createFadingLineMaterial(lineOpacity);
+        const mesh = new THREE.Mesh(geom, material);
+        mesh.renderOrder = 1;
+        lines.push(mesh);
       });
       return;
     } else {
@@ -260,8 +313,6 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       posA = getPosition(starA).clone();
       posB = getPosition(starB).clone();
     }
-    
-    const gradientColor = c1.clone().lerp(c2, 0.5);
     
     const normDist = distance / (largestPairDistance || distance);
     const lineThickness = THREE.MathUtils.lerp(10, 1, normDist);
@@ -275,18 +326,13 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
     } else {
       points = [posA, posB];
     }
-    const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
-    const tArray = points.map((p,i)=> i/(points.length-1));
-    geometryLine.setAttribute("linePos", new THREE.Float32BufferAttribute(tArray,1));
-    const colorArr = [];
-    for(let i=0;i<points.length;i++){ colorArr.push(gradientColor.r, gradientColor.g, gradientColor.b); }
-    geometryLine.setAttribute("color", new THREE.Float32BufferAttribute(colorArr,3));
-    const materialLine = createFadingLineMaterial(lineOpacity, lineThickness);
-    const line = new THREE.Line(geometryLine, materialLine);
+    const geom = buildWideLineGeometry(points, lineThickness, c1, c2);
+    const materialLine = createFadingLineMaterial(lineOpacity);
+    const mesh = new THREE.Mesh(geom, materialLine);
     if (mapType === 'Globe') {
-      line.renderOrder = 1;
+      mesh.renderOrder = 1;
     }
-    lines.push(line);
+    lines.push(mesh);
   });
   return lines;
 }

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -5,6 +5,35 @@ import { adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide, getMol
 
 const GC_SEGMENTS = 32;
 
+function createFadingLineMaterial(opacity = 1.0, lineWidth = 1) {
+  return new THREE.ShaderMaterial({
+    uniforms: { opacity: { value: opacity } },
+    transparent: true,
+    vertexColors: true,
+    linewidth: lineWidth,
+    vertexShader: `
+      attribute float linePos;
+      varying float vPos;
+      varying vec3 vColor;
+      void main() {
+        vPos = linePos;
+        vColor = color;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      uniform float opacity;
+      varying float vPos;
+      varying vec3 vColor;
+      void main() {
+        float fade = smoothstep(0.0, 0.1, vPos) * smoothstep(1.0, 0.9, vPos);
+        gl_FragColor = vec4(vColor, opacity * fade);
+        if(gl_FragColor.a <= 0.0) discard;
+      }
+    `
+  });
+}
+
 /**
  * Helper: Returns a THREE.Vector3 for a star’s position.
  *  - If star.truePosition is available, it is returned.
@@ -75,6 +104,7 @@ export function computeConnectionPairs(stars, maxDistance) {
 export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates', opacity = 0.5) {
   const positions = [];
   const colors = [];
+  const linePositions = [];
 
   connectionObjs.forEach(pair => {
     const { starA, starB } = pair;
@@ -94,6 +124,7 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
         const cA = new THREE.Color(starA.displayColor || '#ffffff');
         const cB = new THREE.Color(starB.displayColor || '#ffffff');
         colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
+          linePositions.push(0, 1);
       });
       return; // continue to next pair
     } else {
@@ -103,21 +134,18 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
     positions.push(posA.x, posA.y, posA.z);
     positions.push(posB.x, posB.y, posB.z);
 
+    linePositions.push(0, 1);
     const cA = new THREE.Color(starA.displayColor || '#ffffff');
     const cB = new THREE.Color(starB.displayColor || '#ffffff');
     colors.push(cA.r, cA.g, cA.b, cB.r, cB.g, cB.b);
   });
   
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions,3));
   geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
-  
-  const material = new THREE.LineBasicMaterial({
-    vertexColors: true,
-    transparent: true,
-    opacity,
-    linewidth: 1
-  });
+  geometry.setAttribute('linePos', new THREE.Float32BufferAttribute(linePositions,1));
+
+  const material = createFadingLineMaterial(opacity, 1);
   
   const mergedLines = new THREE.LineSegments(geometry, material);
   return mergedLines;
@@ -127,15 +155,12 @@ export function createMollweideConnectionSegments(pairs, opacity = 0.5) {
   const segCount = pairs.length * GC_SEGMENTS * 2; // each GC segment may wrap
   const positions = new Float32Array(segCount * 2 * 3);
   const colors = new Float32Array(segCount * 2 * 3);
+  const linePosArr = new Float32Array(segCount * 2);
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-  const material = new THREE.LineBasicMaterial({
-    vertexColors: true,
-    transparent: true,
-    opacity,
-    linewidth: 1
-  });
+  geometry.setAttribute('linePos', new THREE.BufferAttribute(linePosArr, 1));
+  const material = createFadingLineMaterial(opacity, 1);
   const lineSegs = new THREE.LineSegments(geometry, material);
   lineSegs.userData = { pairs, segments: GC_SEGMENTS };
   updateMollweideConnectionSegments(lineSegs);
@@ -147,6 +172,7 @@ export function updateMollweideConnectionSegments(lineSegs) {
   const segsCount = lineSegs.userData.segments || GC_SEGMENTS;
   const posAttr = lineSegs.geometry.getAttribute('position');
   const colorAttr = lineSegs.geometry.getAttribute('color');
+  const linePosAttr = lineSegs.geometry.getAttribute('linePos');
   let idx = 0;
   pairs.forEach(pair => {
     const p1 = pair.starA.spherePosition;
@@ -169,6 +195,8 @@ export function updateMollweideConnectionSegments(lineSegs) {
         colorAttr.array[idx+3] = THREE.MathUtils.lerp(cA.r, cB.r, t2);
         colorAttr.array[idx+4] = THREE.MathUtils.lerp(cA.g, cB.g, t2);
         colorAttr.array[idx+5] = THREE.MathUtils.lerp(cA.b, cB.b, t2);
+        linePosAttr.array[idx/3] = t1;
+        linePosAttr.array[idx/3 + 1] = t2;
         idx += 6;
       });
     }
@@ -177,7 +205,9 @@ export function updateMollweideConnectionSegments(lineSegs) {
   for (; idx < posAttr.array.length; idx++) {
     posAttr.array[idx] = 0;
     colorAttr.array[idx] = 0;
+    linePosAttr.array[idx/3] = 0;
   }
+  linePosAttr.needsUpdate = true;
   posAttr.needsUpdate = true;
   colorAttr.needsUpdate = true;
   lineSegs.computeLineDistances();
@@ -215,12 +245,12 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       segments.forEach(([s1, s2]) => {
         const points = [s1, s2];
         const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
-        const materialLine = new THREE.LineBasicMaterial({
-          color: c1.clone().lerp(c2, 0.5),
-          transparent: true,
-          opacity: THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)),
-          linewidth: THREE.MathUtils.lerp(5, 1, distance / (largestPairDistance || distance))
-        });
+        geometryLine.setAttribute("linePos", new THREE.Float32BufferAttribute([0,1],1));
+        const col = c1.clone().lerp(c2, 0.5);
+        geometryLine.setAttribute("color", new THREE.Float32BufferAttribute([col.r,col.g,col.b,col.r,col.g,col.b],3));
+        const op = THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)) * opacityFactor;
+        const width = THREE.MathUtils.lerp(10, 1, distance / (largestPairDistance || distance));
+        const materialLine = createFadingLineMaterial(op, width);
         const line = new THREE.Line(geometryLine, materialLine);
         lines.push(line);
       });
@@ -234,7 +264,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
     const gradientColor = c1.clone().lerp(c2, 0.5);
     
     const normDist = distance / (largestPairDistance || distance);
-    const lineThickness = THREE.MathUtils.lerp(5, 1, normDist);
+    const lineThickness = THREE.MathUtils.lerp(10, 1, normDist);
     const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
     
     let points;
@@ -245,14 +275,13 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
     } else {
       points = [posA, posB];
     }
-
     const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
-    const materialLine = new THREE.LineBasicMaterial({
-      color: gradientColor,
-      transparent: true,
-      opacity: lineOpacity,
-      linewidth: lineThickness
-    });
+    const tArray = points.map((p,i)=> i/(points.length-1));
+    geometryLine.setAttribute("linePos", new THREE.Float32BufferAttribute(tArray,1));
+    const colorArr = [];
+    for(let i=0;i<points.length;i++){ colorArr.push(gradientColor.r, gradientColor.g, gradientColor.b); }
+    geometryLine.setAttribute("color", new THREE.Float32BufferAttribute(colorArr,3));
+    const materialLine = createFadingLineMaterial(lineOpacity, lineThickness);
     const line = new THREE.Line(geometryLine, materialLine);
     if (mapType === 'Globe') {
       line.renderOrder = 1;

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -22,9 +22,12 @@ function createWideLineMaterial(color) {
     side: THREE.DoubleSide,
     vertexShader: `
       attribute float side;
+      attribute float linePos;
       varying float vSide;
+      varying float vPos;
       void main() {
         vSide = side;
+        vPos = linePos;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
     `,
@@ -32,8 +35,10 @@ function createWideLineMaterial(color) {
       uniform vec3 color;
       uniform float opacityFactor;
       varying float vSide;
+      varying float vPos;
       void main() {
         float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        alpha *= smoothstep(0.0, 0.1, vPos) * smoothstep(1.0, 0.9, vPos);
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -44,6 +49,7 @@ function createWideLineMaterial(color) {
 function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
+  const linePos = [];
   for (let i = 0; i < points.length; i += 2) {
     const p1 = points[i];
     const p2 = points[i + 1];
@@ -56,12 +62,15 @@ function buildWideLineGeometry(points, width) {
 
     vertices.push(a1.x, a1.y, a1.z, a2.x, a2.y, a2.z, b2.x, b2.y, b2.z);
     sides.push(1, -1, -1);
+    linePos.push(0, 0, 1);
     vertices.push(a1.x, a1.y, a1.z, b2.x, b2.y, b2.z, b1.x, b1.y, b1.z);
     sides.push(1, -1, 1);
+    linePos.push(0, 1, 1);
   }
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
   geom.setAttribute('side', new THREE.Float32BufferAttribute(sides, 1));
+  geom.setAttribute('linePos', new THREE.Float32BufferAttribute(linePos, 1));
   return geom;
 }
 

--- a/stellar_class.json
+++ b/stellar_class.json
@@ -1,52 +1,52 @@
 {
   "O": {
-    "color": "#9bb0ff",
-    "size": 8,
+    "color": "#4E8CFF",
+    "size": 16,
     "hierarchy": 1
   },
   "B": {
-    "color": "#aabfff",
-    "size": 7,
+    "color": "#80AFFF",
+    "size": 14,
     "hierarchy": 2
   },
   "A": {
-    "color": "#cad7ff",
-    "size": 6,
+    "color": "#CAD8FF",
+    "size": 12,
     "hierarchy": 3
   },
   "F": {
-    "color": "#f8f7ff",
-    "size": 5,
+    "color": "#F5F8E7",
+    "size": 10,
     "hierarchy": 4
   },
   "G": {
-    "color": "#fff4ea",
-    "size": 4,
+    "color": "#FFEFA1",
+    "size": 8,
     "hierarchy": 5
   },
   "K": {
-    "color": "#ffd2a1",
-    "size": 3,
+    "color": "#FFC074",
+    "size": 7,
     "hierarchy": 6
   },
   "M": {
-    "color": "#ffcc6f",
-    "size": 2,
+    "color": "#FF7259",
+    "size": 6,
     "hierarchy": 7
   },
   "L": {
-    "color": "#ffb46f",
-    "size": 1.6,
+    "color": "#B34747",
+    "size": 5,
     "hierarchy": 8
   },
   "T": {
-    "color": "#639bff",
-    "size": 1.2,
+    "color": "#6A4FC9",
+    "size": 4,
     "hierarchy": 9
   },
   "Y": {
-    "color": "#0000ff",
-    "size": 0.8,
+    "color": "#3B2717",
+    "size": 4,
     "hierarchy": 10
   }
 }

--- a/stellar_class.json
+++ b/stellar_class.json
@@ -1,22 +1,22 @@
 {
   "O": {
     "color": "#4E8CFF",
-    "size": 16,
+    "size": 12,
     "hierarchy": 1
   },
   "B": {
     "color": "#80AFFF",
-    "size": 14,
+    "size": 10,
     "hierarchy": 2
   },
   "A": {
     "color": "#CAD8FF",
-    "size": 12,
+    "size": 9,
     "hierarchy": 3
   },
   "F": {
     "color": "#F5F8E7",
-    "size": 10,
+    "size": 8.5,
     "hierarchy": 4
   },
   "G": {
@@ -26,27 +26,27 @@
   },
   "K": {
     "color": "#FFC074",
-    "size": 7,
+    "size": 7.5,
     "hierarchy": 6
   },
   "M": {
     "color": "#FF7259",
-    "size": 6,
+    "size": 7,
     "hierarchy": 7
   },
   "L": {
     "color": "#B34747",
-    "size": 5,
+    "size": 6.5,
     "hierarchy": 8
   },
   "T": {
     "color": "#6A4FC9",
-    "size": 4,
+    "size": 6,
     "hierarchy": 9
   },
   "Y": {
     "color": "#3B2717",
-    "size": 4,
+    "size": 6,
     "hierarchy": 10
   }
 }


### PR DESCRIPTION
## Summary
- update stellar class color palette and sizes
- scale connection line width up to 10 for nearby pairs
- fade ends of custom wide lines used in density and cloud filters
- smooth connection lines with fading shader

## Testing
- `node -e "require('./filters/connectionsFilter.js'); require('./filters/densityFilter.js'); require('./filters/cloudsFilter.js');"` *(fails: ERR_NETWORK_IMPORT_DISALLOWED)*

------
https://chatgpt.com/codex/tasks/task_e_6885e4cefe9c832aa101379e98edcf0b