### PR TITLE
Enhance Mollweide export line styles

### DIFF
--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -127,8 +127,14 @@ export function createConstellationBoundariesForMollweide(opacity = 0.4) {
   const lineSegs = new THREE.LineSegments(geometry, material);
   lineSegs.renderOrder = 1;
   lineSegs.computeLineDistances();
-  lineSegs.userData.boundaryData = boundaryData;
-  lineSegs.userData.R = R;
+  lineSegs.userData = {
+    boundaryData,
+    R,
+    baseLineWidth: 1,
+    baseOpacity: opacity,
+    exportLineWidthFactor: 1.5,
+    exportOpacityFactor: 2
+  };
   updateConstellationBoundariesForMollweide(lineSegs);
   return [lineSegs];
 }

--- a/script.js
+++ b/script.js
@@ -396,14 +396,23 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   }
   const geometry = buildWideLineGeometry(pts, thickness);
   const material = new THREE.MeshBasicMaterial({
-    color: 0xaaaaaa,
+    color: 0xbbbbbb,
     side: THREE.DoubleSide,
     depthTest: false,
-    depthWrite: false
+    depthWrite: false,
+    transparent: false,
+    opacity: 1
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.renderOrder = 1001;
-  mesh.userData = { baseWidth: thickness, points: pts, exportLineWidthFactor: 3 };
+  mesh.userData = {
+    baseWidth: thickness,
+    points: pts,
+    exportLineWidthFactor: 3,
+    baseRadius: R,
+    segments,
+    isMollweideBorder: true
+  };
   return mesh;
 }
 
@@ -1440,7 +1449,24 @@ function scaleMollweideSceneForExport(scale) {
       let width = obj.userData.baseWidth;
       if (obj.userData.exportLineWidthFactor) width *= obj.userData.exportLineWidthFactor;
       obj.geometry.dispose();
-      obj.geometry = buildWideLineGeometry(obj.userData.points, width);
+      if (obj.userData.isMollweideBorder) {
+        const R = obj.userData.baseRadius || 100;
+        const segments = obj.userData.segments || 1024;
+        const pts = [];
+        let prev = null;
+        const offsetR = R + width / 2;
+        for (let i = 0; i <= segments; i++) {
+          const theta = (i / segments) * 2 * Math.PI;
+          const p = new THREE.Vector3(2 * offsetR * Math.cos(theta), offsetR * Math.sin(theta), 0);
+          if (prev) {
+            pts.push(prev, p);
+          }
+          prev = p;
+        }
+        obj.geometry = buildWideLineGeometry(pts, width);
+      } else {
+        obj.geometry = buildWideLineGeometry(obj.userData.points, width);
+      }
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       let lwFactor = scale;
       if (obj.userData.exportLineWidthFactor) lwFactor *= obj.userData.exportLineWidthFactor;

--- a/script.js
+++ b/script.js
@@ -398,7 +398,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   });
   const line = new THREE.LineLoop(geometry, material);
   line.renderOrder = 1001;
-  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 2 };
+  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 3 };
   return line;
 }
 

--- a/script.js
+++ b/script.js
@@ -398,6 +398,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   });
   const line = new THREE.LineLoop(geometry, material);
   line.renderOrder = 1001;
+  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 2 };
   return line;
 }
 
@@ -1432,9 +1433,15 @@ function scaleMollweideSceneForExport(scale) {
   mollweideMap.scene.traverse(obj => {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
       obj.geometry.dispose();
-      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth / scale);
+      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
-      obj.material.linewidth = obj.userData.baseLineWidth / scale;
+      let lwFactor = scale;
+      if (obj.userData.exportLineWidthFactor) lwFactor *= obj.userData.exportLineWidthFactor;
+      obj.material.linewidth = obj.userData.baseLineWidth * lwFactor;
+      if (obj.userData.baseOpacity !== undefined) {
+        const opFactor = obj.userData.exportOpacityFactor || 1;
+        obj.material.opacity = Math.min(1, obj.userData.baseOpacity * opFactor);
+      }
     }
   });
 }
@@ -1449,6 +1456,7 @@ function restoreMollweideScene(scale) {
       obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       obj.material.linewidth = obj.userData.baseLineWidth;
+      if (obj.userData.baseOpacity !== undefined) obj.material.opacity = obj.userData.baseOpacity;
     }
   });
 }

--- a/script.js
+++ b/script.js
@@ -384,22 +384,27 @@ function createMollweideBackground(R = 100, segments = 1024) {
 }
 
 function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
-  const points = [];
+  const pts = [];
+  let prev = null;
   for (let i = 0; i <= segments; i++) {
     const theta = (i / segments) * 2 * Math.PI;
-    points.push(new THREE.Vector3(2 * R * Math.cos(theta), R * Math.sin(theta), 0));
+    const p = new THREE.Vector3(2 * R * Math.cos(theta), R * Math.sin(theta), 0);
+    if (prev) {
+      pts.push(prev, p);
+    }
+    prev = p;
   }
-  const geometry = new THREE.BufferGeometry().setFromPoints(points);
-  const material = new THREE.LineBasicMaterial({
+  const geometry = buildWideLineGeometry(pts, thickness);
+  const material = new THREE.MeshBasicMaterial({
     color: 0xaaaaaa,
-    linewidth: thickness,
+    side: THREE.DoubleSide,
     depthTest: false,
     depthWrite: false
   });
-  const line = new THREE.LineLoop(geometry, material);
-  line.renderOrder = 1001;
-  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 6 };
-  return line;
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 1001;
+  mesh.userData = { baseWidth: thickness, points: pts, exportLineWidthFactor: 8 };
+  return mesh;
 }
 
 function createMollweideMask(R = 100, segments = 1024) {
@@ -1432,8 +1437,10 @@ function scaleMollweideSceneForExport(scale) {
   }
   mollweideMap.scene.traverse(obj => {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
+      let width = obj.userData.baseWidth;
+      if (obj.userData.exportLineWidthFactor) width *= obj.userData.exportLineWidthFactor;
       obj.geometry.dispose();
-      obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
+      obj.geometry = buildWideLineGeometry(obj.userData.points, width);
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       let lwFactor = scale;
       if (obj.userData.exportLineWidthFactor) lwFactor *= obj.userData.exportLineWidthFactor;

--- a/script.js
+++ b/script.js
@@ -408,10 +408,12 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   mesh.userData = {
     baseWidth: thickness,
     points: pts,
-    exportLineWidthFactor: 1.25,
+    exportLineWidthFactor: 0.85,
     baseRadius: R,
     segments,
-    isMollweideBorder: true
+    isMollweideBorder: true,
+    baseColor: 0xbbbbbb,
+    exportColor: 0x888888
   };
   return mesh;
 }
@@ -1467,6 +1469,9 @@ function scaleMollweideSceneForExport(scale) {
       } else {
         obj.geometry = buildWideLineGeometry(obj.userData.points, width);
       }
+      if (obj.userData.exportColor !== undefined && obj.material && obj.material.color) {
+        obj.material.color.setHex(obj.userData.exportColor);
+      }
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       let lwFactor = scale;
       if (obj.userData.exportLineWidthFactor) lwFactor *= obj.userData.exportLineWidthFactor;
@@ -1487,6 +1492,9 @@ function restoreMollweideScene(scale) {
     if (obj.userData && obj.userData.baseWidth && obj.userData.points) {
       obj.geometry.dispose();
       obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
+      if (obj.userData.baseColor !== undefined && obj.material && obj.material.color) {
+        obj.material.color.setHex(obj.userData.baseColor);
+      }
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       obj.material.linewidth = obj.userData.baseLineWidth;
       if (obj.userData.baseOpacity !== undefined) obj.material.opacity = obj.userData.baseOpacity;

--- a/script.js
+++ b/script.js
@@ -400,7 +400,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
     side: THREE.DoubleSide,
     depthTest: false,
     depthWrite: false,
-    transparent: false,
+    transparent: true,
     opacity: 1
   });
   const mesh = new THREE.Mesh(geometry, material);
@@ -408,7 +408,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   mesh.userData = {
     baseWidth: thickness,
     points: pts,
-    exportLineWidthFactor: 3,
+    exportLineWidthFactor: 5,
     baseRadius: R,
     segments,
     isMollweideBorder: true

--- a/script.js
+++ b/script.js
@@ -408,7 +408,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   mesh.userData = {
     baseWidth: thickness,
     points: pts,
-    exportLineWidthFactor: 2.5,
+    exportLineWidthFactor: 1.25,
     baseRadius: R,
     segments,
     isMollweideBorder: true

--- a/script.js
+++ b/script.js
@@ -403,7 +403,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.renderOrder = 1001;
-  mesh.userData = { baseWidth: thickness, points: pts, exportLineWidthFactor: 8 };
+  mesh.userData = { baseWidth: thickness, points: pts, exportLineWidthFactor: 3 };
   return mesh;
 }
 

--- a/script.js
+++ b/script.js
@@ -398,7 +398,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   });
   const line = new THREE.LineLoop(geometry, material);
   line.renderOrder = 1001;
-  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 3 };
+  line.userData = { baseLineWidth: thickness, exportLineWidthFactor: 6 };
   return line;
 }
 

--- a/script.js
+++ b/script.js
@@ -408,7 +408,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   mesh.userData = {
     baseWidth: thickness,
     points: pts,
-    exportLineWidthFactor: 3,
+    exportLineWidthFactor: 2.5,
     baseRadius: R,
     segments,
     isMollweideBorder: true

--- a/script.js
+++ b/script.js
@@ -408,7 +408,7 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
   mesh.userData = {
     baseWidth: thickness,
     points: pts,
-    exportLineWidthFactor: 5,
+    exportLineWidthFactor: 3,
     baseRadius: R,
     segments,
     isMollweideBorder: true


### PR DESCRIPTION
## Summary
- Preserve wide connection line geometry when exporting the Mollweide map
- Increase border and constellation line weight and opacity specifically for export
- Record base styling metadata for constellation boundaries and border lines

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f57fd18a8832ab994078ec1bac696