### PR TITLE
Update star sizes and line opacity logic

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -276,7 +276,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       if (!starA.mollweidePosition || !starB.mollweidePosition) return;
       const normDist = (distance - smallestPairDistance) / (largestPairDistance - smallestPairDistance || 1);
       const width = THREE.MathUtils.lerp(5, 1, normDist);
-      const opacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
+      const opacity = THREE.MathUtils.lerp(1.0, 0.0, normDist) * opacityFactor;
       const segments = splitMollweideWrap(
         starA.mollweidePosition,
         starB.mollweidePosition
@@ -301,7 +301,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
 
     const normDist = (distance - smallestPairDistance) / (largestPairDistance - smallestPairDistance || 1);
     const lineThickness = THREE.MathUtils.lerp(5, 1, normDist);
-    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
+    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.0, normDist) * opacityFactor;
     
     let points;
     if (mapType === 'Globe') {

--- a/filters/sizeFilter.js
+++ b/filters/sizeFilter.js
@@ -32,7 +32,7 @@ export function applySizeFilter(stars, filters) {
       }
 
       const classData = stellarClassData[primaryClass];
-      star.displaySize = classData ? classData.size : 1; // fallback to 1 if not found
+      star.displaySize = classData ? classData.size : 8; // fallback to 8 if not found
     });
   } else {
     // Default if no recognized size filter

--- a/stellar_class.json
+++ b/stellar_class.json
@@ -1,52 +1,52 @@
 {
   "O": {
     "color": "#4E8CFF",
-    "size": 10,
+    "size": 16,
     "hierarchy": 1
   },
   "B": {
     "color": "#80AFFF",
-    "size": 8.7,
+    "size": 15,
     "hierarchy": 2
   },
   "A": {
     "color": "#CAD8FF",
-    "size": 7.3,
+    "size": 14,
     "hierarchy": 3
   },
   "F": {
     "color": "#F5F8E7",
-    "size": 6,
+    "size": 12,
     "hierarchy": 4
   },
   "G": {
     "color": "#FFEFA1",
-    "size": 4.7,
+    "size": 11,
     "hierarchy": 5
   },
   "K": {
     "color": "#FFC074",
-    "size": 4,
+    "size": 10,
     "hierarchy": 6
   },
   "M": {
     "color": "#FF7259",
-    "size": 3.3,
+    "size": 9,
     "hierarchy": 7
   },
   "L": {
     "color": "#B34747",
-    "size": 2.7,
+    "size": 8.5,
     "hierarchy": 8
   },
   "T": {
     "color": "#6A4FC9",
-    "size": 2,
+    "size": 8,
     "hierarchy": 9
   },
   "Y": {
     "color": "#3B2717",
-    "size": 2,
+    "size": 8,
     "hierarchy": 10
   }
 }


### PR DESCRIPTION
## Summary
- adjust star sizes by spectral class
- default to size 8 when class is missing
- fade connection lines by distance so farthest lines become fully transparent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68860b42c6c0832aa300cf064de9cdb5