### PR TITLE
Add export resolution options and fix Mollweide border

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,12 +298,10 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
-          <select id="export-resolution">
-            <option value="1">4K</option>
-            <option value="2">8K</option>
-            <option value="3">12K</option>
-            <option value="4">16K</option>
-          </select>
+            <select id="export-resolution">
+              <option value="1">4K</option>
+              <option value="2">8K</option>
+            </select>
           <button id="export-mollweide" class="export-btn">Export</button>
           <button id="export-png" class="export-btn" style="display:none">PNG</button>
           <button id="export-pdf" class="export-btn" style="display:none">PDF</button>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,8 @@
             <select id="export-resolution">
               <option value="1">4K</option>
               <option value="2">8K</option>
+              <option value="3">12K</option>
+              <option value="4">16K</option>
             </select>
           <button id="export-mollweide" class="export-btn">Export</button>
           <button id="export-png" class="export-btn" style="display:none">PNG</button>

--- a/index.html
+++ b/index.html
@@ -298,6 +298,12 @@
         <button class="fullscreen-btn" aria-label="Fullscreen Mollweide Map">⤢</button>
         <canvas id="mollweideMap"></canvas>
         <div class="export-controls">
+          <select id="export-resolution">
+            <option value="1">4K</option>
+            <option value="2">8K</option>
+            <option value="3">12K</option>
+            <option value="4">16K</option>
+          </select>
           <button id="export-mollweide" class="export-btn">Export</button>
           <button id="export-png" class="export-btn" style="display:none">PNG</button>
           <button id="export-pdf" class="export-btn" style="display:none">PDF</button>

--- a/script.js
+++ b/script.js
@@ -384,19 +384,21 @@ function createMollweideBackground(R = 100, segments = 1024) {
   return mesh;
 }
 
-function createMollweideBorder(R = 100, segments = 1024) {
-  const curve = new THREE.EllipseCurve(0, 0, 2 * R, R, 0, 2 * Math.PI, false, 0);
-  const points = curve.getPoints(segments);
-  const geometry = new THREE.BufferGeometry().setFromPoints(points);
-  const material = new THREE.LineBasicMaterial({
+function createMollweideBorder(R = 100, thickness = 1.5, segments = 1024) {
+  const geometry = new THREE.RingGeometry(R - thickness, R + thickness, segments);
+  geometry.scale(2, 1, 1); // turn the circular ring into an ellipse
+
+  const material = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
+    side: THREE.DoubleSide,
     depthTest: false,
     depthWrite: false
   });
-  const line = new THREE.LineLoop(geometry, material);
-  line.renderOrder = 1001;
-  line.raycast = () => {};
-  return line;
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 1001;
+  mesh.raycast = () => {};
+  return mesh;
 }
 
 function createMollweideMask(R = 100, segments = 1024) {
@@ -1433,7 +1435,7 @@ function exportMollweideMap(format = 'png', rect = null) {
   const exportWidth = Math.round(baseWidth * scale);
   const exportHeight = Math.round(baseHeight * scale);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
-  exportRenderer.setPixelRatio(1);
+  exportRenderer.setPixelRatio(mollweideMap.renderer.getPixelRatio());
   let cropX = 0;
   let cropY = 0;
   let cropW = baseWidth;
@@ -1452,8 +1454,23 @@ function exportMollweideMap(format = 'png', rect = null) {
   finalCanvas.width = exportCropW;
   finalCanvas.height = exportCropH;
   const ctx = finalCanvas.getContext('2d');
+  ctx.imageSmoothingEnabled = false;
   const maxSize = exportRenderer.capabilities.maxTextureSize;
   const tile = Math.min(Math.floor(maxSize / scale), 8192);
+
+  // Temporarily scale star and line sizes for faithful export
+  let originalZoom = null;
+  if (mollweideMap.points && mollweideMap.points.material.uniforms && mollweideMap.points.material.uniforms.cameraZoom) {
+    originalZoom = mollweideMap.points.material.uniforms.cameraZoom.value;
+    mollweideMap.points.material.uniforms.cameraZoom.value = originalZoom * scale;
+  }
+  const lineMats = [];
+  mollweideMap.scene.traverse(obj => {
+    if (obj.isLine && obj.material && obj.material.linewidth !== undefined) {
+      lineMats.push({ mat: obj.material, width: obj.material.linewidth });
+      obj.material.linewidth *= scale;
+    }
+  });
   for (let y = cropY; y < cropY + cropH; y += tile) {
     for (let x = cropX; x < cropX + cropW; x += tile) {
       const tileW = Math.min(tile, cropW - (x - cropX));
@@ -1488,6 +1505,12 @@ function exportMollweideMap(format = 'png', rect = null) {
     }
   }
   exportRenderer.dispose();
+  if (originalZoom !== null) {
+    mollweideMap.points.material.uniforms.cameraZoom.value = originalZoom;
+  }
+  lineMats.forEach(({ mat, width }) => {
+    mat.linewidth = width;
+  });
   if (format === 'pdf') {
     const imgData = finalCanvas.toDataURL('image/png');
     const { jsPDF } = window.jspdf;

--- a/script.js
+++ b/script.js
@@ -123,6 +123,7 @@ let exportPdfBtn = null;
 let exportStart = null;
 let exportCurrentRect = null;
 let isSelecting = false;
+let exportResSelect = null;
 
 const ROTATE_SENSITIVITY = 0.3;
 
@@ -391,7 +392,8 @@ function createMollweideBorder(R = 100, thickness = 8, segments = 1024) {
     color: 0xaaaaaa,
     side: THREE.DoubleSide,
     depthTest: false,
-    depthWrite: false
+    depthWrite: false,
+    transparent: true
   });
 
   const mesh = new THREE.Mesh(geometry, material);
@@ -1426,7 +1428,10 @@ window.updateMollweideView = updateMollweideView;
 function exportMollweideMap(format = 'png', rect = null) {
   const baseWidth = mollweideMap.renderer.domElement.width;
   const baseHeight = mollweideMap.renderer.domElement.height;
-  const scale = Math.max(1, 3840 / baseWidth, 2160 / baseHeight);
+  const factor = exportResSelect ? parseInt(exportResSelect.value, 10) : 1;
+  const targetWidth = 3840 * factor;
+  const targetHeight = 2160 * factor;
+  const scale = Math.max(1, targetWidth / baseWidth, targetHeight / baseHeight);
   const exportWidth = Math.round(baseWidth * scale);
   const exportHeight = Math.round(baseHeight * scale);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
@@ -1569,7 +1574,8 @@ function setupExportControls() {
   exportPdfBtn = document.getElementById('export-pdf');
   exportOverlay = document.getElementById('export-selection-overlay');
   exportRectElem = document.getElementById('export-selection-rect');
-  if (!btn || !exportOverlay || !exportRectElem || !exportPngBtn || !exportPdfBtn) return;
+  exportResSelect = document.getElementById('export-resolution');
+  if (!btn || !exportOverlay || !exportRectElem || !exportPngBtn || !exportPdfBtn || !exportResSelect) return;
 
   exportPngBtn.addEventListener('click', () => {
     if (exportCurrentRect) exportMollweideMap('png', exportCurrentRect);

--- a/script.js
+++ b/script.js
@@ -384,21 +384,19 @@ function createMollweideBackground(R = 100, segments = 1024) {
   return mesh;
 }
 
-function createMollweideBorder(R = 100, thickness = 8, segments = 1024) {
-  const geometry = new THREE.RingGeometry(R, R + thickness, segments);
-  geometry.scale(2, 1, 1); // turn the circular ring into an ellipse
-
-  const material = new THREE.MeshBasicMaterial({
+function createMollweideBorder(R = 100, segments = 1024) {
+  const curve = new THREE.EllipseCurve(0, 0, 2 * R, R, 0, 2 * Math.PI, false, 0);
+  const points = curve.getPoints(segments);
+  const geometry = new THREE.BufferGeometry().setFromPoints(points);
+  const material = new THREE.LineBasicMaterial({
     color: 0xaaaaaa,
-    side: THREE.DoubleSide,
     depthTest: false,
-    depthWrite: false,
-    transparent: true
+    depthWrite: false
   });
-
-  const mesh = new THREE.Mesh(geometry, material);
-  mesh.renderOrder = 1001;
-  return mesh;
+  const line = new THREE.LineLoop(geometry, material);
+  line.renderOrder = 1001;
+  line.raycast = () => {};
+  return line;
 }
 
 function createMollweideMask(R = 100, segments = 1024) {


### PR DESCRIPTION
## Summary
- allow choosing 4K, 8K, 12K, or 16K when exporting the Mollweide map
- restore the missing oval border around the Mollweide projection

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4725e368832aae23e717745fb39c