### PR TITLE
Load stellar class data before UI generation

### DIFF
--- a/filters/index.js
+++ b/filters/index.js
@@ -37,7 +37,7 @@ export async function setupFilterUI(allStars) {
     console.warn('[setupFilterUI] No #filters-form found in DOM!');
     return;
   }
-  loadStellarClassData();
+  await loadStellarClassData();
   scGenerate(allStars);
   const mainLegends = filterForm.querySelectorAll('legend.collapsible');
   mainLegends.forEach(legend => {


### PR DESCRIPTION
## Summary
- wait for `loadStellarClassData` before generating stellar class filters

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886187d3a84832a96d6c600ad4ec4be