### PR TITLE
Adopt parchment-themed 1600s UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Astrography is a 3D visualization tool focused on performing astrography—the mapping of our local stellar environment. This tool charts stars within 20 light years of the Sun (as of March 2025) and uses density mapping to distinguish “seas” (areas with few stars) from “continents” (clusters of stars). It’s designed to help researchers, educators, and space planners understand our local space geography and assess potential future pathways for exploration and expansion.
 
+### 1600s Theme
+
+The interface now evokes a seventeenth‑century star chart. Sepia parchment backgrounds, inked eight‑point star markers and dark‑brown calligraphic labels give the visualization a vintage atlas style.
+
 ---
 
 ## Key Features ✨
@@ -16,8 +20,8 @@ Astrography is a 3D visualization tool focused on performing astrography—the m
 - **Density Mapping:**  
   Visualize regions of high and low star density to identify potential "continents" and "seas" in space.
 
-- **Interactive Exploration:**  
-  - **Custom Camera Controls:** Rotate, zoom, and pan using mouse or touch.  
+- **Interactive Exploration:**
+  - **Custom Camera Controls:** Rotate, zoom, and pan using mouse or touch.
   - **Dynamic Labels & Tooltips:** Click or hover on stars to see detailed information (e.g., star name, distance, spectral type, mass).
 
 - **Advanced Filtering:**  
@@ -50,7 +54,7 @@ Astrography is a 3D visualization tool focused on performing astrography—the m
 
 3. **Open in Browser:**
 
-   Navigate to [http://localhost:8000](http://localhost:8000) to launch Astrography.
+Navigate to [http://localhost:8000](http://localhost:8000) to launch Astrography.
 
 ---
 
@@ -76,6 +80,11 @@ Astrography is a 3D visualization tool focused on performing astrography—the m
 Astrography is free to use for any purpose. If you use Astrography in your work, please include the following attribution:
 
 > *"This work utilizes Astrography, developed by Antoine Paulet."*
+
+### Assets & Fonts
+
+- Calligraphy font: [IM Fell English](https://fonts.google.com/specimen/IM+Fell+English)
+- Parchment and decorative graphics are original vector placeholders located in the `assets/` directory.
 
 ---
 

--- a/assets/compass-rose.svg
+++ b/assets/compass-rose.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="none" stroke="#3b2f2f" stroke-width="2"/>
+  <path d="M50 5 L60 40 L95 50 L60 60 L50 95 L40 60 L5 50 L40 40 Z" fill="none" stroke="#3b2f2f" stroke-width="2"/>
+</svg>

--- a/assets/ornate-frame.svg
+++ b/assets/ornate-frame.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 100 100">
+  <rect x="2" y="2" width="96" height="96" fill="none" stroke="#3b2f2f" stroke-width="4"/>
+  <rect x="6" y="6" width="88" height="88" fill="none" stroke="#3b2f2f" stroke-width="1"/>
+</svg>

--- a/assets/parchment-bg.svg
+++ b/assets/parchment-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="50%" r="75%">
+      <stop offset="0%" stop-color="#f5e6c4"/>
+      <stop offset="100%" stop-color="#e2d3b5"/>
+    </radialGradient>
+  </defs>
+  <rect width="100" height="100" fill="url(#g)"/>
+</svg>

--- a/assets/parchment-strip.svg
+++ b/assets/parchment-strip.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">
+  <defs>
+    <linearGradient id="strip" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5e6c4"/>
+      <stop offset="100%" stop-color="#e2d3b5"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="50" fill="url(#strip)"/>
+</svg>

--- a/filters/colorFilter.js
+++ b/filters/colorFilter.js
@@ -1,6 +1,7 @@
 // /filters/colorFilter.js
 
 import { getStellarClassData } from './stellarClassData.js';
+import { generateColorPalette } from '../utils.js';
 
 /**
  * Applies color filter to stars based on the selected filter.
@@ -19,20 +20,17 @@ export function applyColorFilter(stars, filters) {
   const stellarClassData = getStellarClassData();
 
   if (filters.color === 'stellar-class') {
+    const classes = Object.keys(stellarClassData);
+    const palette = generateColorPalette(classes.length);
+    const classMapping = {};
+    classes.forEach((cls, idx) => {
+      classMapping[cls] = palette[idx];
+    });
     stars.forEach(star => {
       const primaryClass = star.Stellar_class ? star.Stellar_class.charAt(0).toUpperCase() : 'G';
-      const classData = stellarClassData[primaryClass];
-      star.displayColor = classData ? classData.color : '#FFFFFF';
+      star.displayColor = classMapping[primaryClass] || '#3b2f2f';
     });
   } else if (filters.color === 'constellation') {
-    // Use a fixed palette similar to the constellation overlay.
-    const distinctPalette = [
-      "#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00",
-      "#ffff33", "#a65628", "#f781bf", "#66c2a5", "#fc8d62",
-      "#8da0cb", "#e78ac3", "#a6d854", "#ffd92f", "#e5c494",
-      "#b3b3b3", "#1b9e77", "#d95f02", "#7570b3", "#e7298a"
-    ];
-    // Build a mapping from unique constellation names (uppercased) found in the star data.
     const constellationSet = new Set();
     stars.forEach(star => {
       if (star.Constellation) {
@@ -40,31 +38,31 @@ export function applyColorFilter(stars, filters) {
       }
     });
     const constellations = Array.from(constellationSet).sort();
+    const palette = generateColorPalette(constellations.length);
     const colorMapping = {};
     constellations.forEach((constName, index) => {
-      colorMapping[constName] = distinctPalette[index % distinctPalette.length];
+      colorMapping[constName] = palette[index];
     });
-    // Apply the mapping to each star.
     stars.forEach(star => {
       const constKey = star.Constellation ? star.Constellation.toUpperCase() : '';
-      star.displayColor = colorMapping[constKey] || '#FFFFFF';
+      star.displayColor = colorMapping[constKey] || '#3b2f2f';
     });
   } else if (filters.color === 'galactic-plane') {
     const maxZ = Math.max(...stars.map(s => Math.abs(s.z_coordinate)));
     stars.forEach(star => {
       const factor = Math.abs(star.z_coordinate) / maxZ;
       if (star.z_coordinate < 0) {
-        star.displayColor = interpolateHex('#ffffff', '#0000ff', factor);
+        star.displayColor = interpolateHex('#f5e6c4', '#3b2f2f', factor);
       } else if (star.z_coordinate > 0) {
-        star.displayColor = interpolateHex('#ffffff', '#ff0000', factor);
+        star.displayColor = interpolateHex('#f5e6c4', '#3b2f2f', factor);
       } else {
-        star.displayColor = '#ffffff';
+        star.displayColor = '#3b2f2f';
       }
     });
   } else {
     stars.forEach(star => {
       if (!star.displayColor) {
-        star.displayColor = '#FFFFFF';
+        star.displayColor = '#3b2f2f';
       }
     });
   }

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -96,9 +96,9 @@ export function createConstellationBoundariesForGlobe(opacity = 0.4) {
     const points = curve.getPoints(32);
     const geometry = new THREE.BufferGeometry().setFromPoints(points);
     const material = new THREE.LineDashedMaterial({
-      color: 0x888888,
-      dashSize: 2,
-      gapSize: 1,
+      color: 0x3b2f2f,
+      dashSize: 3,
+      gapSize: 1.5,
       linewidth: 1,
       transparent: true,
       opacity
@@ -113,9 +113,9 @@ export function createConstellationBoundariesForGlobe(opacity = 0.4) {
 export function createConstellationBoundariesForMollweide(opacity = 0.4) {
   const R = 100;
   const material = new THREE.LineDashedMaterial({
-    color: 0x888888,
-    dashSize: 2,
-    gapSize: 1,
+    color: 0x3b2f2f,
+    dashSize: 3,
+    gapSize: 1.5,
     linewidth: 1,
     transparent: true,
     opacity

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Starmap Visualization</title>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -14,7 +14,7 @@
 
   <!-- Header with Menu Toggle Button -->
   <header>
-    <button id="menu-toggle" aria-label="Toggle Menu">☰</button>
+    <button id="menu-toggle" aria-label="Toggle Menu">⚜</button>
     <h1>Starmap Visualization</h1>
   </header>
 
@@ -330,6 +330,9 @@
   <div id="export-selection-overlay" style="display:none">
     <div id="export-selection-rect"></div>
   </div>
+
+  <img id="compass-rose" src="assets/compass-rose.svg" alt="Compass Rose" />
+  <img id="page-frame" src="assets/ornate-frame.svg" alt="Ornate Frame" />
 
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/labelManager.js
+++ b/labelManager.js
@@ -1,7 +1,6 @@
 // labelManager.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { interpolateColor } from './utils.js';
 
 /**
  * Returns a ShaderMaterial that renders a texture double‑sided without mirroring.
@@ -59,7 +58,7 @@ export class LabelManager {
    * Creates or updates the 3D label and connecting line for a single star.
    */
   createOrUpdateLabel(star) {
-    const starColor = star.displayColor || '#888888';
+    const starColor = '#3b2f2f';
     const displayName = star.displayName || '';
 
     // Check our cache
@@ -96,7 +95,7 @@ export class LabelManager {
 
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      ctx.font = `${fontSize}px Oswald`;
+      ctx.font = `${fontSize}px 'IM Fell English'`;
 
       const textMetrics = ctx.measureText(displayName);
       const textWidth = textMetrics.width;
@@ -106,10 +105,11 @@ export class LabelManager {
       canvas.width = textWidth + paddingX * 2;
       canvas.height = textHeight + paddingY * 2;
 
-      // Draw text without background
-      ctx.font = `${fontSize}px Oswald`;
-      const labelColor = '#' + interpolateColor('#ffffff', starColor, 0.5).toString(16).padStart(6, '0');
-      ctx.fillStyle = labelColor;
+      // Draw parchment backdrop
+      ctx.fillStyle = '#f5e6c4';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.font = `${fontSize}px 'IM Fell English'`;
+      ctx.fillStyle = starColor;
       ctx.textBaseline = 'middle';
       ctx.fillText(displayName, paddingX, canvas.height / 2);
 
@@ -216,7 +216,7 @@ export class LabelManager {
     // Update line geometry
     const points = [starPos, labelPos];
     lineObj.geometry.setFromPoints(points);
-    lineObj.material.color.set(star.displayColor || '#888888');
+      lineObj.material.color.set(starColor);
   }
 
   /**

--- a/script.js
+++ b/script.js
@@ -850,25 +850,26 @@ function createStarTexture() {
   canvas.width = size;
   canvas.height = size;
   const ctx = canvas.getContext('2d');
-  const gradient = ctx.createRadialGradient(
-    size / 2,
-    size / 2,
-    0,
-    size / 2,
-    size / 2,
-    size / 2
-  );
-  // Create a bright, opaque core that quickly fades outward so stars look like
-  // they have a luminous center with radiating light.
-  gradient.addColorStop(0, 'rgba(255,255,255,1)');
-  gradient.addColorStop(0.3, 'rgba(255,255,255,0.9)');
-  gradient.addColorStop(0.6, 'rgba(255,255,255,0.4)');
-  gradient.addColorStop(1, 'rgba(255,255,255,0)');
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, size, size);
+
+  ctx.translate(size / 2, size / 2);
+  ctx.strokeStyle = '#3b2f2f';
+  ctx.fillStyle = '#3b2f2f';
+  ctx.lineWidth = 2;
+
+  ctx.beginPath();
+  for (let i = 0; i < 8; i++) {
+    const angle = (i * Math.PI) / 4;
+    const r = i % 2 === 0 ? size * 0.5 : size * 0.2;
+    ctx.lineTo(r * Math.cos(angle), r * Math.sin(angle));
+  }
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
   const texture = new THREE.CanvasTexture(canvas);
   texture.minFilter = THREE.LinearFilter;
   texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
   return texture;
 }
 
@@ -912,7 +913,7 @@ function createStarMaterial(texture, opacity, sizeAttenuation, cameraZoom) {
     `,
     transparent: true,
     depthWrite: false,
-    blending: THREE.AdditiveBlending
+    blending: THREE.NormalBlending
   });
 }
 
@@ -1090,7 +1091,7 @@ class MapManager {
         positions[i * 3 + 1] = pos.y;
         positions[i * 3 + 2] = pos.z;
         sizes[i] = scale;
-        const color = new THREE.Color(star.displayColor || '#ffffff');
+        const color = new THREE.Color(star.displayColor || '#3b2f2f');
         colors[i * 3] = color.r;
         colors[i * 3 + 1] = color.g;
         colors[i * 3 + 2] = color.b;
@@ -1119,7 +1120,7 @@ class MapManager {
         dummy.scale.set(scale, scale, scale);
         dummy.updateMatrix();
         this.instancedMesh.setMatrixAt(i, dummy.matrix);
-        const color = new THREE.Color(star.displayColor || '#ffffff');
+        const color = new THREE.Color(star.displayColor || '#3b2f2f');
         colors[i * 3] = color.r;
         colors[i * 3 + 1] = color.g;
         colors[i * 3 + 2] = color.b;

--- a/styles.css
+++ b/styles.css
@@ -9,9 +9,10 @@
 
 /* Body, Loader */
 body {
-  font-family: 'Oswald', sans-serif;
-  background-color: #0d0d0d;
-  color: #e0e0e0;
+  font-family: 'IM Fell English', serif;
+  background-color: #f5e6c4;
+  background-image: url('assets/parchment-bg.svg');
+  color: #3b2f2f;
   overflow: hidden;
 }
 
@@ -21,14 +22,15 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(13, 13, 13, 0.95);
-  color: #e0e0e0;
+  background-color: rgba(245, 230, 196, 0.95);
+  color: #3b2f2f;
   font-size: 24px;
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1100;
   transition: opacity 0.5s, visibility 0.5s;
+  font-family: 'IM Fell English', serif;
 }
 
 #loader.hidden {
@@ -43,11 +45,14 @@ header {
   left: 0;
   width: 100%;
   height: 60px;
-  background-color: rgba(20, 20, 20, 0.9);
+  background-image: url('assets/parchment-strip.svg');
+  background-size: cover;
+  background-color: rgba(245, 230, 196, 0.9);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1050;
+  border-bottom: 2px solid #3b2f2f;
 }
 
 #menu-toggle {
@@ -56,17 +61,19 @@ header {
   top: 50%;
   transform: translateY(-50%);
   font-size: 32px;
-  background: none;
-  border: none;
-  color: #ff6f61;
+  background-image: url('assets/parchment-strip.svg');
+  background-size: cover;
+  border: 1px solid #3b2f2f;
+  color: #3b2f2f;
   cursor: pointer;
 }
 
 /* Title remains centered */
 header h1 {
   font-size: 24px;
-  color: #e0e0e0;
-  text-shadow: 0 0 5px rgba(255, 255, 255, 0.2);
+  color: #3b2f2f;
+  text-shadow: none;
+  font-family: 'IM Fell English', serif;
 }
 
 /* Main Container */
@@ -84,10 +91,10 @@ header h1 {
   left: 0;
   bottom: 0;
   width: 300px;
-  background-color: rgba(30, 30, 30, 0.95);
+  background-image: url('assets/parchment-strip.svg');
   padding: 25px;
   overflow-y: auto;
-  border-right: 1px solid #444;
+  border-right: 1px solid #3b2f2f;
   z-index: 1100;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
@@ -100,31 +107,33 @@ header h1 {
 .sidebar h2 {
   margin-bottom: 15px;
   font-size: 22px;
-  border-bottom: 2px solid #555;
+  border-bottom: 2px solid #3b2f2f;
   padding-bottom: 5px;
-  color: #f0f0f0;
+  color: #3b2f2f;
+  font-family: 'IM Fell English', serif;
 }
 
 /* Filter Fieldsets */
 .sidebar fieldset {
-  border: 1px solid #555;
+  border: 1px solid #3b2f2f;
   border-radius: 5px;
   padding: 15px;
   margin-bottom: 20px;
-  background-color: rgba(50, 50, 50, 0.8);
+  background-color: rgba(245, 230, 196, 0.8);
 }
 
 .sidebar legend {
   font-size: 18px;
   padding: 0 5px;
-  color: #f0f0f0;
+  color: #3b2f2f;
   cursor: pointer;
   user-select: none;
   display: block;
+  font-family: 'IM Fell English', serif;
 }
 
 .sidebar legend:hover {
-  background-color: rgba(60, 60, 60, 0.8);
+  background-color: rgba(223, 209, 176, 0.8);
   border-radius: 4px;
 }
 
@@ -155,16 +164,16 @@ header h1 {
 .subcategory-header {
   font-size: 16px;
   margin-bottom: 5px;
-  color: #ff6f61; 
+  color: #3b2f2f;
   user-select: none;
   cursor: pointer;
-  background-color: #2a2a2a;
+  background-color: #e2d3b5;
   padding: 5px;
   border-radius: 4px;
   transition: background-color 0.3s;
 }
 .subcategory-header:hover {
-  background-color: rgba(60, 60, 60, 0.8);
+  background-color: #d0c0a5;
 }
 
 /* Subcategory content */
@@ -188,14 +197,14 @@ header h1 {
 .filter-item label {
   margin-left: 10px;
   font-size: 13px;
-  color: #e0e0e0;
+  color: #3b2f2f;
   cursor: pointer;
 }
 
 .filter-item button {
-  background: rgba(20, 20, 20, 0.9);
-  color: #ff6f61;
-  border: 1px solid #555;
+  background-image: url('assets/parchment-strip.svg');
+  color: #3b2f2f;
+  border: 1px solid #3b2f2f;
   padding: 4px 6px;
   border-radius: 4px;
   font-size: 14px;
@@ -207,7 +216,7 @@ header h1 {
   width: 18px;
   height: 18px;
   cursor: pointer;
-  accent-color: #ff6f61;
+  accent-color: #3b2f2f;
 }
 
 .filter-item input[type="range"] {
@@ -216,7 +225,7 @@ header h1 {
   cursor: pointer;
   appearance: none;
   height: 6px;
-  background: #555;
+  background: #e2d3b5;
   border-radius: 3px;
   outline: none;
   transition: background 0.3s;
@@ -226,27 +235,27 @@ header h1 {
   appearance: none;
   width: 16px;
   height: 16px;
-  background: #ff6f61;
+  background: #3b2f2f;
   border-radius: 50%;
   cursor: pointer;
-  border: 2px solid #fff;
+  border: 2px solid #f5e6c4;
   transition: background 0.3s;
 }
 filter-item input[type="range"]::-moz-range-thumb {
   width: 16px;
   height: 16px;
-  background: #ff6f61;
+  background: #3b2f2f;
   border: none;
   border-radius: 50%;
   cursor: pointer;
-  border: 2px solid #fff;
+  border: 2px solid #f5e6c4;
   transition: background 0.3s;
 }
 filter-item input[type="range"]:hover {
-  background: #666;
+  background: #d0c0a5;
 }
 filter-item input[type="range"]::-webkit-slider-thumb:hover {
-  background: #ff8566;
+  background: #5c4433;
 }
 filter-item input[type="range"]::-moz-range-thumb:hover {
   background: #ff8566;
@@ -259,7 +268,7 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 #density-bottom-value {
   font-weight: bold;
   margin-left: 5px;
-  color: #ff6f61;
+  color: #3b2f2f;
 }
 
 /* Maps Section */
@@ -267,7 +276,8 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: #121212;
+  background-image: url('assets/parchment-bg.svg');
+  background-color: #f5e6c4;
   padding-top: 10px;
   padding-bottom: 10px;
 }
@@ -277,19 +287,19 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto 30px;
-  background-color: rgba(20, 20, 20, 0.95);
-  border: 1px solid #555;
+  background-image: url('assets/parchment-strip.svg');
+  border: 1px solid #3b2f2f;
   border-radius: 8px;
   padding: 10px;
-  box-shadow: 0 0 15px rgba(255, 111, 97, 0.5);
+  box-shadow: 0 0 15px rgba(59, 47, 47, 0.5);
 }
 
 .map-container h2 {
   text-align: center;
   margin-bottom: 10px;
   font-size: 18px;
-  color: #ff6f61;
-  text-shadow: 0 0 3px rgba(255, 111, 97, 0.7);
+  color: #3b2f2f;
+  text-shadow: none;
 }
 
 .map-container canvas {
@@ -319,15 +329,15 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 #label-edit-overlay .handle {
   width: 36px;
   height: 36px;
-  background: #ff6f61;
-  border: 2px solid #fff;
+  background: #3b2f2f;
+  border: 2px solid #f5e6c4;
   border-radius: 50%;
   position: absolute;
   pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: #f5e6c4;
   font-size: 30px;
 }
 #label-edit-overlay .rotate-handle {
@@ -353,8 +363,8 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 }
 #export-selection-rect {
   position: absolute;
-  border: 2px dashed #ff6f61;
-  background: rgba(255, 111, 97, 0.2);
+  border: 2px dashed #3b2f2f;
+  background: rgba(59, 47, 47, 0.2);
   pointer-events: none;
 }
 
@@ -364,9 +374,9 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   top: 10px;
   right: 10px;
   font-size: 24px;
-  background: rgba(20, 20, 20, 0.7);
-  border: none;
-  color: #ff6f61;
+  background-image: url('assets/parchment-strip.svg');
+  border: 1px solid #3b2f2f;
+  color: #3b2f2f;
   cursor: pointer;
   padding: 5px 10px;
   border-radius: 4px;
@@ -380,16 +390,16 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   right: 10px;
   display: flex;
   gap: 6px;
-  background: rgba(20, 20, 20, 0.7);
+  background-image: url('assets/parchment-strip.svg');
   padding: 5px;
   border-radius: 4px;
   z-index: 1100;
 }
 .export-controls select,
 .export-controls button {
-  background: rgba(20, 20, 20, 0.9);
-  color: #ff6f61;
-  border: 1px solid #555;
+  background-image: url('assets/parchment-strip.svg');
+  color: #3b2f2f;
+  border: 1px solid #3b2f2f;
   padding: 4px 6px;
   border-radius: 4px;
   font-size: 14px;
@@ -398,19 +408,21 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
   cursor: pointer;
 }
 .export-btn.active {
-  background: #ff6f61;
-  color: #000;
+  background: #3b2f2f;
+  color: #f5e6c4;
 }
 
 /* Tooltip */
 #tooltip {
   position: absolute;
-  background-color: rgba(20, 20, 20, 0.95);
-  color: #e0e0e0;
+  background-image: url('assets/parchment-strip.svg');
+  color: #3b2f2f;
   padding: 10px;
   border-radius: 4px;
+  border: 1px solid #3b2f2f;
   pointer-events: none;
   font-size: 14px;
+  font-family: 'IM Fell English', serif;
   max-width: 220px;
   z-index: 1200;
   transition: opacity 0.3s, visibility 0.3s;
@@ -426,11 +438,11 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 #tooltip-starName {
   font-size: 16px;
   font-weight: bold;
-  color: #ff6f61;
+  color: #3b2f2f;
 }
 #tooltip-systemName {
   font-size: 14px;
-  color: #ff8566;
+  color: #3b2f2f;
 }
 #tooltip-distance,
 #tooltip-stellarClass,
@@ -438,23 +450,42 @@ filter-item input[type="range"]::-moz-range-thumb:hover {
 #tooltip-apparentMag,
 #tooltip-absoluteMag {
   font-size: 12px;
-  color: #e0e0e0;
+  color: #3b2f2f;
   margin-top: 4px;
+}
+
+#compass-rose {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 120px;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+#page-frame {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 500;
 }
 
 /* Label Styles */
 .label-container .label {
   position: absolute;
   background-color: transparent;
-  color: #ffffff;
+  color: #3b2f2f;
   padding: 3px 6px;
   border-radius: 4px;
   font-size: 13px;
   pointer-events: none;
   white-space: nowrap;
   z-index: 1200;
-  text-shadow: 0px 0px 2px rgba(0,0,0,0.7);
-  box-shadow: 0 0 3px rgba(0,0,0,0.5);
+  text-shadow: none;
+  box-shadow: none;
 }
 
 /* Fullscreen CSS so that the element in fullscreen fills the viewport */

--- a/tooltips.js
+++ b/tooltips.js
@@ -38,7 +38,7 @@ export function showTooltip(x, y, star) {
       <div id="tooltip-catalogLink">
         <strong>Catalog:</strong> 
         ${star.Catalog_link 
-            ? `<a href="${star.Catalog_link}" target="_blank" style="color: #ff6f61; text-decoration: underline;">Catalog</a>` 
+            ? `<a href="${star.Catalog_link}" target="_blank" style="color: #3b2f2f; text-decoration: underline;">Catalog</a>`
             : 'N/A'}
       </div>
     `;

--- a/utils.js
+++ b/utils.js
@@ -26,17 +26,15 @@ export function generateConstellationColors(stars) {
  * @param {number} numColors - Number of unique colors to generate.
  * @returns {Array} - Array of HEX color strings.
  */
-function generateColorPalette(numColors) {
+export function generateColorPalette(numColors) {
+  const earthTones = [
+    '#3b2f2f', '#5c4433', '#765c3d', '#8a6f47', '#a88b58',
+    '#c0a474', '#d8c19f', '#e8d9c2', '#f5e6c4'
+  ];
   const palette = [];
-  const hueStep = 360 / (numColors || 1);
-
   for (let i = 0; i < numColors; i++) {
-    const hue = i * hueStep;
-    const saturation = 70; // Percentage
-    const lightness = 50; // Percentage
-    palette.push(hslToHex(hue, saturation, lightness));
+    palette.push(earthTones[i % earthTones.length]);
   }
-
   return palette;
 }
 
@@ -49,11 +47,13 @@ function generateColorPalette(numColors) {
  */
 function hslToHex(h, s, l) {
   l /= 100;
-  const a = s * Math.min(l, 1 - l) / 100;
+  const a = (s * Math.min(l, 1 - l)) / 100;
   const f = n => {
     const k = (n + h / 30) % 12;
     const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color).toString(16).padStart(2, '0');
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0');
   };
   return `#${f(0)}${f(8)}${f(4)}`;
 }


### PR DESCRIPTION
## Summary
- Switch site typography to IM Fell English and add decorative compass and frame graphics
- Rework styles and tooltips with parchment textures and sepia palette
- Render eight-point star sprites and earth-tone color palettes for classes and constellations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f9ad75f0832a94de904526b56eae