### PR TITLE
feat: add historical aesthetic toggle

### DIFF
--- a/filters/colorFilter.js
+++ b/filters/colorFilter.js
@@ -18,6 +18,14 @@ import { getStellarClassData } from './stellarClassData.js';
 export function applyColorFilter(stars, filters) {
   const stellarClassData = getStellarClassData();
 
+  // Override colors with a monochrome palette in historical mode.
+  if (document.body.classList.contains('historical')) {
+    stars.forEach(star => {
+      star.displayColor = '#3b2d1f';
+    });
+    return stars;
+  }
+
   if (filters.color === 'stellar-class') {
     stars.forEach(star => {
       const primaryClass = star.Stellar_class ? star.Stellar_class.charAt(0).toUpperCase() : 'G';

--- a/filters/connectionsFilter.js
+++ b/filters/connectionsFilter.js
@@ -2,6 +2,7 @@
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { splitMollweideWrap, greatCircleToMollweide, getMollweideLambda0 } from '../utils/geometryUtils.js';
+import { getThemeFont } from '../utils/theme.js';
 
 // Tunable parameters for the connections lines
 let connectionMaxWidth = 5;
@@ -339,13 +340,13 @@ export function createConnectionLines(stars, pairs, mapType, opacityFactor = 0.5
       const fontSize = baseFontSize * connectionLabelSize;
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      ctx.font = `${fontSize}px Oswald`;
+      ctx.font = getThemeFont(fontSize);
       const metrics = ctx.measureText(distanceText);
       const padX = 10;
       const padY = 5;
       canvas.width = metrics.width + padX * 2;
       canvas.height = fontSize + padY * 2;
-      ctx.font = `${fontSize}px Oswald`;
+      ctx.font = getThemeFont(fontSize);
       const labelColor = c1.clone().lerp(c2, 0.5);
       ctx.fillStyle = `#${labelColor.getHexString()}`;
       ctx.textBaseline = 'middle';

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -2,6 +2,7 @@
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide } from '../utils/geometryUtils.js';
+import { getThemeFont } from '../utils/theme.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -184,12 +185,12 @@ export function createConstellationLabelsForGlobe(opacity = 0.8) {
     const baseFontSize = 300; // Very large base font size
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    ctx.font = `${baseFontSize}px Oswald`;
+    ctx.font = getThemeFont(baseFontSize);
     const textWidth = ctx.measureText(c.name).width;
     canvas.width = textWidth + 20;
     canvas.height = baseFontSize * 1.2;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.font = `${baseFontSize}px Oswald`;
+    ctx.font = getThemeFont(baseFontSize);
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);
@@ -246,12 +247,12 @@ export function createConstellationLabelsForMollweide(opacity = 0.8) {
     const baseFontSize = 300;
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    ctx.font = `${baseFontSize}px Oswald`;
+    ctx.font = getThemeFont(baseFontSize);
     const textWidth = ctx.measureText(c.name).width;
     canvas.width = textWidth + 20;
     canvas.height = baseFontSize * 1.2;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.font = `${baseFontSize}px Oswald`;
+    ctx.font = getThemeFont(baseFontSize);
     ctx.fillStyle = '#888888';
     ctx.fillText(c.name, 10, baseFontSize);
     const texture = new THREE.CanvasTexture(canvas);

--- a/filters/planesFilter.js
+++ b/filters/planesFilter.js
@@ -1,5 +1,6 @@
 // filters/planesFilter.js
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
+import { getThemeFont } from '../utils/theme.js';
 import { radToSphere, radToMollweide, getMollweideLambda0, splitMollweideWrap } from '../utils/geometryUtils.js';
 
 const DEG2RAD = Math.PI / 180;
@@ -244,11 +245,11 @@ export function updateCelestialEquatorMollweide(line) {
 function createTextSprite(text, color = '#ffffff', opacity = 0.8, fontSize = 150) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
-  ctx.font = `${fontSize}px Oswald`;
+  ctx.font = getThemeFont(fontSize);
   const textWidth = ctx.measureText(text).width;
   canvas.width = textWidth + 20;
   canvas.height = fontSize * 1.2;
-  ctx.font = `${fontSize}px Oswald`;
+  ctx.font = getThemeFont(fontSize);
   ctx.fillStyle = color;
   ctx.fillText(text, 10, fontSize);
   const texture = new THREE.CanvasTexture(canvas);
@@ -262,11 +263,11 @@ function createTextSprite(text, color = '#ffffff', opacity = 0.8, fontSize = 150
 function createTextPlane(text, color = '#ffffff', opacity = 0.8, fontSize = 150) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
-  ctx.font = `${fontSize}px Oswald`;
+  ctx.font = getThemeFont(fontSize);
   const textWidth = ctx.measureText(text).width;
   canvas.width = textWidth + 20;
   canvas.height = fontSize * 1.2;
-  ctx.font = `${fontSize}px Oswald`;
+  ctx.font = getThemeFont(fontSize);
   ctx.fillStyle = color;
   ctx.fillText(text, 10, fontSize);
   const texture = new THREE.CanvasTexture(canvas);

--- a/index.html
+++ b/index.html
@@ -110,6 +110,16 @@
           </div>
         </fieldset>
 
+        <!-- Style Filter -->
+        <fieldset>
+          <legend class="collapsible" aria-expanded="false">Style</legend>
+          <div class="filter-content">
+            <div class="filter-item">
+              <button type="button" id="historical-toggle">Enable Historical Aesthetic</button>
+            </div>
+          </div>
+        </fieldset>
+
         <!-- Stars Shown Filter -->
         <fieldset>
           <legend class="collapsible" aria-expanded="false">Stars Shown</legend>

--- a/labelManager.js
+++ b/labelManager.js
@@ -2,6 +2,7 @@
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { interpolateColor } from './utils.js';
+import { getThemeFont } from './utils/theme.js';
 
 /**
  * Returns a ShaderMaterial that renders a texture double‑sided without mirroring.
@@ -96,7 +97,7 @@ export class LabelManager {
 
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      ctx.font = `${fontSize}px Oswald`;
+      ctx.font = getThemeFont(fontSize);
 
       const textMetrics = ctx.measureText(displayName);
       const textWidth = textMetrics.width;
@@ -107,7 +108,7 @@ export class LabelManager {
       canvas.height = textHeight + paddingY * 2;
 
       // Draw text without background
-      ctx.font = `${fontSize}px Oswald`;
+      ctx.font = getThemeFont(fontSize);
       const labelColor = '#' + interpolateColor('#ffffff', starColor, 0.5).toString(16).padStart(6, '0');
       ctx.fillStyle = labelColor;
       ctx.textBaseline = 'middle';

--- a/script.js
+++ b/script.js
@@ -2389,3 +2389,4 @@ async function main() {
 }
 
 window.onload = main;
+window.buildAndApplyFilters = buildAndApplyFilters;

--- a/styles.css
+++ b/styles.css
@@ -570,6 +570,10 @@ body.historical .map-container h2 {
 }
 body.historical .map-container canvas {
   background-color: #f5f1e1;
+  filter: sepia(1) saturate(0.6) contrast(0.85);
+}
+body.historical canvas {
+  filter: sepia(1) saturate(0.6) contrast(0.85);
 }
 body.historical .fullscreen-btn {
   background: rgba(215, 198, 171, 0.7);

--- a/styles.css
+++ b/styles.css
@@ -506,3 +506,77 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
     font-size:11px;
   }
 }
+
+/* Historical Aesthetic */
+body.historical {
+  background-color: #f5f1e1;
+  color: #3b2d1f;
+  font-family: 'Times New Roman', serif;
+}
+body.historical #loader {
+  background-color: rgba(245, 241, 225, 0.95);
+  color: #3b2d1f;
+}
+body.historical header {
+  background-color: rgba(215, 198, 171, 0.9);
+}
+body.historical #menu-toggle {
+  color: #6b4a2b;
+}
+body.historical .sidebar {
+  background-color: rgba(245, 241, 225, 0.95);
+  border-right: 1px solid #b8a47a;
+}
+body.historical .sidebar h2 {
+  border-bottom: 2px solid #b8a47a;
+  color: #6b4a2b;
+}
+body.historical .sidebar fieldset {
+  background-color: rgba(245, 241, 225, 0.8);
+  border-color: #b8a47a;
+}
+body.historical .sidebar legend {
+  color: #6b4a2b;
+}
+body.historical .sidebar legend:hover {
+  background-color: rgba(232, 219, 196, 0.8);
+}
+body.historical .filter-item label {
+  color: #3b2d1f;
+}
+body.historical .filter-item input[type="checkbox"],
+body.historical .filter-item input[type="radio"] {
+  accent-color: #6b4a2b;
+}
+body.historical .filter-item input[type="range"] {
+  background: #b8a47a;
+}
+body.historical .filter-item input[type="range"]::-webkit-slider-thumb {
+  background: #6b4a2b;
+  border: 2px solid #f5f1e1;
+}
+body.historical .filter-item input[type="range"]::-moz-range-thumb {
+  background: #6b4a2b;
+  border: 2px solid #f5f1e1;
+}
+body.historical .map-container {
+  background-color: rgba(245, 241, 225, 0.95);
+  border-color: #b8a47a;
+  box-shadow: 0 0 15px rgba(107, 74, 43, 0.5);
+}
+body.historical .map-container h2 {
+  color: #6b4a2b;
+  text-shadow: 0 0 3px rgba(107, 74, 43, 0.7);
+}
+body.historical .map-container canvas {
+  background-color: #f5f1e1;
+}
+body.historical .fullscreen-btn {
+  background: rgba(215, 198, 171, 0.7);
+  color: #6b4a2b;
+}
+body.historical .filter-item button {
+  background: rgba(215, 198, 171, 0.9);
+  color: #6b4a2b;
+  border-color: #b8a47a;
+}

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -7,6 +7,18 @@ export function initFilterUI() {
     document.querySelector('.sidebar').classList.toggle('open');
   });
 
+  // Historical aesthetic toggle.
+  const historicalBtn = document.getElementById('historical-toggle');
+  if (historicalBtn) {
+    historicalBtn.addEventListener('click', function () {
+      document.body.classList.toggle('historical');
+      const enabled = document.body.classList.contains('historical');
+      historicalBtn.textContent = enabled
+        ? 'Disable Historical Aesthetic'
+        : 'Enable Historical Aesthetic';
+    });
+  }
+
   // Enable/disable connection slider.
   const enableConnectionsChk = document.getElementById('enable-connections');
   const connectionSlider = document.getElementById('connection-slider');

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -16,6 +16,9 @@ export function initFilterUI() {
       historicalBtn.textContent = enabled
         ? 'Disable Historical Aesthetic'
         : 'Enable Historical Aesthetic';
+      if (window.buildAndApplyFilters) {
+        window.buildAndApplyFilters();
+      }
     });
   }
 

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,0 +1,5 @@
+export function getThemeFont(fontSize) {
+  const isHistorical = document.body.classList.contains('historical');
+  const family = isHistorical ? '"Times New Roman", serif' : 'Oswald';
+  return `${fontSize}px ${family}`;
+}


### PR DESCRIPTION
## Summary
- add Style category with Historical Aesthetic button
- implement JS to toggle historical theme
- style historical theme with parchment-like colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f236e2b8832aa43a0c81608f639e