### PR TITLE
Increase export resolution and restore Mollweide outline

### DIFF
--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -4,7 +4,7 @@ import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/thr
 import { adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
 
 // Tunable parameters for the connections lines
-let connectionMaxWidth = 5;
+let connectionMaxWidth = 8;
 let connectionFadePower = 1.0;
 
 export function setConnectionLineParams(maxWidth, fadePower) {
@@ -13,7 +13,7 @@ export function setConnectionLineParams(maxWidth, fadePower) {
 }
 
 // Helper material and geometry builders for wide fading lines on the Mollweide map
-function createWideLineMaterial(color) {
+export function createWideLineMaterial(color) {
   return new THREE.ShaderMaterial({
     uniforms: {
       color: { value: new THREE.Color(color) },

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -50,7 +50,7 @@ function createWideLineMaterial(color) {
   });
 }
 
-function buildWideLineGeometry(points, width) {
+export function buildWideLineGeometry(points, width) {
   const vertices = [];
   const sides = [];
   const along = [];
@@ -300,6 +300,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
         mat.uniforms.fadePower.value = connectionFadePower;
         const mesh = new THREE.Mesh(geom, mat);
         mesh.renderOrder = 3;
+        mesh.userData = { baseWidth: width, points: pts };
         lines.push(mesh);
       });
       return;
@@ -332,6 +333,7 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       linewidth: lineThickness
     });
     const line = new THREE.Line(geometryLine, materialLine);
+    line.userData = { baseLineWidth: lineThickness };
     if (mapType === 'Globe') {
       line.renderOrder = 1;
     } else if (mapType === 'Mollweide') {

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -127,8 +127,13 @@ export function createConstellationBoundariesForMollweide(opacity = 0.4) {
   const lineSegs = new THREE.LineSegments(geometry, material);
   lineSegs.renderOrder = 1;
   lineSegs.computeLineDistances();
-  lineSegs.userData.boundaryData = boundaryData;
-  lineSegs.userData.R = R;
+  lineSegs.userData = {
+    boundaryData,
+    R,
+    baseLineWidth: material.linewidth,
+    baseDashSize: material.dashSize,
+    baseGapSize: material.gapSize
+  };
   updateConstellationBoundariesForMollweide(lineSegs);
   return [lineSegs];
 }

--- a/script.js
+++ b/script.js
@@ -383,20 +383,22 @@ function createMollweideBackground(R = 100, segments = 1024) {
   return mesh;
 }
 
-function createMollweideBorder(R = 100, thickness = 8, segments = 1024) {
-  const geometry = new THREE.RingGeometry(R, R + thickness, segments);
-  geometry.scale(2, 1, 1); // turn the circular ring into an ellipse
-
-  const material = new THREE.MeshBasicMaterial({
+function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
+  const points = [];
+  for (let i = 0; i <= segments; i++) {
+    const theta = (i / segments) * 2 * Math.PI;
+    points.push(new THREE.Vector3(2 * R * Math.cos(theta), R * Math.sin(theta), 0));
+  }
+  const geometry = new THREE.BufferGeometry().setFromPoints(points);
+  const material = new THREE.LineBasicMaterial({
     color: 0xaaaaaa,
-    side: THREE.DoubleSide,
+    linewidth: thickness,
     depthTest: false,
     depthWrite: false
   });
-
-  const mesh = new THREE.Mesh(geometry, material);
-  mesh.renderOrder = 1001;
-  return mesh;
+  const line = new THREE.LineLoop(geometry, material);
+  line.renderOrder = 1001;
+  return line;
 }
 
 function createMollweideMask(R = 100, segments = 1024) {
@@ -1426,7 +1428,7 @@ window.updateMollweideView = updateMollweideView;
 function exportMollweideMap(format = 'png', rect = null) {
   const baseWidth = mollweideMap.renderer.domElement.width;
   const baseHeight = mollweideMap.renderer.domElement.height;
-  const scale = Math.max(1, 3840 / baseWidth, 2160 / baseHeight);
+  const scale = Math.max(1, 7680 / baseWidth, 4320 / baseHeight);
   const exportWidth = Math.round(baseWidth * scale);
   const exportHeight = Math.round(baseHeight * scale);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });

--- a/script.js
+++ b/script.js
@@ -383,7 +383,7 @@ function createMollweideBackground(R = 100, segments = 1024) {
   return mesh;
 }
 
-function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
+function createMollweideBorder(R = 100, thickness = 1.5, segments = 1024) {
   const points = [];
   for (let i = 0; i <= segments; i++) {
     const theta = (i / segments) * 2 * Math.PI;
@@ -398,6 +398,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   });
   const line = new THREE.LineLoop(geometry, material);
   line.renderOrder = 1001;
+  line.userData = { baseLineWidth: thickness };
   return line;
 }
 
@@ -1433,8 +1434,11 @@ function scaleMollweideSceneForExport(scale) {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
       obj.geometry.dispose();
       obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth / scale);
-    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
-      obj.material.linewidth = obj.userData.baseLineWidth / scale;
+    } else if (obj.userData && obj.userData.baseDashSize !== undefined && obj.material && obj.material.dashSize !== undefined) {
+      obj.material.dashSize = obj.userData.baseDashSize / scale;
+      if (obj.userData.baseGapSize !== undefined && obj.material.gapSize !== undefined) {
+        obj.material.gapSize = obj.userData.baseGapSize / scale;
+      }
     }
   });
 }
@@ -1447,8 +1451,11 @@ function restoreMollweideScene(scale) {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
       obj.geometry.dispose();
       obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
-    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
-      obj.material.linewidth = obj.userData.baseLineWidth;
+    } else if (obj.userData && obj.userData.baseDashSize !== undefined && obj.material && obj.material.dashSize !== undefined) {
+      obj.material.dashSize = obj.userData.baseDashSize;
+      if (obj.userData.baseGapSize !== undefined && obj.material.gapSize !== undefined) {
+        obj.material.gapSize = obj.userData.baseGapSize;
+      }
     }
   });
 }

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI, generateStellarClassFilters } from './filters/index.js';
-import { createConnectionLines, mergeConnectionLines, setConnectionLineParams, buildWideLineGeometry } from './filters/connectionsFilter.js';
+import { createConnectionLines, mergeConnectionLines, setConnectionLineParams, buildWideLineGeometry, createWideLineMaterial } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
@@ -384,22 +384,21 @@ function createMollweideBackground(R = 100, segments = 1024) {
 }
 
 function createMollweideBorder(R = 100, thickness = 1.5, segments = 1024) {
-  const points = [];
+  const pts = [];
   for (let i = 0; i <= segments; i++) {
     const theta = (i / segments) * 2 * Math.PI;
-    points.push(new THREE.Vector3(2 * R * Math.cos(theta), R * Math.sin(theta), 0));
+    pts.push(new THREE.Vector3(2 * R * Math.cos(theta), R * Math.sin(theta), 0));
   }
-  const geometry = new THREE.BufferGeometry().setFromPoints(points);
-  const material = new THREE.LineBasicMaterial({
-    color: 0xaaaaaa,
-    linewidth: thickness,
-    depthTest: false,
-    depthWrite: false
-  });
-  const line = new THREE.LineLoop(geometry, material);
-  line.renderOrder = 1001;
-  line.userData = { baseLineWidth: thickness };
-  return line;
+  const segPoints = [];
+  for (let i = 0; i < pts.length - 1; i++) {
+    segPoints.push(pts[i], pts[i + 1]);
+  }
+  const geometry = buildWideLineGeometry(segPoints, thickness);
+  const material = createWideLineMaterial(0xaaaaaa);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 1001;
+  mesh.userData = { baseWidth: thickness, points: segPoints };
+  return mesh;
 }
 
 function createMollweideMask(R = 100, segments = 1024) {
@@ -1427,25 +1426,29 @@ async function updateMollweideView() {
 window.updateMollweideView = updateMollweideView;
 
 function scaleMollweideSceneForExport(scale) {
+  const pixelRatio = mollweideMap.renderer?.getPixelRatio() || window.devicePixelRatio || 1;
   if (mollweideMap.points && mollweideMap.points.material.uniforms.cameraZoom) {
-    mollweideMap.points.material.uniforms.cameraZoom.value *= scale;
+    mollweideMap.points.material.uniforms.cameraZoom.value *= scale * pixelRatio;
   }
   mollweideMap.scene.traverse(obj => {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
       obj.geometry.dispose();
-      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth / scale);
+      obj.geometry = buildWideLineGeometry(obj.userData.points, (obj.userData.baseWidth * pixelRatio) / scale);
     } else if (obj.userData && obj.userData.baseDashSize !== undefined && obj.material && obj.material.dashSize !== undefined) {
-      obj.material.dashSize = obj.userData.baseDashSize / scale;
+      obj.material.dashSize = (obj.userData.baseDashSize * pixelRatio) / scale;
       if (obj.userData.baseGapSize !== undefined && obj.material.gapSize !== undefined) {
-        obj.material.gapSize = obj.userData.baseGapSize / scale;
+        obj.material.gapSize = (obj.userData.baseGapSize * pixelRatio) / scale;
       }
+    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
+      obj.material.linewidth = (obj.userData.baseLineWidth * pixelRatio) / scale;
     }
   });
 }
 
 function restoreMollweideScene(scale) {
+  const pixelRatio = mollweideMap.renderer?.getPixelRatio() || window.devicePixelRatio || 1;
   if (mollweideMap.points && mollweideMap.points.material.uniforms.cameraZoom) {
-    mollweideMap.points.material.uniforms.cameraZoom.value /= scale;
+    mollweideMap.points.material.uniforms.cameraZoom.value /= scale * pixelRatio;
   }
   mollweideMap.scene.traverse(obj => {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
@@ -1456,6 +1459,8 @@ function restoreMollweideScene(scale) {
       if (obj.userData.baseGapSize !== undefined && obj.material.gapSize !== undefined) {
         obj.material.gapSize = obj.userData.baseGapSize;
       }
+    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
+      obj.material.linewidth = obj.userData.baseLineWidth;
     }
   });
 }

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // script.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI, generateStellarClassFilters } from './filters/index.js';
-import { createConnectionLines, mergeConnectionLines, setConnectionLineParams } from './filters/connectionsFilter.js';
+import { createConnectionLines, mergeConnectionLines, setConnectionLineParams, buildWideLineGeometry } from './filters/connectionsFilter.js';
 import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
@@ -1425,10 +1425,39 @@ async function updateMollweideView() {
 }
 window.updateMollweideView = updateMollweideView;
 
+function scaleMollweideSceneForExport(scale) {
+  if (mollweideMap.points && mollweideMap.points.material.uniforms.cameraZoom) {
+    mollweideMap.points.material.uniforms.cameraZoom.value *= scale;
+  }
+  mollweideMap.scene.traverse(obj => {
+    if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
+      obj.geometry.dispose();
+      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth / scale);
+    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
+      obj.material.linewidth = obj.userData.baseLineWidth / scale;
+    }
+  });
+}
+
+function restoreMollweideScene(scale) {
+  if (mollweideMap.points && mollweideMap.points.material.uniforms.cameraZoom) {
+    mollweideMap.points.material.uniforms.cameraZoom.value /= scale;
+  }
+  mollweideMap.scene.traverse(obj => {
+    if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
+      obj.geometry.dispose();
+      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
+    } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
+      obj.material.linewidth = obj.userData.baseLineWidth;
+    }
+  });
+}
+
 function exportMollweideMap(format = 'png', rect = null) {
   const baseWidth = mollweideMap.renderer.domElement.width;
   const baseHeight = mollweideMap.renderer.domElement.height;
   const scale = Math.max(1, 7680 / baseWidth, 4320 / baseHeight);
+  scaleMollweideSceneForExport(scale);
   const exportWidth = Math.round(baseWidth * scale);
   const exportHeight = Math.round(baseHeight * scale);
   const exportRenderer = new THREE.WebGLRenderer({ antialias: true });
@@ -1486,6 +1515,7 @@ function exportMollweideMap(format = 'png', rect = null) {
       );
     }
   }
+  restoreMollweideScene(scale);
   exportRenderer.dispose();
   if (format === 'pdf') {
     const imgData = finalCanvas.toDataURL('image/png');


### PR DESCRIPTION
## Summary
- Restore Mollweide map's missing oval outline with a thin line border.
- Export Mollweide images at 8K (7680×4320) resolution without altering the export method.

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4f02c784832a960850287dc4aba9