### PR TITLE
Scale star sizes for high-res Mollweide exports

### DIFF
--- a/filters/cloudDensityFilter.js
+++ b/filters/cloudDensityFilter.js
@@ -40,8 +40,10 @@ class CloudDensityGridOverlay {
     this.color = uniqueColorFromName(cloudName);
     this.opacityFactor = 1.0;
 
-    this.canvasWidth = 1024;
-    this.canvasHeight = 512;
+    // Use a higher-resolution canvas so the Mollweide overlay appears smooth
+    // even when exporting very large images.
+    this.canvasWidth = 4096;
+    this.canvasHeight = 2048;
     this.canvas = document.createElement('canvas');
     this.canvas.width = this.canvasWidth;
     this.canvas.height = this.canvasHeight;

--- a/script.js
+++ b/script.js
@@ -1412,7 +1412,26 @@ function exportMollweideMap(format = 'png', rect = null) {
   const width = 7680;
   const height = 3840;
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
+  exportRenderer.outputColorSpace = mollweideMap.renderer.outputColorSpace;
+  exportRenderer.toneMapping = mollweideMap.renderer.toneMapping;
+  exportRenderer.toneMappingExposure = mollweideMap.renderer.toneMappingExposure;
+  exportRenderer.setClearColor(
+    mollweideMap.renderer.getClearColor(new THREE.Color()),
+    mollweideMap.renderer.getClearAlpha()
+  );
   exportRenderer.setPixelRatio(1);
+  let originalZoom = null;
+  if (
+    mollweideMap.points &&
+    mollweideMap.points.material &&
+    mollweideMap.points.material.uniforms &&
+    mollweideMap.points.material.uniforms.cameraZoom
+  ) {
+    originalZoom = mollweideMap.points.material.uniforms.cameraZoom.value;
+    const scaleFactor = width / mollweideMap.renderer.domElement.width;
+    mollweideMap.points.material.uniforms.cameraZoom.value =
+      originalZoom * scaleFactor;
+  }
   let cropX = 0;
   let cropY = 0;
   let cropW = width;
@@ -1456,6 +1475,9 @@ function exportMollweideMap(format = 'png', rect = null) {
     }
   }
   exportRenderer.dispose();
+  if (originalZoom !== null) {
+    mollweideMap.points.material.uniforms.cameraZoom.value = originalZoom;
+  }
   if (format === 'pdf') {
     const imgData = finalCanvas.toDataURL('image/png');
     const { jsPDF } = window.jspdf;

--- a/script.js
+++ b/script.js
@@ -1415,6 +1415,11 @@ function exportMollweideMap(format = 'png', rect = null) {
   exportRenderer.outputColorSpace = mollweideMap.renderer.outputColorSpace;
   exportRenderer.toneMapping = mollweideMap.renderer.toneMapping;
   exportRenderer.toneMappingExposure = mollweideMap.renderer.toneMappingExposure;
+  exportRenderer.physicallyCorrectLights = mollweideMap.renderer.physicallyCorrectLights;
+  exportRenderer.sortObjects = mollweideMap.renderer.sortObjects;
+  exportRenderer.useLegacyLights = mollweideMap.renderer.useLegacyLights;
+  exportRenderer.shadowMap.enabled = mollweideMap.renderer.shadowMap.enabled;
+  exportRenderer.shadowMap.type = mollweideMap.renderer.shadowMap.type;
   exportRenderer.setClearColor(
     mollweideMap.renderer.getClearColor(new THREE.Color()),
     mollweideMap.renderer.getClearAlpha()
@@ -1428,7 +1433,9 @@ function exportMollweideMap(format = 'png', rect = null) {
     mollweideMap.points.material.uniforms.cameraZoom
   ) {
     originalZoom = mollweideMap.points.material.uniforms.cameraZoom.value;
-    const scaleFactor = width / mollweideMap.renderer.domElement.width;
+    const onscreenWidth = mollweideMap.renderer.domElement.width;
+    const scaleFactor =
+      (width * exportRenderer.getPixelRatio()) / onscreenWidth;
     mollweideMap.points.material.uniforms.cameraZoom.value =
       originalZoom * scaleFactor;
   }


### PR DESCRIPTION
## Summary
- preserve renderer color space and tone mapping during Mollweide export
- scale star shader's zoom so point sizes match on-screen appearance when exporting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e41958c5c832aaff554df51957059