### PR TITLE
Fuse overlapping dust cloud density cells

### DIFF
--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -5,6 +5,23 @@ import { lightenColor } from './densityColorUtils.js';
 import { getDustCloudColor } from './dustCloudColors.js';
 import { loadCachedCloudData } from './dustCloudDataCache.js';
 
+// Utility to create a striped texture from an array of THREE.Color objects.
+function createStripedTexture(colors) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 32;
+  canvas.height = 32;
+  const ctx = canvas.getContext('2d');
+  const stripeWidth = canvas.width / colors.length;
+  colors.forEach((col, idx) => {
+    ctx.fillStyle = `#${col.getHexString()}`;
+    ctx.fillRect(idx * stripeWidth, 0, stripeWidth, canvas.height);
+  });
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.minFilter = THREE.LinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  return tex;
+}
+
 async function loadCloudData(cloudFileUrl) {
   return await loadCachedCloudData(cloudFileUrl);
 }
@@ -259,4 +276,55 @@ export function updateCloudDensityOverlay(
 ) {
   overlay.opacityFactor = opacity;
   overlay.update(overlay.cloudPositions, sceneTC, sceneGlobe, sceneMoll, radius);
+}
+
+// Merge cells occupying the same position across multiple overlays. When a cell
+// is shared, a striped texture of the contributing colors is applied to a
+// single visible mesh.
+export function fuseCloudDensityCells(overlays) {
+  const map = new Map();
+  overlays.forEach(ov => {
+    ov.cubesData.forEach(cell => {
+      const key = `${cell.tcPos.x},${cell.tcPos.y},${cell.tcPos.z}`;
+      const col = cell.tcMesh.material.color.clone();
+      const alpha = cell.tcMesh.material.opacity;
+      if (!map.has(key)) {
+        map.set(key, { cells: [cell], colors: [col], opacity: alpha });
+      } else {
+        const entry = map.get(key);
+        entry.cells.push(cell);
+        entry.colors.push(col);
+        entry.opacity = Math.max(entry.opacity, alpha);
+      }
+    });
+  });
+
+  map.forEach(entry => {
+    const [base, ...rest] = entry.cells;
+    if (entry.cells.length > 1) {
+      const tex = createStripedTexture(entry.colors);
+      [base.tcMesh, base.globeMesh, base.mollweideMesh].forEach(mesh => {
+        mesh.material.map = tex;
+        mesh.material.color.set(0xffffff);
+        mesh.material.opacity = entry.opacity;
+        mesh.material.transparent = true;
+        mesh.material.needsUpdate = true;
+        mesh.visible = true;
+      });
+      rest.forEach(c => {
+        c.tcMesh.visible = false;
+        c.globeMesh.visible = false;
+        c.mollweideMesh.visible = false;
+      });
+    } else {
+      // Ensure single cells keep their color and no texture
+      [base.tcMesh, base.globeMesh, base.mollweideMesh].forEach(mesh => {
+        mesh.material.map = null;
+        mesh.material.color.copy(entry.colors[0]);
+        mesh.material.opacity = entry.opacity;
+        mesh.material.needsUpdate = true;
+        mesh.visible = true;
+      });
+    }
+  });
 }

--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -228,12 +228,14 @@ class CloudDensityGridOverlay {
         const pattern = ctx.createPattern(cell.stripedCanvas, 'repeat');
         ctx.save();
         ctx.translate(px, py);
+        ctx.filter = 'none';
         ctx.beginPath();
         ctx.arc(0, 0, radius, 0, Math.PI * 2);
         ctx.closePath();
         ctx.fillStyle = pattern;
         ctx.globalAlpha = alpha;
         ctx.fill();
+        ctx.filter = 'blur(4px)';
         const grad = ctx.createRadialGradient(0, 0, 0, 0, 0, radius);
         grad.addColorStop(0, 'rgba(255,255,255,1)');
         grad.addColorStop(1, 'rgba(255,255,255,0)');
@@ -241,6 +243,7 @@ class CloudDensityGridOverlay {
         ctx.fillStyle = grad;
         ctx.fill();
         ctx.restore();
+        ctx.filter = 'blur(4px)';
         ctx.globalCompositeOperation = 'source-over';
       } else {
         const r = Math.round(col.r * 255);
@@ -337,6 +340,7 @@ export function fuseCloudDensityCells(overlays) {
         mesh.visible = true;
       });
       rest.forEach(c => {
+        c.active = false;
         c.tcMesh.visible = false;
         c.globeMesh.visible = false;
         c.mollweideMesh.visible = false;
@@ -353,5 +357,9 @@ export function fuseCloudDensityCells(overlays) {
         mesh.visible = true;
       });
     }
+  });
+
+  overlays.forEach(ov => {
+    ov.drawHeatmap(getMollweideLambda0());
   });
 }

--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -5,7 +5,9 @@ import { lightenColor } from './densityColorUtils.js';
 import { getDustCloudColor } from './dustCloudColors.js';
 import { loadCachedCloudData } from './dustCloudDataCache.js';
 
-// Utility to create a striped texture from an array of THREE.Color objects.
+// Utility to create a striped canvas and texture from an array of THREE.Color
+// objects. The returned object contains both the canvas and the THREE texture
+// so the canvas can also be reused for 2D drawing (e.g. the heatmap overlay).
 function createStripedTexture(colors) {
   const canvas = document.createElement('canvas');
   canvas.width = 32;
@@ -19,7 +21,7 @@ function createStripedTexture(colors) {
   const tex = new THREE.CanvasTexture(canvas);
   tex.minFilter = THREE.LinearFilter;
   tex.magFilter = THREE.LinearFilter;
-  return tex;
+  return { texture: tex, canvas };
 }
 
 async function loadCloudData(cloudFileUrl) {
@@ -221,17 +223,37 @@ class CloudDensityGridOverlay {
       const py = (100 - y) * yScale;
       const col = cell.mollweideMesh.material.color;
       const alpha = cell.mollweideMesh.material.opacity;
-      const r = Math.round(col.r * 255);
-      const g = Math.round(col.g * 255);
-      const b = Math.round(col.b * 255);
       const radius = Math.max(width, height) * 0.6;
-      const grd = ctx.createRadialGradient(px, py, 0, px, py, radius);
-      grd.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
-      grd.addColorStop(1, `rgba(${r},${g},${b},0)`);
-      ctx.fillStyle = grd;
-      ctx.beginPath();
-      ctx.arc(px, py, radius, 0, Math.PI * 2);
-      ctx.fill();
+      if (cell.isStriped && cell.stripedCanvas) {
+        const pattern = ctx.createPattern(cell.stripedCanvas, 'repeat');
+        ctx.save();
+        ctx.translate(px, py);
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.closePath();
+        ctx.fillStyle = pattern;
+        ctx.globalAlpha = alpha;
+        ctx.fill();
+        const grad = ctx.createRadialGradient(0, 0, 0, 0, 0, radius);
+        grad.addColorStop(0, 'rgba(255,255,255,1)');
+        grad.addColorStop(1, 'rgba(255,255,255,0)');
+        ctx.globalCompositeOperation = 'destination-in';
+        ctx.fillStyle = grad;
+        ctx.fill();
+        ctx.restore();
+        ctx.globalCompositeOperation = 'source-over';
+      } else {
+        const r = Math.round(col.r * 255);
+        const g = Math.round(col.g * 255);
+        const b = Math.round(col.b * 255);
+        const grd = ctx.createRadialGradient(px, py, 0, px, py, radius);
+        grd.addColorStop(0, `rgba(${r},${g},${b},${alpha})`);
+        grd.addColorStop(1, `rgba(${r},${g},${b},0)`);
+        ctx.fillStyle = grd;
+        ctx.beginPath();
+        ctx.arc(px, py, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
     });
     ctx.filter = 'none';
     this.texture.needsUpdate = true;
@@ -285,6 +307,7 @@ export function fuseCloudDensityCells(overlays) {
   const map = new Map();
   overlays.forEach(ov => {
     ov.cubesData.forEach(cell => {
+      if (!cell.active) return; // Ignore inactive cells
       const key = `${cell.tcPos.x},${cell.tcPos.y},${cell.tcPos.z}`;
       const col = cell.tcMesh.material.color.clone();
       const alpha = cell.tcMesh.material.opacity;
@@ -302,7 +325,9 @@ export function fuseCloudDensityCells(overlays) {
   map.forEach(entry => {
     const [base, ...rest] = entry.cells;
     if (entry.cells.length > 1) {
-      const tex = createStripedTexture(entry.colors);
+      const { texture: tex, canvas } = createStripedTexture(entry.colors);
+      base.isStriped = true;
+      base.stripedCanvas = canvas;
       [base.tcMesh, base.globeMesh, base.mollweideMesh].forEach(mesh => {
         mesh.material.map = tex;
         mesh.material.color.set(0xffffff);
@@ -318,6 +343,8 @@ export function fuseCloudDensityCells(overlays) {
       });
     } else {
       // Ensure single cells keep their color and no texture
+      base.isStriped = false;
+      base.stripedCanvas = null;
       [base.tcMesh, base.globeMesh, base.mollweideMesh].forEach(mesh => {
         mesh.material.map = null;
         mesh.material.color.copy(entry.colors[0]);

--- a/script.js
+++ b/script.js
@@ -11,7 +11,11 @@ import {
   updateCloudsOverlay,
   updateMollweideCloudSegments
 } from './filters/cloudsFilter.js';
-import { createCloudDensityOverlay, updateCloudDensityOverlay } from './filters/cloudDensityFilter.js';
+import {
+  createCloudDensityOverlay,
+  updateCloudDensityOverlay,
+  fuseCloudDensityCells
+} from './filters/cloudDensityFilter.js';
 import {
   createGalacticPlaneMesh,
   createEclipticPlaneMesh,
@@ -647,6 +651,7 @@ async function buildAndApplyFilters() {
       cloudDensityOverlays.push(ov);
       mollweideMap.scene.add(ov.textureMesh);
     }
+    fuseCloudDensityCells(cloudDensityOverlays);
   } else {
     cloudDensityOverlays.forEach(ov => {
       ov.cubesData.forEach(c => {


### PR DESCRIPTION
## Summary
- add helper to create striped textures for overlapped dust clouds
- add `fuseCloudDensityCells` to merge cells with stripes
- call fusion step when building dust cloud density overlays

## Testing
- `node --check filters/cloudDensityFilter.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68886bed7b3c832a8429a5ec474b9280