### PR TITLE
Implement consistent layer order on Mollweide map

### DIFF
--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -2,6 +2,7 @@ import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/thr
 import { cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
 import { minimalRADifference } from '../utils.js';
 import { lightenColor } from './densityColorUtils.js';
+import { getDustCloudColor } from './dustCloudColors.js';
 
 async function loadCloudData(cloudFileUrl) {
   const response = await fetch(cloudFileUrl);
@@ -12,6 +13,10 @@ async function loadCloudData(cloudFileUrl) {
 }
 
 function uniqueColorFromName(name) {
+  const predefined = getDustCloudColor(name);
+  if (predefined) {
+    return new THREE.Color(predefined);
+  }
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
@@ -22,8 +27,11 @@ function uniqueColorFromName(name) {
 
 function getCloudNameFromFileUrl(fileUrl) {
   const parts = fileUrl.split('/');
-  const filename = parts[parts.length - 1];
-  return filename.replace('_cloud_data.json', '').replace('_', ' ');
+  let filename = parts[parts.length - 1];
+  filename = filename
+    .replace(/_cloud_data\.json$/i, '')
+    .replace(/\.json$/i, '');
+  return filename.replace(/_/g, ' ').trim();
 }
 
 class CloudDensityGridOverlay {

--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -3,13 +3,10 @@ import { cachedRadToMollweide, getMollweideLambda0 } from '../utils/geometryUtil
 import { minimalRADifference } from '../utils.js';
 import { lightenColor } from './densityColorUtils.js';
 import { getDustCloudColor } from './dustCloudColors.js';
+import { loadCachedCloudData } from './dustCloudDataCache.js';
 
 async function loadCloudData(cloudFileUrl) {
-  const response = await fetch(cloudFileUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to load cloud data from ${cloudFileUrl}`);
-  }
-  return await response.json();
+  return await loadCachedCloudData(cloudFileUrl);
 }
 
 function uniqueColorFromName(name) {

--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -175,7 +175,7 @@ export async function createCloudOverlay(
     depthWrite: false
   });
   const lineSegments = new THREE.LineSegments(geometry, material);
-  lineSegments.renderOrder = 1;
+  lineSegments.renderOrder = 2;
   return lineSegments;
 }
 
@@ -210,7 +210,7 @@ const GC_SEGMENTS = 32;
 export function createMollweideCloudSegments(pairs, color, opacityFactor = 1.0, width = 30) {
   const mesh = new THREE.Mesh(new THREE.BufferGeometry(), createWideLineMaterial(color));
   mesh.material.uniforms.opacityFactor.value = opacityFactor;
-  mesh.renderOrder = 1;
+  mesh.renderOrder = 2;
   mesh.userData = { pairs, segments: GC_SEGMENTS, lineWidth: width, isMollweideCloud: true };
   updateMollweideCloudSegments(mesh);
   return mesh;

--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -9,6 +9,7 @@ import {
   greatCircleToMollweide,
   splitMollweideWrap
 } from '../utils/geometryUtils.js';
+import { getDustCloudColor } from './dustCloudColors.js';
 
 // Helper material and geometry builders for wide fading lines on the Mollweide map
 function createWideLineMaterial(color) {
@@ -185,6 +186,10 @@ export async function createCloudOverlay(
  * @returns {THREE.Color}
  */
 function uniqueColorFromName(name) {
+  const predefined = getDustCloudColor(name);
+  if (predefined) {
+    return new THREE.Color(predefined);
+  }
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
@@ -201,8 +206,11 @@ function uniqueColorFromName(name) {
  */
 function getCloudNameFromFileUrl(fileUrl) {
   const parts = fileUrl.split('/');
-  const filename = parts[parts.length - 1];
-  return filename.replace('_cloud_data.json', '').replace('_', ' ');
+  let filename = parts[parts.length - 1];
+  filename = filename
+    .replace(/_cloud_data\.json$/i, '')
+    .replace(/\.json$/i, '');
+  return filename.replace(/_/g, ' ').trim();
 }
 
 const GC_SEGMENTS = 32;

--- a/filters/cloudsFilter.js
+++ b/filters/cloudsFilter.js
@@ -10,6 +10,7 @@ import {
   splitMollweideWrap
 } from '../utils/geometryUtils.js';
 import { getDustCloudColor } from './dustCloudColors.js';
+import { loadCachedCloudData } from './dustCloudDataCache.js';
 
 // Helper material and geometry builders for wide fading lines on the Mollweide map
 function createWideLineMaterial(color) {
@@ -81,11 +82,7 @@ function buildWideLineGeometry(points, width) {
  * @returns {Promise<Array>} - Promise resolving to an array of cloud star objects.
  */
 async function loadCloudData(cloudFileUrl) {
-  const response = await fetch(cloudFileUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to load cloud data from ${cloudFileUrl}`);
-  }
-  return await response.json();
+  return await loadCachedCloudData(cloudFileUrl);
 }
 
 /**

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -299,7 +299,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
         mat.uniforms.opacityFactor.value = opacity;
         mat.uniforms.fadePower.value = connectionFadePower;
         const mesh = new THREE.Mesh(geom, mat);
-        mesh.renderOrder = 1;
+        mesh.renderOrder = 3;
         lines.push(mesh);
       });
       return;
@@ -334,6 +334,8 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
     const line = new THREE.Line(geometryLine, materialLine);
     if (mapType === 'Globe') {
       line.renderOrder = 1;
+    } else if (mapType === 'Mollweide') {
+      line.renderOrder = 3;
     }
     lines.push(line);
   });

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -125,6 +125,7 @@ export function createConstellationBoundariesForMollweide(opacity = 0.4) {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   const lineSegs = new THREE.LineSegments(geometry, material);
+  lineSegs.renderOrder = 1;
   lineSegs.computeLineDistances();
   lineSegs.userData.boundaryData = boundaryData;
   lineSegs.userData.R = R;
@@ -250,6 +251,7 @@ export function createConstellationLabelsForMollweide(opacity = 0.8) {
     const texture = new THREE.CanvasTexture(canvas);
     const material = new THREE.SpriteMaterial({ map: texture, transparent: true, opacity });
     const sprite = new THREE.Sprite(material);
+    sprite.renderOrder = 1;
     sprite.scale.set(canvas.width / 100, canvas.height / 100, 1);
     sprite.position.copy(p);
     sprite.userData = { name: c.name, ra: c.ra, dec: c.dec };

--- a/filters/constellationOverlayFilter.js
+++ b/filters/constellationOverlayFilter.js
@@ -216,7 +216,7 @@ export function createConstellationOverlayForGlobe() {
       depthWrite: false
     });
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.renderOrder = 1;
+    mesh.renderOrder = 2;
     mesh.userData.constellation = constellation;
     overlays.push(mesh);
   }
@@ -310,7 +310,7 @@ export function createConstellationOverlayForMollweide() {
       depthWrite: false
     });
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.renderOrder = 1;
+    mesh.renderOrder = 2;
     mesh.userData.constellation = constellation;
     overlays.push(mesh);
   }

--- a/filters/densityFilter.js
+++ b/filters/densityFilter.js
@@ -268,10 +268,10 @@ class DensityGridOverlay {
             linewidth: 2
           });
           const line = new THREE.Line(geom, mat);
-          line.renderOrder = 1;
+          line.renderOrder = 2;
           const mollMat = createWideLineMaterial(0xff0000, this.fadePower);
           const lineM = new THREE.Mesh(geomM, mollMat);
-          lineM.renderOrder = 1;
+          lineM.renderOrder = 2;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });

--- a/filters/dustCloudColors.js
+++ b/filters/dustCloudColors.js
@@ -1,19 +1,22 @@
 export const dustCloudColors = {
+  // Explicit colors for user-specified clouds
   'Local interstellar cloud': '#ff0000', // red
-  'Ophiuchus': '#32cd32', // lime
-  'Microscopi': '#00008b', // dark blue
-  'Gemini': '#008000', // green
-  'North Galactic Pole': '#ee82ee', // violet
-  'Leo': '#006400', // dark green
-  'Auriga': '#800080', // purple/dark red
-  'Blue': '#00bfff', // bright blue
-  'Galactic': '#f5f5dc', // beige
-  'Dorado': '#00ffff', // light blue/cyan
-  'Ceti': '#ffa500', // orange
-  'Vela': '#ff69b4', // pink
-  'Aquila': '#00ff00', // bright green
-  'Eridani': '#9400d3', // dark violet
-  'Hyades': '#6699cc' // grey blue
+  Ophiuchus: '#00ff00', // green
+  Microscopi: '#ff8c00', // orange
+  Blue: '#0000ff', // blue
+  Galactic: '#ffff00', // yellow
+  Aquila: '#00ffff', // cyan
+  Eridani: '#8a2be2', // violet
+
+  // Unique colors for remaining clouds
+  'North Galactic Pole': '#7fffd4', // aquamarine
+  Leo: '#cd5c5c', // indian red
+  Auriga: '#ff1493', // deep pink
+  Gemini: '#f08080', // light coral
+  Dorado: '#00ff7f', // spring green
+  Ceti: '#ff69b4', // hot pink
+  Hyades: '#dda0dd', // plum
+  Vela: '#ff00ff' // magenta
 };
 
 export function getDustCloudColor(name) {

--- a/filters/dustCloudColors.js
+++ b/filters/dustCloudColors.js
@@ -1,0 +1,27 @@
+export const dustCloudColors = {
+  'Local interstellar cloud': '#ff0000', // red
+  'Ophiuchus': '#32cd32', // lime
+  'Microscopi': '#00008b', // dark blue
+  'Gemini': '#008000', // green
+  'North Galactic Pole': '#ee82ee', // violet
+  'Leo': '#006400', // dark green
+  'Auriga': '#800080', // purple/dark red
+  'Blue': '#00bfff', // bright blue
+  'Galactic': '#f5f5dc', // beige
+  'Dorado': '#00ffff', // light blue/cyan
+  'Ceti': '#ffa500', // orange
+  'Vela': '#ff69b4', // pink
+  'Aquila': '#00ff00', // bright green
+  'Eridani': '#9400d3', // dark violet
+  'Hyades': '#6699cc' // grey blue
+};
+
+export function getDustCloudColor(name) {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(dustCloudColors)) {
+    if (key.toLowerCase() === lower) {
+      return dustCloudColors[key];
+    }
+  }
+  return null;
+}

--- a/filters/dustCloudDataCache.js
+++ b/filters/dustCloudDataCache.js
@@ -1,0 +1,18 @@
+const dataCache = new Map();
+
+export async function loadCachedCloudData(fileUrl) {
+  if (dataCache.has(fileUrl)) {
+    return dataCache.get(fileUrl);
+  }
+  const response = await fetch(fileUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to load cloud data from ${fileUrl}`);
+  }
+  const data = await response.json();
+  dataCache.set(fileUrl, data);
+  return data;
+}
+
+export function clearCloudDataCache() {
+  dataCache.clear();
+}

--- a/filters/isolationFilter.js
+++ b/filters/isolationFilter.js
@@ -225,10 +225,11 @@ class IsolationGridOverlay {
 
           const mat = createGradientLineMaterial();
           const line = new THREE.Line(geom, mat);
-          line.renderOrder = 1;
+          line.renderOrder = 2;
 
           const mollMat = createGradientLineMaterial();
           const lineM = new THREE.LineSegments(geomM, mollMat);
+          lineM.renderOrder = 2;
           this.adjacentLines.push({ line, lineM, cell1: cell, cell2: neighbor });
         }
       });

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -297,7 +297,7 @@ function createTextPlane(text, color = '#ffffff', opacity = 0.8, fontSize = 150)
     new THREE.PlaneGeometry(canvas.width / 100, canvas.height / 100),
     material
   );
-  plane.renderOrder = 1;
+  plane.renderOrder = 2;
   return plane;
 }
 

--- a/labelManager.js
+++ b/labelManager.js
@@ -125,7 +125,7 @@ export class LabelManager {
         );
         const material = getDoubleSidedLabelMaterial(texture, this.labelOpacity);
         labelObj = new THREE.Mesh(planeGeom, material);
-        labelObj.renderOrder = 1;
+        labelObj.renderOrder = this.mapType === 'Mollweide' ? 5 : 1;
       } else {
         const spriteMaterial = new THREE.SpriteMaterial({
           map: texture,
@@ -135,6 +135,7 @@ export class LabelManager {
           opacity: this.labelOpacity,
         });
         labelObj = new THREE.Sprite(spriteMaterial);
+        labelObj.renderOrder = this.mapType === 'Mollweide' ? 5 : 1;
         labelObj.scale.set(
           (canvas.width / 100) * scaleFactor,
           (canvas.height / 100) * scaleFactor,
@@ -153,7 +154,7 @@ export class LabelManager {
         linewidth: 2,
       });
       lineObj = new THREE.Line(lineGeom, lineMat);
-      lineObj.renderOrder = 1;
+      lineObj.renderOrder = this.mapType === 'Mollweide' ? 5 : 1;
       this.lines.set(star, lineObj);
 
       // Update cache

--- a/script.js
+++ b/script.js
@@ -355,6 +355,20 @@ function createGlobeGrid(R = 100, options = {}) {
   return gridGroup;
 }
 
+function createMollweideBackground(R = 100, segments = 1024) {
+  const geometry = new THREE.CircleGeometry(R, segments);
+  geometry.scale(2, 1, 1);
+  const material = new THREE.MeshBasicMaterial({
+    color: 0x000000,
+    side: THREE.DoubleSide,
+    depthTest: false,
+    depthWrite: false
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 0;
+  return mesh;
+}
+
 function createMollweideBorder(R = 100, thickness = 8, segments = 1024) {
   const geometry = new THREE.RingGeometry(R, R + thickness, segments);
   geometry.scale(2, 1, 1); // turn the circular ring into an ellipse
@@ -933,6 +947,8 @@ class MapManager {
         panCameraLeft: true,
         panCameraRight: false
       });
+      const background = createMollweideBackground(100);
+      this.scene.add(background);
       const mask = createMollweideMask(100);
       this.scene.add(mask);
       const border = createMollweideBorder(100);
@@ -978,6 +994,7 @@ class MapManager {
           zoomVal
         );
         this.points = new THREE.Points(geometry, material);
+        this.points.renderOrder = 4;
         this.starGroup.add(this.points);
       }
     } else {
@@ -1009,6 +1026,7 @@ class MapManager {
         });
         this.instancedMesh = new THREE.InstancedMesh(baseGeometry, material, count);
         this.instancedMesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);
+        this.instancedMesh.renderOrder = 4;
         this.starGroup.add(this.instancedMesh);
       }
     }


### PR DESCRIPTION
## Summary
- add Mollweide background mesh and use it in the map
- assign renderOrder values for stars, labels, connection lines and filters
- ensure constellation names and boundaries render below other features

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688799899ac4832ab954730f9b4c83a7