### PR TITLE
Enhance density overlays with heatmap textures

### DIFF
--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -183,7 +183,7 @@ class CloudDensityGridOverlay {
   drawHeatmap(lambda0 = getMollweideLambda0()) {
     const ctx = this.ctx;
     ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
-    ctx.filter = 'blur(2px)';
+    ctx.filter = 'blur(4px)';
     const xScale = this.canvasWidth / 400;
     const yScale = this.canvasHeight / 200;
     this.cubesData.forEach(cell => {
@@ -199,8 +199,17 @@ class CloudDensityGridOverlay {
       const py = (100 - y) * yScale;
       const col = cell.mollweideMesh.material.color;
       const alpha = cell.mollweideMesh.material.opacity;
-      ctx.fillStyle = `rgba(${Math.round(col.r * 255)},${Math.round(col.g * 255)},${Math.round(col.b * 255)},${alpha})`;
-      ctx.fillRect(px - width / 2, py - height / 2, width, height);
+      const r = Math.round(col.r * 255);
+      const g = Math.round(col.g * 255);
+      const b = Math.round(col.b * 255);
+      const radius = Math.max(width, height) * 0.6;
+      const grd = ctx.createRadialGradient(px, py, 0, px, py, radius);
+      grd.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
+      grd.addColorStop(1, `rgba(${r},${g},${b},0)`);
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(px, py, radius, 0, Math.PI * 2);
+      ctx.fill();
     });
     ctx.filter = 'none';
     this.texture.needsUpdate = true;

--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -34,6 +34,23 @@ class CloudDensityGridOverlay {
     this.cubesData = [];
     this.color = uniqueColorFromName(cloudName);
     this.opacityFactor = 1.0;
+
+    this.canvasWidth = 1024;
+    this.canvasHeight = 512;
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = this.canvasWidth;
+    this.canvas.height = this.canvasHeight;
+    this.ctx = this.canvas.getContext('2d');
+    this.texture = new THREE.CanvasTexture(this.canvas);
+    this.texture.minFilter = THREE.LinearFilter;
+    this.texture.magFilter = THREE.LinearFilter;
+    const mat = new THREE.MeshBasicMaterial({
+      map: this.texture,
+      transparent: true,
+      depthWrite: false
+    });
+    this.textureMesh = new THREE.Mesh(new THREE.PlaneGeometry(400, 200), mat);
+    this.textureMesh.renderOrder = 2;
   }
 
   createGrid() {
@@ -155,7 +172,38 @@ class CloudDensityGridOverlay {
     });
     if (sceneTC) this.cubesData.forEach(c => sceneTC.add(c.tcMesh));
     if (sceneGlobe) this.cubesData.forEach(c => sceneGlobe.add(c.globeMesh));
-    if (sceneMoll) this.cubesData.forEach(c => sceneMoll.add(c.mollweideMesh));
+    if (sceneMoll) {
+      if (!sceneMoll.children.includes(this.textureMesh)) {
+        sceneMoll.add(this.textureMesh);
+      }
+    }
+    this.drawHeatmap(getMollweideLambda0());
+  }
+
+  drawHeatmap(lambda0 = getMollweideLambda0()) {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+    ctx.filter = 'blur(2px)';
+    const xScale = this.canvasWidth / 400;
+    const yScale = this.canvasHeight / 200;
+    this.cubesData.forEach(cell => {
+      if (!cell.active) return;
+      const lambda = minimalRADifference(cell.raRad - lambda0);
+      const x = cell.mollXFactor * lambda;
+      const y = cell.mollY;
+      const ratio = cell.tcPos.length() / this.maxDistance;
+      const scale = THREE.MathUtils.lerp(20.0, 0.1, Math.min(1, ratio));
+      const width = this.gridSize * scale * xScale;
+      const height = this.gridSize * scale * yScale;
+      const px = (x + 200) * xScale;
+      const py = (100 - y) * yScale;
+      const col = cell.mollweideMesh.material.color;
+      const alpha = cell.mollweideMesh.material.opacity;
+      ctx.fillStyle = `rgba(${Math.round(col.r * 255)},${Math.round(col.g * 255)},${Math.round(col.b * 255)},${alpha})`;
+      ctx.fillRect(px - width / 2, py - height / 2, width, height);
+    });
+    ctx.filter = 'none';
+    this.texture.needsUpdate = true;
   }
 
   refreshMollweide(lambda0 = getMollweideLambda0()) {
@@ -167,6 +215,7 @@ class CloudDensityGridOverlay {
         0
       );
     });
+    this.drawHeatmap(lambda0);
   }
 }
 

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -281,7 +281,7 @@ class DensityGridOverlay {
   drawHeatmap(lambda0 = getMollweideLambda0()) {
     const ctx = this.ctx;
     ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
-    ctx.filter = 'blur(2px)';
+    ctx.filter = 'blur(4px)';
     const xScale = this.canvasWidth / 400;
     const yScale = this.canvasHeight / 200;
     this.cubesData.forEach(cell => {
@@ -297,8 +297,17 @@ class DensityGridOverlay {
       const py = (100 - y) * yScale;
       const col = cell.mollweideMesh.material.color;
       const alpha = cell.mollweideMesh.material.opacity;
-      ctx.fillStyle = `rgba(${Math.round(col.r * 255)},${Math.round(col.g * 255)},${Math.round(col.b * 255)},${alpha})`;
-      ctx.fillRect(px - width / 2, py - height / 2, width, height);
+      const r = Math.round(col.r * 255);
+      const g = Math.round(col.g * 255);
+      const b = Math.round(col.b * 255);
+      const radius = Math.max(width, height) * 0.6;
+      const grd = ctx.createRadialGradient(px, py, 0, px, py, radius);
+      grd.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
+      grd.addColorStop(1, `rgba(${r},${g},${b},0)`);
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(px, py, radius, 0, Math.PI * 2);
+      ctx.fill();
     });
     ctx.filter = 'none';
     this.texture.needsUpdate = true;
@@ -403,7 +412,6 @@ class DensityGridOverlay {
       this.adjacentLines.forEach(o => { sceneGlobe.add(o.line); });
     }
     if (sceneMoll) {
-      this.adjacentLines.forEach(o => { sceneMoll.add(o.lineM); });
       if (!sceneMoll.children.includes(this.textureMesh)) {
         sceneMoll.add(this.textureMesh);
       }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -87,6 +87,27 @@ class DensityGridOverlay {
     this.mollLineWidth = 30; // width of connection lines on the Mollweide map
     this.opacityFactor = 1.0;
     this.fadePower = 1.0;
+
+    // Off-screen canvas for smooth Mollweide heatmap
+    this.canvasWidth = 1024;
+    this.canvasHeight = 512;
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = this.canvasWidth;
+    this.canvas.height = this.canvasHeight;
+    this.ctx = this.canvas.getContext('2d');
+    this.texture = new THREE.CanvasTexture(this.canvas);
+    this.texture.minFilter = THREE.LinearFilter;
+    this.texture.magFilter = THREE.LinearFilter;
+    const mat = new THREE.MeshBasicMaterial({
+      map: this.texture,
+      transparent: true,
+      depthWrite: false
+    });
+    this.textureMesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(400, 200),
+      mat
+    );
+    this.textureMesh.renderOrder = 2;
   }
 
   createGrid(stars) {
@@ -257,6 +278,32 @@ class DensityGridOverlay {
     });
   }
 
+  drawHeatmap(lambda0 = getMollweideLambda0()) {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+    ctx.filter = 'blur(2px)';
+    const xScale = this.canvasWidth / 400;
+    const yScale = this.canvasHeight / 200;
+    this.cubesData.forEach(cell => {
+      if (!cell.active) return;
+      const lambda = minimalRADifference(cell.raRad - lambda0);
+      const x = cell.mollXFactor * lambda;
+      const y = cell.mollY;
+      const ratio = cell.tcPos.length() / this.maxDistance;
+      const scale = THREE.MathUtils.lerp(20.0, 0.1, Math.min(1, ratio));
+      const width = this.gridSize * scale * xScale;
+      const height = this.gridSize * scale * yScale;
+      const px = (x + 200) * xScale;
+      const py = (100 - y) * yScale;
+      const col = cell.mollweideMesh.material.color;
+      const alpha = cell.mollweideMesh.material.opacity;
+      ctx.fillStyle = `rgba(${Math.round(col.r * 255)},${Math.round(col.g * 255)},${Math.round(col.b * 255)},${alpha})`;
+      ctx.fillRect(px - width / 2, py - height / 2, width, height);
+    });
+    ctx.filter = 'none';
+    this.texture.needsUpdate = true;
+  }
+
   update(stars, sceneTC, sceneGlobe, sceneMoll) {
     const radiusSlider = document.getElementById('density-slider');
     const tolSlider = document.getElementById('density-tolerance-slider');
@@ -357,7 +404,11 @@ class DensityGridOverlay {
     }
     if (sceneMoll) {
       this.adjacentLines.forEach(o => { sceneMoll.add(o.lineM); });
+      if (!sceneMoll.children.includes(this.textureMesh)) {
+        sceneMoll.add(this.textureMesh);
+      }
     }
+    this.drawHeatmap(getMollweideLambda0());
   }
 
   refreshMollweide(lambda0 = getMollweideLambda0()) {
@@ -386,6 +437,7 @@ class DensityGridOverlay {
         obj.lineM.material.uniforms.fadePower.value = this.fadePower;
       }
     });
+    this.drawHeatmap(lambda0);
   }
 }
 

--- a/filters/index.js
+++ b/filters/index.js
@@ -518,6 +518,7 @@ export function applyFilters(allStars) {
           window.globeMap.scene.remove(obj.line);
           window.mollweideMap.scene.remove(obj.lineM);
         });
+        window.mollweideMap.scene.remove(densityOverlay.textureMesh);
       }
       densityOverlay = initDensityFilter(filters.minDistance, filters.maxDistance, allStars, gridSize);
       densityOverlay.cubesData.forEach(cell => {
@@ -527,6 +528,7 @@ export function applyFilters(allStars) {
         window.globeMap.scene.add(obj.line);
         window.mollweideMap.scene.add(obj.lineM);
       });
+      window.mollweideMap.scene.add(densityOverlay.textureMesh);
     }
     updateDensityFilter(allStars, densityOverlay, window.trueCoordinatesMap.scene, window.globeMap.scene, window.mollweideMap.scene);
   } else {
@@ -538,6 +540,7 @@ export function applyFilters(allStars) {
         window.globeMap.scene.remove(obj.line);
         window.mollweideMap.scene.remove(obj.lineM);
       });
+      window.mollweideMap.scene.remove(densityOverlay.textureMesh);
       densityOverlay = null;
     }
   }

--- a/filters/index.js
+++ b/filters/index.js
@@ -516,7 +516,6 @@ export function applyFilters(allStars) {
         });
         densityOverlay.adjacentLines.forEach(obj => {
           window.globeMap.scene.remove(obj.line);
-          window.mollweideMap.scene.remove(obj.lineM);
         });
         window.mollweideMap.scene.remove(densityOverlay.textureMesh);
       }
@@ -526,7 +525,6 @@ export function applyFilters(allStars) {
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.add(obj.line);
-        window.mollweideMap.scene.add(obj.lineM);
       });
       window.mollweideMap.scene.add(densityOverlay.textureMesh);
     }
@@ -538,7 +536,6 @@ export function applyFilters(allStars) {
       });
       densityOverlay.adjacentLines.forEach(obj => {
         window.globeMap.scene.remove(obj.line);
-        window.mollweideMap.scene.remove(obj.lineM);
       });
       window.mollweideMap.scene.remove(densityOverlay.textureMesh);
       densityOverlay = null;

--- a/script.js
+++ b/script.js
@@ -1774,9 +1774,6 @@ function registerMollweideEditableLines() {
     });
   }
   constellationLinesMoll.forEach(l => editableLines.push(l));
-  if (densityOverlay && densityOverlay.adjacentLines) {
-    densityOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
-  }
   if (isolationOverlay && isolationOverlay.adjacentLines) {
     isolationOverlay.adjacentLines.forEach(o => editableLines.push(o.lineM));
   }

--- a/script.js
+++ b/script.js
@@ -617,6 +617,7 @@ async function buildAndApplyFilters() {
         globeMap.scene.remove(c.globeMesh);
         mollweideMap.scene.remove(c.mollweideMesh);
       });
+      mollweideMap.scene.remove(ov.textureMesh);
     });
     cloudDensityOverlays = [];
     for (const f of files) {
@@ -630,6 +631,7 @@ async function buildAndApplyFilters() {
         cloudDensityOpacity / 100
       );
       cloudDensityOverlays.push(ov);
+      mollweideMap.scene.add(ov.textureMesh);
     }
   } else {
     cloudDensityOverlays.forEach(ov => {
@@ -638,6 +640,7 @@ async function buildAndApplyFilters() {
         globeMap.scene.remove(c.globeMesh);
         mollweideMap.scene.remove(c.mollweideMesh);
       });
+      mollweideMap.scene.remove(ov.textureMesh);
     });
     cloudDensityOverlays = [];
   }


### PR DESCRIPTION
## Summary
- generate an off-screen canvas for density grid overlays
- draw colored heatmaps instead of individual squares
- display heatmap textures on the Mollweide view
- hook up texture management for cloud density overlays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886697bd07c832a8cf34824908355c4