### PR TITLE
Add controls for line width and fading

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -72,7 +72,7 @@ export function computeConnectionPairs(stars, maxDistance) {
  * @param {Array} connectionObjs - Array of connection objects.
  * @returns {THREE.LineSegments} - The merged connection lines.
  */
-export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates', opacity = 0.5) {
+export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates', opacity = 0.5, lineWidth = 1) {
   const positions = [];
   const colors = [];
 
@@ -116,14 +116,14 @@ export function mergeConnectionLines(connectionObjs, mapType = 'TrueCoordinates'
     vertexColors: true,
     transparent: true,
     opacity,
-    linewidth: 1
+    linewidth: lineWidth
   });
   
   const mergedLines = new THREE.LineSegments(geometry, material);
   return mergedLines;
 }
 
-export function createMollweideConnectionSegments(pairs, opacity = 0.5) {
+export function createMollweideConnectionSegments(pairs, opacity = 0.5, lineWidth = 1) {
   const segCount = pairs.length * GC_SEGMENTS * 2; // each GC segment may wrap
   const positions = new Float32Array(segCount * 2 * 3);
   const colors = new Float32Array(segCount * 2 * 3);
@@ -134,7 +134,7 @@ export function createMollweideConnectionSegments(pairs, opacity = 0.5) {
     vertexColors: true,
     transparent: true,
     opacity,
-    linewidth: 1
+    linewidth: lineWidth
   });
   const lineSegs = new THREE.LineSegments(geometry, material);
   lineSegs.userData = { pairs, segments: GC_SEGMENTS };
@@ -191,7 +191,7 @@ export function updateMollweideConnectionSegments(lineSegs) {
  * @param {string} mapType - 'Globe' or other.
  * @returns {Array} - Array of THREE.Line objects.
  */
-export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5) {
+export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5, maxWidth = 5, fadePower = 1) {
   if (!pairs || pairs.length === 0) return [];
   
   const largestPairDistance = pairs.reduce((max, p) => Math.max(max, p.distance), 0);
@@ -215,11 +215,12 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       segments.forEach(([s1, s2]) => {
         const points = [s1, s2];
         const geometryLine = new THREE.BufferGeometry().setFromPoints(points);
+        const nrm = distance / (largestPairDistance || distance);
         const materialLine = new THREE.LineBasicMaterial({
           color: c1.clone().lerp(c2, 0.5),
           transparent: true,
-          opacity: THREE.MathUtils.lerp(1.0, 0.3, distance / (largestPairDistance || distance)),
-          linewidth: THREE.MathUtils.lerp(5, 1, distance / (largestPairDistance || distance))
+          opacity: THREE.MathUtils.lerp(1.0, 0.3, Math.pow(nrm, fadePower)) * opacityFactor,
+          linewidth: THREE.MathUtils.lerp(maxWidth, 1, nrm)
         });
         const line = new THREE.Line(geometryLine, materialLine);
         lines.push(line);
@@ -234,8 +235,9 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
     const gradientColor = c1.clone().lerp(c2, 0.5);
     
     const normDist = distance / (largestPairDistance || distance);
-    const lineThickness = THREE.MathUtils.lerp(5, 1, normDist);
-    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, normDist) * opacityFactor;
+    const lineThickness = THREE.MathUtils.lerp(maxWidth, 1, normDist);
+    const fadeT = Math.pow(normDist, fadePower);
+    const lineOpacity = THREE.MathUtils.lerp(1.0, 0.3, fadeT) * opacityFactor;
     
     let points;
     if (mapType === 'Globe') {

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -15,7 +15,8 @@ function createWideLineMaterial(color) {
   return new THREE.ShaderMaterial({
     uniforms: {
       color: { value: new THREE.Color(color) },
-      opacityFactor: { value: 1.0 }
+      opacityFactor: { value: 1.0 },
+      fadePower: { value: 1.0 }
     },
     transparent: true,
     depthWrite: false,
@@ -31,9 +32,10 @@ function createWideLineMaterial(color) {
     fragmentShader: `
       uniform vec3 color;
       uniform float opacityFactor;
+      uniform float fadePower;
       varying float vSide;
       void main() {
-        float alpha = 0.5 * (1.0 - abs(vSide)) * opacityFactor;
+        float alpha = pow(0.5 * (1.0 - abs(vSide)), fadePower) * opacityFactor;
         if(alpha <= 0.0) discard;
         gl_FragColor = vec4(color, alpha);
       }
@@ -75,6 +77,7 @@ class DensityGridOverlay {
     this.maxDensity = 0;
     this.mollLineWidth = 30; // width of connection lines on the Mollweide map
     this.opacityFactor = 1.0;
+    this.fadePower = 1.0;
   }
 
   createGrid(stars) {
@@ -237,6 +240,7 @@ class DensityGridOverlay {
           const line = new THREE.Line(geom, mat);
           line.renderOrder = 1;
           const mollMat = createWideLineMaterial(0xff0000);
+          mollMat.uniforms.fadePower.value = this.fadePower;
           const lineM = new THREE.Mesh(geomM, mollMat);
           lineM.renderOrder = 1;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
@@ -251,11 +255,15 @@ class DensityGridOverlay {
     const bottomSlider = document.getElementById('density-bottom-slider');
     const topSlider = document.getElementById('density-top-slider');
     const opacitySlider = document.getElementById('density-opacity-slider');
+    const widthSlider = document.getElementById('density-line-width-slider');
+    const fadeSlider = document.getElementById('density-fade-slider');
     const radius = radiusSlider ? parseFloat(radiusSlider.value) : 10;
     const tolerance = tolSlider ? parseInt(tolSlider.value) : 0;
     const bottomPct = bottomSlider ? parseFloat(bottomSlider.value) : 10;
     const topPct = topSlider ? parseFloat(topSlider.value) : 10;
     this.opacityFactor = opacitySlider ? parseFloat(opacitySlider.value) / 100 : 1.0;
+    this.mollLineWidth = widthSlider ? parseFloat(widthSlider.value) : this.mollLineWidth;
+    this.fadePower = fadeSlider ? parseFloat(fadeSlider.value) : this.fadePower;
 
     const extendedStars = stars.filter(star => {
       const d = star.Distance_from_the_Sun;
@@ -317,12 +325,25 @@ class DensityGridOverlay {
         const c2 = cell2.tcMesh.material.color;
         const avgColor = c1.clone().lerp(c2, 0.5);
         const avgOpacity = (cell1.tcMesh.material.opacity + cell2.tcMesh.material.opacity) / 2;
+        const gcPts = getGreatCirclePoints(cell1.globeMesh.position,
+          cell2.globeMesh.position, 100, 16).map(v => {
+            const { ra, dec } = vectorToRaDecRad(v, 100);
+            return radToMollweide(ra, dec, 100, getMollweideLambda0());
+          });
+        const pts = [];
+        for (let i = 0; i < gcPts.length - 1; i++) {
+          const segs = splitMollweideWrap(gcPts[i], gcPts[i + 1]);
+          segs.forEach(([s,e]) => { pts.push(s, e); });
+        }
+        lineM.geometry.dispose();
+        lineM.geometry = buildWideLineGeometry(pts, this.mollLineWidth);
         line.material.color.copy(avgColor);
         line.material.opacity = avgOpacity;
         line.material.vertexColors = false;
         line.material.needsUpdate = true;
         lineM.material.uniforms.color.value.copy(avgColor);
         lineM.material.uniforms.opacityFactor.value = avgOpacity;
+        lineM.material.uniforms.fadePower.value = this.fadePower;
         lineM.material.needsUpdate = true;
       }
     });
@@ -359,6 +380,7 @@ class DensityGridOverlay {
       }
       obj.lineM.geometry.dispose();
       obj.lineM.geometry = buildWideLineGeometry(pts, this.mollLineWidth);
+      obj.lineM.material.uniforms.fadePower.value = this.fadePower;
     });
   }
 }
@@ -366,6 +388,10 @@ class DensityGridOverlay {
 export function initDensityFilter(minDistance, maxDistance, starArray, gridSize = 2) {
   const overlay = new DensityGridOverlay(minDistance, maxDistance, gridSize);
   overlay.createGrid(starArray);
+  const w = document.getElementById('density-line-width-slider');
+  if (w) overlay.mollLineWidth = parseFloat(w.value);
+  const f = document.getElementById('density-fade-slider');
+  if (f) overlay.fadePower = parseFloat(f.value);
   return overlay;
 }
 

--- a/filters/index.js
+++ b/filters/index.js
@@ -334,6 +334,8 @@ export function applyFilters(allStars) {
         starOpacity: 100,
         starNameOpacity: 100,
         connectionOpacity: 50,
+        connectionLineWidth: 5,
+        connectionFade: 1,
         constellationLineOpacity: 40,
         constellationNameOpacity: 80,
         planeOpacity: 50,
@@ -343,6 +345,8 @@ export function applyFilters(allStars) {
         maxDistance: 20,
         isolationGridSize: 1,
         densityGridSize: 1,
+        densityLineWidth: 30,
+        densityFade: 1,
         showClouds: false,
         showGalacticPlane: false,
         showEclipticPlane: false,
@@ -381,13 +385,17 @@ export function applyFilters(allStars) {
     starOpacity: parseFloat(formData.get('star-opacity')) || 100,
     starNameOpacity: parseFloat(formData.get('star-name-opacity')) || 100,
     connectionOpacity: parseFloat(formData.get('connection-opacity')) || 50,
+    connectionLineWidth: parseFloat(formData.get('connection-width')) || 5,
+    connectionFade: parseFloat(formData.get('connection-fade')) || 1,
     constellationLineOpacity: parseFloat(formData.get('constellation-line-opacity')) || 40,
     constellationNameOpacity: parseFloat(formData.get('constellation-name-opacity')) || 80,
     planeOpacity: parseFloat(formData.get('plane-opacity')) || 50,
     showClouds: (formData.getAll('dust-clouds').length > 0),
     showGalacticPlane: (formData.get('show-galactic-plane') !== null),
     showEclipticPlane: (formData.get('show-ecliptic-plane') !== null),
-    showCelestialEquator: (formData.get('show-celestial-equator') !== null)
+    showCelestialEquator: (formData.get('show-celestial-equator') !== null),
+    densityLineWidth: parseFloat(formData.get('density-line-width')) || 30,
+    densityFade: parseFloat(formData.get('density-fade')) || 1
   };
 
   let filteredStars = applyDistanceFilter(allStars, filters);
@@ -544,6 +552,8 @@ export function applyFilters(allStars) {
     starOpacity: filters.starOpacity,
     starNameOpacity: filters.starNameOpacity,
     connectionOpacity: filters.connectionOpacity,
+    connectionLineWidth: filters.connectionLineWidth,
+    connectionFade: filters.connectionFade,
     constellationLineOpacity: filters.constellationLineOpacity,
     constellationNameOpacity: filters.constellationNameOpacity,
     planeOpacity: filters.planeOpacity,
@@ -551,6 +561,8 @@ export function applyFilters(allStars) {
     showGalacticPlane: filters.showGalacticPlane,
     showEclipticPlane: filters.showEclipticPlane,
     showCelestialEquator: filters.showCelestialEquator,
+    densityLineWidth: filters.densityLineWidth,
+    densityFade: filters.densityFade,
     isolationOverlay,
     densityOverlay
   };

--- a/index.html
+++ b/index.html
@@ -160,6 +160,18 @@
               <input type="number" id="connection-opacity-number" name="connection-opacity" min="0" max="100" value="50" step="1" disabled />
               <span id="connection-opacity-value">50</span>%
             </div>
+            <div class="filter-item">
+              <label for="connection-width-slider">Max Line Width:</label>
+              <input type="range" id="connection-width-slider" name="connection-width" min="1" max="10" value="5" step="0.5" disabled />
+              <input type="number" id="connection-width-number" name="connection-width" min="1" max="10" value="5" step="0.5" disabled />
+              <span id="connection-width-value">5</span>
+            </div>
+            <div class="filter-item">
+              <label for="connection-fade-slider">Edge Fade Hardness:</label>
+              <input type="range" id="connection-fade-slider" name="connection-fade" min="0.5" max="3" value="1" step="0.1" disabled />
+              <input type="number" id="connection-fade-number" name="connection-fade" min="0.5" max="3" value="1" step="0.1" disabled />
+              <span id="connection-fade-value">1</span>
+            </div>
           </div>
         </fieldset>
 
@@ -237,6 +249,18 @@
               <input type="range" id="density-opacity-slider" name="density-opacity" min="0" max="100" value="100" step="1" disabled />
               <input type="number" id="density-opacity-number" name="density-opacity" min="0" max="100" value="100" step="1" disabled />
               <span id="density-opacity-value">100</span>%
+            </div>
+            <div class="filter-item">
+              <label for="density-line-width-slider">Line Width:</label>
+              <input type="range" id="density-line-width-slider" name="density-line-width" min="5" max="100" value="30" step="1" disabled />
+              <input type="number" id="density-line-width-number" name="density-line-width" min="5" max="100" value="30" step="1" disabled />
+              <span id="density-line-width-value">30</span>
+            </div>
+            <div class="filter-item">
+              <label for="density-fade-slider">Edge Fade Hardness:</label>
+              <input type="range" id="density-fade-slider" name="density-fade" min="0.5" max="3" value="1" step="0.1" disabled />
+              <input type="number" id="density-fade-number" name="density-fade" min="0.5" max="3" value="1" step="0.1" disabled />
+              <span id="density-fade-value">1</span>
             </div>
           </div>
         </fieldset>

--- a/script.js
+++ b/script.js
@@ -466,6 +466,8 @@ async function buildAndApplyFilters() {
     starOpacity,
     starNameOpacity,
     connectionOpacity,
+    connectionLineWidth,
+    connectionFade,
     constellationLineOpacity,
     constellationNameOpacity,
     planeOpacity,
@@ -473,7 +475,9 @@ async function buildAndApplyFilters() {
     showEclipticPlane,
     showCelestialEquator,
     isolationOverlay: returnedIsolationOverlay,
-    densityOverlay: returnedDensityOverlay
+    densityOverlay: returnedDensityOverlay,
+    densityLineWidth,
+    densityFade
   } = filters;
 
   showConstellationBoundariesFlag = showConstellationBoundaries;
@@ -517,6 +521,12 @@ async function buildAndApplyFilters() {
   trueCoordinatesMap.setConnectionOpacity(connectionOpacity / 100);
   globeMap.setConnectionOpacity(connectionOpacity / 100);
   mollweideMap.setConnectionOpacity(connectionOpacity / 100);
+  trueCoordinatesMap.connectionLineWidth = connectionLineWidth;
+  globeMap.connectionLineWidth = connectionLineWidth;
+  mollweideMap.connectionLineWidth = connectionLineWidth;
+  trueCoordinatesMap.connectionFade = connectionFade;
+  globeMap.connectionFade = connectionFade;
+  mollweideMap.connectionFade = connectionFade;
 
   trueCoordinatesMap.connectionOpacity = connectionOpacity / 100;
   globeMap.connectionOpacity = connectionOpacity / 100;
@@ -803,6 +813,8 @@ class MapManager {
     this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
     this.starOpacity = 1.0;
     this.connectionOpacity = 0.5;
+    this.connectionLineWidth = 5;
+    this.connectionFade = 1;
     this.labelOpacity = 1.0;
     this.points = null;
     this.instancedMesh = null;
@@ -1009,13 +1021,13 @@ class MapManager {
     if (!connectionObjs || connectionObjs.length === 0) return;
     this.connectionGroup = new THREE.Group();
     if (this.mapType === 'Globe') {
-      const linesArray = createConnectionLines(stars, connectionObjs, 'Globe', opacity);
+      const linesArray = createConnectionLines(stars, connectionObjs, 'Globe', opacity, this.connectionLineWidth, this.connectionFade);
       linesArray.forEach(line => this.connectionGroup.add(line));
     } else if (this.mapType === 'Mollweide') {
-      const merged = createMollweideConnectionSegments(connectionObjs, opacity);
+      const merged = createMollweideConnectionSegments(connectionObjs, opacity, this.connectionLineWidth);
       this.connectionGroup.add(merged);
     } else {
-      const merged = mergeConnectionLines(connectionObjs, this.mapType, opacity);
+      const merged = mergeConnectionLines(connectionObjs, this.mapType, opacity, this.connectionLineWidth);
       this.connectionGroup.add(merged);
     }
     this.scene.add(this.connectionGroup);

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -13,12 +13,22 @@ export function initFilterUI() {
   const connectionNumber = document.getElementById('connection-number');
   const connectionOpacitySlider = document.getElementById('connection-opacity-slider');
   const connectionOpacityNumber = document.getElementById('connection-opacity-number');
+  const connectionWidthSlider = document.getElementById('connection-width-slider');
+  const connectionWidthNumber = document.getElementById('connection-width-number');
+  const connectionWidthSpan = document.getElementById('connection-width-value');
+  const connectionFadeSlider = document.getElementById('connection-fade-slider');
+  const connectionFadeNumber = document.getElementById('connection-fade-number');
+  const connectionFadeSpan = document.getElementById('connection-fade-value');
   enableConnectionsChk.addEventListener('change', function () {
     const enabled = this.checked;
     connectionSlider.disabled = !enabled;
     connectionNumber.disabled = !enabled;
     connectionOpacitySlider.disabled = !enabled;
     connectionOpacityNumber.disabled = !enabled;
+    if (connectionWidthSlider) connectionWidthSlider.disabled = !enabled;
+    if (connectionWidthNumber) connectionWidthNumber.disabled = !enabled;
+    if (connectionFadeSlider) connectionFadeSlider.disabled = !enabled;
+    if (connectionFadeNumber) connectionFadeNumber.disabled = !enabled;
   });
   connectionSlider.addEventListener('input', function () {
     connectionNumber.value = this.value;
@@ -34,6 +44,26 @@ export function initFilterUI() {
     connectionOpacitySlider.value = this.value;
     document.getElementById('connection-opacity-value').textContent = this.value;
   });
+  if (connectionWidthSlider && connectionWidthNumber && connectionWidthSpan) {
+    connectionWidthSlider.addEventListener('input', function () {
+      connectionWidthNumber.value = this.value;
+      connectionWidthSpan.textContent = this.value;
+    });
+    connectionWidthNumber.addEventListener('input', function () {
+      connectionWidthSlider.value = this.value;
+      connectionWidthSpan.textContent = this.value;
+    });
+  }
+  if (connectionFadeSlider && connectionFadeNumber && connectionFadeSpan) {
+    connectionFadeSlider.addEventListener('input', function () {
+      connectionFadeNumber.value = this.value;
+      connectionFadeSpan.textContent = this.value;
+    });
+    connectionFadeNumber.addEventListener('input', function () {
+      connectionFadeSlider.value = this.value;
+      connectionFadeSpan.textContent = this.value;
+    });
+  }
 
   // Isolation Filter UI controls.
   const enableIsolationChk = document.getElementById('enable-isolation-filter');
@@ -81,6 +111,12 @@ export function initFilterUI() {
   const densityGridNumber = document.getElementById('density-grid-number');
   const densityOpacitySlider = document.getElementById('density-opacity-slider');
   const densityOpacityNumber = document.getElementById('density-opacity-number');
+  const densityLineWidthSlider = document.getElementById('density-line-width-slider');
+  const densityLineWidthNumber = document.getElementById('density-line-width-number');
+  const densityLineWidthSpan = document.getElementById('density-line-width-value');
+  const densityFadeSlider = document.getElementById('density-fade-slider');
+  const densityFadeNumber = document.getElementById('density-fade-number');
+  const densityFadeSpan = document.getElementById('density-fade-value');
   const starOpacitySlider = document.getElementById('star-opacity-slider');
   const starOpacityNumber = document.getElementById('star-opacity-number');
   const starNameOpacitySlider = document.getElementById('star-name-opacity-slider');
@@ -98,6 +134,10 @@ export function initFilterUI() {
     densityGridNumber.disabled = !enabled;
     densityOpacitySlider.disabled = !enabled;
     densityOpacityNumber.disabled = !enabled;
+    if (densityLineWidthSlider) densityLineWidthSlider.disabled = !enabled;
+    if (densityLineWidthNumber) densityLineWidthNumber.disabled = !enabled;
+    if (densityFadeSlider) densityFadeSlider.disabled = !enabled;
+    if (densityFadeNumber) densityFadeNumber.disabled = !enabled;
   });
   densitySlider.addEventListener('input', function () {
     densityNumber.value = this.value;
@@ -140,6 +180,26 @@ export function initFilterUI() {
     densityOpacitySlider.value = this.value;
     document.getElementById('density-opacity-value').textContent = this.value;
   });
+  if (densityLineWidthSlider && densityLineWidthNumber && densityLineWidthSpan) {
+    densityLineWidthSlider.addEventListener('input', function () {
+      densityLineWidthNumber.value = this.value;
+      densityLineWidthSpan.textContent = this.value;
+    });
+    densityLineWidthNumber.addEventListener('input', function () {
+      densityLineWidthSlider.value = this.value;
+      densityLineWidthSpan.textContent = this.value;
+    });
+  }
+  if (densityFadeSlider && densityFadeNumber && densityFadeSpan) {
+    densityFadeSlider.addEventListener('input', function () {
+      densityFadeNumber.value = this.value;
+      densityFadeSpan.textContent = this.value;
+    });
+    densityFadeNumber.addEventListener('input', function () {
+      densityFadeSlider.value = this.value;
+      densityFadeSpan.textContent = this.value;
+    });
+  }
 
   starOpacitySlider.addEventListener('input', function () {
     starOpacityNumber.value = this.value;


### PR DESCRIPTION
## Summary
- add line width & fade sliders for connection and density lines
- synchronize new sliders in UI logic
- track width and fade values in filter system
- render connections and density overlay with customizable width and fade

## Testing
- `node --check ui/filterUI.js`
- `node --check filters/index.js`
- `node --check filters/connectionsFilter.js`
- `node --check filters/densityFilter.js`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68863176ec90832aa124f368e1ee8c41