### PR TITLE
Adjust star sizes and connection visuals

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -216,7 +216,7 @@ export function updateMollweideConnectionSegments(lineSegs) {
     const p1 = pair.starA.spherePosition;
     const p2 = pair.starB.spherePosition;
     if (!p1 || !p2) return;
-    const pts = greatCircleToMollweide(p1, p2, 100, segsCount, getMollweideLambda0());
+    const pts = greatCircleToMollweide(p1, p2, 50, segsCount, getMollweideLambda0());
     const cA = new THREE.Color(pair.starA.displayColor || '#ffffff');
     const cB = new THREE.Color(pair.starB.displayColor || '#ffffff');
     for (let j = 0; j < pts.length - 1; j++) {
@@ -276,7 +276,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
       const normDist = (distance - smallestPairDistance) / (largestPairDistance - smallestPairDistance || 1);
       const width = THREE.MathUtils.lerp(5, 1, normDist);
-      const opacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
+      const opacity = THREE.MathUtils.lerp(1.0, 0.0, normDist) * opacityFactor;
       const segments = splitMollweideWrap(
         starA.mollweidePosition,
         starB.mollweidePosition
@@ -301,13 +301,12 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
 
     const normDist = (distance - smallestPairDistance) / (largestPairDistance - smallestPairDistance || 1);
     const lineThickness = THREE.MathUtils.lerp(5, 1, normDist);
-    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
+    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.0, normDist) * opacityFactor;
     
     let points;
     if (mapType === 'Globe') {
       const R = 100;
-      const curve = new THREE.CatmullRomCurve3(getGreatCirclePoints(posA, posB, R, 32));
-      points = curve.getPoints(32);
+      points = getGreatCirclePoints(posA, posB, R, 16);
     } else {
       points = [posA, posB];
     }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -219,10 +219,10 @@ class DensityGridOverlay {
         const neighborKey = `${cell.grid.ix + dir.dx},${cell.grid.iy + dir.dy},${cell.grid.iz + dir.dz}`;
         if (cellMap.has(neighborKey)) {
           const neighbor = cellMap.get(neighborKey);
-          const points = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 16);
+          const points = getGreatCirclePoints(cell.globeMesh.position, neighbor.globeMesh.position, 100, 8);
           const positions = [];
           const mollPts = getGreatCirclePoints(cell.globeMesh.position,
-            neighbor.globeMesh.position, 100, 16).map(v => {
+            neighbor.globeMesh.position, 100, 8).map(v => {
               const { ra, dec } = vectorToRaDecRad(v, 100);
               return radToMollweide(ra, dec, 100, getMollweideLambda0());
             });
@@ -357,7 +357,7 @@ class DensityGridOverlay {
     });
     this.adjacentLines.forEach(obj => {
       const gcPts = getGreatCirclePoints(obj.cell1.globeMesh.position,
-        obj.cell2.globeMesh.position, 100, 16).map(v => {
+        obj.cell2.globeMesh.position, 100, 8).map(v => {
           const { ra, dec } = vectorToRaDecRad(v, 100);
           return radToMollweide(ra, dec, 100, lambda0);
         });

--- a/filters/sizeFilter.js
+++ b/filters/sizeFilter.js
@@ -32,7 +32,7 @@ export function applySizeFilter(stars, filters) {
       }
 
       const classData = stellarClassData[primaryClass];
-      star.displaySize = classData ? classData.size : 1; // fallback to 1 if not found
+      star.displaySize = classData ? classData.size : 8; // fallback size for unknown classes
     });
   } else {
     // Default if no recognized size filter

--- a/stellar_class.json
+++ b/stellar_class.json
@@ -1,52 +1,52 @@
 {
   "O": {
     "color": "#4E8CFF",
-    "size": 10,
+    "size": 16,
     "hierarchy": 1
   },
   "B": {
     "color": "#80AFFF",
-    "size": 8.7,
+    "size": 15,
     "hierarchy": 2
   },
   "A": {
     "color": "#CAD8FF",
-    "size": 7.3,
+    "size": 14,
     "hierarchy": 3
   },
   "F": {
     "color": "#F5F8E7",
-    "size": 6,
+    "size": 12,
     "hierarchy": 4
   },
   "G": {
     "color": "#FFEFA1",
-    "size": 4.7,
+    "size": 11,
     "hierarchy": 5
   },
   "K": {
     "color": "#FFC074",
-    "size": 4,
+    "size": 10,
     "hierarchy": 6
   },
   "M": {
     "color": "#FF7259",
-    "size": 3.3,
+    "size": 9,
     "hierarchy": 7
   },
   "L": {
     "color": "#B34747",
-    "size": 2.7,
+    "size": 8.5,
     "hierarchy": 8
   },
   "T": {
     "color": "#6A4FC9",
-    "size": 2,
+    "size": 8,
     "hierarchy": 9
   },
   "Y": {
     "color": "#3B2717",
-    "size": 2,
+    "size": 8,
     "hierarchy": 10
   }
 }


### PR DESCRIPTION
## Summary
- use larger stellar class sizes
- default size for unknown classes is 8
- use fewer points for great-circle connections and density lines
- fade connection lines with distance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886040d1494832a9ae98803572320f5