### PR TITLE
Add controls for constellation and border styling

### DIFF
--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -83,7 +83,7 @@ export function getConstellationBoundaries() {
 /**
  * Creates constellation boundary line meshes for the Globe.
  */
-export function createConstellationBoundariesForGlobe(opacity = 0.4) {
+export function createConstellationBoundariesForGlobe(opacity = 0.4, lineWidth = 1) {
   const lines = [];
   const R = 100;
   boundaryData.forEach(b => {
@@ -99,24 +99,28 @@ export function createConstellationBoundariesForGlobe(opacity = 0.4) {
       color: 0x888888,
       dashSize: 2,
       gapSize: 1,
-      linewidth: 1,
+      linewidth: lineWidth,
       transparent: true,
       opacity
     });
     const line = new THREE.Line(geometry, material);
     line.computeLineDistances();
+    line.userData = {
+      baseLineWidth: lineWidth,
+      baseOpacity: opacity
+    };
     lines.push(line);
   });
   return lines;
 }
 
-export function createConstellationBoundariesForMollweide(opacity = 0.4) {
+export function createConstellationBoundariesForMollweide(opacity = 0.4, lineWidth = 1) {
   const R = 100;
   const material = new THREE.LineDashedMaterial({
     color: 0x888888,
     dashSize: 2,
     gapSize: 1,
-    linewidth: 1,
+    linewidth: lineWidth,
     transparent: true,
     opacity
   });
@@ -130,10 +134,10 @@ export function createConstellationBoundariesForMollweide(opacity = 0.4) {
   lineSegs.userData = {
     boundaryData,
     R,
-    baseLineWidth: 1,
+    baseLineWidth: lineWidth,
     baseOpacity: opacity,
     exportLineWidthFactor: 1.5,
-    exportOpacityFactor: 2
+    exportOpacityFactor: 1
   };
   updateConstellationBoundariesForMollweide(lineSegs);
   return [lineSegs];

--- a/filters/constellationFilter.js
+++ b/filters/constellationFilter.js
@@ -1,7 +1,8 @@
 // /filters/constellationFilter.js
 
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
-import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, adjustMollweideWrap, splitMollweideWrap, greatCircleToMollweide } from '../utils/geometryUtils.js';
+import { radToSphere, getGreatCirclePoints, cachedRadToMollweide, getMollweideLambda0, splitMollweideWrap, greatCircleToMollweide } from '../utils/geometryUtils.js';
+import { buildWideLineGeometry } from './connectionsFilter.js';
 
 let boundaryData = [];
 let centerData = [];
@@ -114,15 +115,107 @@ export function createConstellationBoundariesForGlobe(opacity = 0.4, lineWidth =
   return lines;
 }
 
+function ensureVisibleConstellationMesh(lineSegs) {
+  if (!lineSegs) return null;
+  if (!lineSegs.userData) lineSegs.userData = {};
+  if (!lineSegs.userData.visibleMesh) {
+    const mesh = new THREE.Mesh(
+      new THREE.BufferGeometry(),
+      new THREE.MeshBasicMaterial({
+        color: 0x888888,
+        transparent: true,
+        opacity: 1,
+        depthWrite: false,
+        depthTest: false,
+        side: THREE.DoubleSide
+      })
+    );
+    mesh.renderOrder = (lineSegs.renderOrder || 1) + 0.01;
+    mesh.userData = {
+      baseWidth: 1,
+      baseOpacity: 1,
+      baseColor: 0x888888,
+      exportLineWidthFactor: 1.5,
+      exportOpacityFactor: 1,
+      points: []
+    };
+    lineSegs.add(mesh);
+    lineSegs.userData.visibleMesh = mesh;
+  }
+  return lineSegs.userData.visibleMesh;
+}
+
+export function rebuildConstellationMeshFromSegments(lineSegs, overrideWidth, overrideOpacity) {
+  if (!lineSegs) return;
+  const mesh = ensureVisibleConstellationMesh(lineSegs);
+  if (!mesh) return;
+  const posAttr = lineSegs.geometry ? lineSegs.geometry.getAttribute('position') : null;
+  if (!posAttr) return;
+  const arr = posAttr.array;
+  const pts = [];
+  for (let i = 0; i + 5 < arr.length; i += 6) {
+    const ax = arr[i];
+    const ay = arr[i + 1];
+    const az = arr[i + 2];
+    const bx = arr[i + 3];
+    const by = arr[i + 4];
+    const bz = arr[i + 5];
+    if (
+      !Number.isFinite(ax) || !Number.isFinite(ay) || !Number.isFinite(az) ||
+      !Number.isFinite(bx) || !Number.isFinite(by) || !Number.isFinite(bz)
+    ) {
+      continue;
+    }
+    if (
+      ax === 0 && ay === 0 && az === 0 &&
+      bx === 0 && by === 0 && bz === 0
+    ) {
+      continue;
+    }
+    pts.push(new THREE.Vector3(ax, ay, az));
+    pts.push(new THREE.Vector3(bx, by, bz));
+  }
+  const width = Math.max(0.1, overrideWidth !== undefined ? overrideWidth : (lineSegs.userData.baseLineWidth || 1));
+  const baseOpacity = overrideOpacity !== undefined ? overrideOpacity : (lineSegs.userData.baseOpacity !== undefined ? lineSegs.userData.baseOpacity : mesh.material.opacity);
+  if (pts.length === 0) {
+    mesh.visible = false;
+  } else {
+    mesh.visible = true;
+    const geometry = buildWideLineGeometry(pts, width);
+    geometry.computeBoundingSphere();
+    if (mesh.geometry) {
+      mesh.geometry.dispose();
+    }
+    mesh.geometry = geometry;
+  }
+  const clampedOpacity = Math.max(0, Math.min(1, baseOpacity));
+  if (mesh.material && mesh.material.color) {
+    mesh.material.color.setHex(0x888888);
+  }
+  mesh.material.opacity = clampedOpacity;
+  mesh.material.needsUpdate = true;
+  mesh.userData.baseWidth = width;
+  mesh.userData.baseOpacity = clampedOpacity;
+  mesh.userData.points = pts.map(p => p.clone());
+  mesh.userData.baseColor = 0x888888;
+  if (mesh.userData.exportColor === undefined) mesh.userData.exportColor = 0x888888;
+  if (mesh.userData.exportLineWidthFactor === undefined) mesh.userData.exportLineWidthFactor = 1.5;
+  if (mesh.userData.exportOpacityFactor === undefined) mesh.userData.exportOpacityFactor = 1;
+  lineSegs.userData.baseLineWidth = width;
+  lineSegs.userData.baseOpacity = clampedOpacity;
+}
+
 export function createConstellationBoundariesForMollweide(opacity = 0.4, lineWidth = 1) {
   const R = 100;
+  const sanitizedWidth = Math.max(0.1, lineWidth);
+  const sanitizedOpacity = Math.max(0, Math.min(1, opacity));
   const material = new THREE.LineDashedMaterial({
     color: 0x888888,
     dashSize: 2,
     gapSize: 1,
-    linewidth: lineWidth,
+    linewidth: sanitizedWidth,
     transparent: true,
-    opacity
+    opacity: 0
   });
   const maxSegments = boundaryData.length * 32; // 16 segments per boundary, each may wrap
   const positions = new Float32Array(maxSegments * 2 * 3); // 2 vertices per segment
@@ -130,12 +223,14 @@ export function createConstellationBoundariesForMollweide(opacity = 0.4, lineWid
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   const lineSegs = new THREE.LineSegments(geometry, material);
   lineSegs.renderOrder = 1;
-  lineSegs.computeLineDistances();
+  lineSegs.material.depthWrite = false;
+  lineSegs.material.transparent = true;
+  lineSegs.material.opacity = 0;
   lineSegs.userData = {
     boundaryData,
     R,
-    baseLineWidth: lineWidth,
-    baseOpacity: opacity,
+    baseLineWidth: sanitizedWidth,
+    baseOpacity: sanitizedOpacity,
     exportLineWidthFactor: 1.5,
     exportOpacityFactor: 1
   };
@@ -172,6 +267,7 @@ export function updateConstellationBoundariesForMollweide(lineSegs) {
   for (; idx < array.length; idx++) array[idx] = 0;
   posAttr.needsUpdate = true;
   lineSegs.computeLineDistances();
+  rebuildConstellationMeshFromSegments(lineSegs);
 }
 
 /**

--- a/filters/index.js
+++ b/filters/index.js
@@ -147,6 +147,37 @@ function addConstellationsFieldset() {
   lineOpDiv.appendChild(document.createTextNode('%'));
   contentDiv.appendChild(lineOpDiv);
 
+  const lineWidthDiv = document.createElement('div');
+  lineWidthDiv.classList.add('filter-item');
+  const lineWidthLabel = document.createElement('label');
+  lineWidthLabel.htmlFor = 'constellation-line-width-slider';
+  lineWidthLabel.textContent = 'Line Width:';
+  const lineWidthSlider = document.createElement('input');
+  lineWidthSlider.type = 'range';
+  lineWidthSlider.id = 'constellation-line-width-slider';
+  lineWidthSlider.name = 'constellation-line-width';
+  lineWidthSlider.min = '0.1';
+  lineWidthSlider.max = '5';
+  lineWidthSlider.value = '1';
+  lineWidthSlider.step = '0.1';
+  const lineWidthNumber = document.createElement('input');
+  lineWidthNumber.type = 'number';
+  lineWidthNumber.id = 'constellation-line-width-number';
+  lineWidthNumber.name = 'constellation-line-width';
+  lineWidthNumber.min = '0.1';
+  lineWidthNumber.max = '5';
+  lineWidthNumber.value = '1.0';
+  lineWidthNumber.step = '0.1';
+  const lineWidthSpan = document.createElement('span');
+  lineWidthSpan.id = 'constellation-line-width-value';
+  lineWidthSpan.textContent = '1.0';
+  lineWidthDiv.appendChild(lineWidthLabel);
+  lineWidthDiv.appendChild(lineWidthSlider);
+  lineWidthDiv.appendChild(lineWidthNumber);
+  lineWidthDiv.appendChild(lineWidthSpan);
+  lineWidthDiv.appendChild(document.createTextNode('px'));
+  contentDiv.appendChild(lineWidthDiv);
+
   const nameOpDiv = document.createElement('div');
   nameOpDiv.classList.add('filter-item');
   const nameOpLabel = document.createElement('label');
@@ -177,6 +208,69 @@ function addConstellationsFieldset() {
   nameOpDiv.appendChild(nameOpSpan);
   nameOpDiv.appendChild(document.createTextNode('%'));
   contentDiv.appendChild(nameOpDiv);
+
+  const borderWidthDiv = document.createElement('div');
+  borderWidthDiv.classList.add('filter-item');
+  const borderWidthLabel = document.createElement('label');
+  borderWidthLabel.htmlFor = 'mollweide-border-width-slider';
+  borderWidthLabel.textContent = 'Border Width:';
+  const borderWidthSlider = document.createElement('input');
+  borderWidthSlider.type = 'range';
+  borderWidthSlider.id = 'mollweide-border-width-slider';
+  borderWidthSlider.name = 'mollweide-border-width';
+  borderWidthSlider.min = '0.1';
+  borderWidthSlider.max = '10';
+  borderWidthSlider.value = '1';
+  borderWidthSlider.step = '0.1';
+  const borderWidthNumber = document.createElement('input');
+  borderWidthNumber.type = 'number';
+  borderWidthNumber.id = 'mollweide-border-width-number';
+  borderWidthNumber.name = 'mollweide-border-width';
+  borderWidthNumber.min = '0.1';
+  borderWidthNumber.max = '10';
+  borderWidthNumber.value = '1.0';
+  borderWidthNumber.step = '0.1';
+  const borderWidthSpan = document.createElement('span');
+  borderWidthSpan.id = 'mollweide-border-width-value';
+  borderWidthSpan.textContent = '1.0';
+  borderWidthDiv.appendChild(borderWidthLabel);
+  borderWidthDiv.appendChild(borderWidthSlider);
+  borderWidthDiv.appendChild(borderWidthNumber);
+  borderWidthDiv.appendChild(borderWidthSpan);
+  borderWidthDiv.appendChild(document.createTextNode('px'));
+  contentDiv.appendChild(borderWidthDiv);
+
+  const borderOpacityDiv = document.createElement('div');
+  borderOpacityDiv.classList.add('filter-item');
+  const borderOpacityLabel = document.createElement('label');
+  borderOpacityLabel.htmlFor = 'mollweide-border-opacity-slider';
+  borderOpacityLabel.textContent = 'Border Opacity:';
+  const borderOpacitySlider = document.createElement('input');
+  borderOpacitySlider.type = 'range';
+  borderOpacitySlider.id = 'mollweide-border-opacity-slider';
+  borderOpacitySlider.name = 'mollweide-border-opacity';
+  borderOpacitySlider.min = '0';
+  borderOpacitySlider.max = '100';
+  borderOpacitySlider.value = '100';
+  borderOpacitySlider.step = '1';
+  const borderOpacityNumber = document.createElement('input');
+  borderOpacityNumber.type = 'number';
+  borderOpacityNumber.id = 'mollweide-border-opacity-number';
+  borderOpacityNumber.name = 'mollweide-border-opacity';
+  borderOpacityNumber.min = '0';
+  borderOpacityNumber.max = '100';
+  borderOpacityNumber.value = '100';
+  borderOpacityNumber.step = '1';
+  const borderOpacitySpan = document.createElement('span');
+  borderOpacitySpan.id = 'mollweide-border-opacity-value';
+  borderOpacitySpan.textContent = '100';
+  borderOpacityDiv.appendChild(borderOpacityLabel);
+  borderOpacityDiv.appendChild(borderOpacitySlider);
+  borderOpacityDiv.appendChild(borderOpacityNumber);
+  borderOpacityDiv.appendChild(borderOpacitySpan);
+  borderOpacityDiv.appendChild(document.createTextNode('%'));
+  contentDiv.appendChild(borderOpacityDiv);
+
   fs.appendChild(contentDiv);
   filterForm.appendChild(fs);
 }
@@ -342,7 +436,10 @@ export function applyFilters(allStars) {
         connectionFade: 1,
         connectionLabelSize: 1,
         constellationLineOpacity: 40,
+        constellationLineWidth: 1,
         constellationNameOpacity: 80,
+        mollweideBorderWidth: 1,
+        mollweideBorderOpacity: 100,
         planeOpacity: 50,
         enableIsolationLabeling: false,
         enableDensityLabeling: false,
@@ -358,6 +455,9 @@ export function applyFilters(allStars) {
     }
   }
   const formData = new FormData(filterForm);
+  const rawConstellationLineWidth = parseFloat(formData.get('constellation-line-width'));
+  const rawMollweideBorderWidth = parseFloat(formData.get('mollweide-border-width'));
+  const rawMollweideBorderOpacity = parseFloat(formData.get('mollweide-border-opacity'));
   const filters = {
     size: formData.get('size'),
     color: formData.get('color'),
@@ -396,8 +496,11 @@ export function applyFilters(allStars) {
     connectionFade: parseFloat(formData.get('connection-fade')) || 1,
     connectionLabelSize: parseFloat(formData.get('connection-label-size')) || 1,
     constellationLineOpacity: parseFloat(formData.get('constellation-line-opacity')) || 40,
+    constellationLineWidth: Number.isFinite(rawConstellationLineWidth) ? rawConstellationLineWidth : 1,
     constellationNameOpacity: parseFloat(formData.get('constellation-name-opacity')) || 80,
     planeOpacity: parseFloat(formData.get('plane-opacity')) || 50,
+    mollweideBorderWidth: Number.isFinite(rawMollweideBorderWidth) ? rawMollweideBorderWidth : 1,
+    mollweideBorderOpacity: Number.isFinite(rawMollweideBorderOpacity) ? rawMollweideBorderOpacity : 100,
     showClouds: (formData.getAll('dust-clouds').length > 0),
     showCloudDensity: (formData.getAll('dust-density-clouds').length > 0),
     showGalacticPlane: (formData.get('show-galactic-plane') !== null),
@@ -583,8 +686,11 @@ export function applyFilters(allStars) {
     connectionFade: filters.connectionFade,
     connectionLabelSize: filters.connectionLabelSize,
     constellationLineOpacity: filters.constellationLineOpacity,
+    constellationLineWidth: filters.constellationLineWidth,
     constellationNameOpacity: filters.constellationNameOpacity,
     planeOpacity: filters.planeOpacity,
+    mollweideBorderWidth: filters.mollweideBorderWidth,
+    mollweideBorderOpacity: filters.mollweideBorderOpacity,
     showClouds: filters.showClouds,
     showCloudDensity: filters.showCloudDensity,
     showGalacticPlane: filters.showGalacticPlane,

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.min.js';
 import { applyFilters, setupFilterUI, generateStellarClassFilters } from './filters/index.js';
 import { createConnectionLines, mergeConnectionLines, setConnectionLineParams, buildWideLineGeometry } from './filters/connectionsFilter.js';
-import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide } from './filters/constellationFilter.js';
+import { createConstellationBoundariesForGlobe, createConstellationLabelsForGlobe, createConstellationBoundariesForMollweide, updateConstellationBoundariesForMollweide, createConstellationLabelsForMollweide, rebuildConstellationMeshFromSegments } from './filters/constellationFilter.js';
 import { createConstellationOverlayForGlobe, createConstellationOverlayForMollweide } from './filters/constellationOverlayFilter.js';
 import { initIsolationFilter, updateIsolationFilter } from './filters/isolationFilter.js';
 import { initDensityFilter, updateDensityFilter } from './filters/densityFilter.js';
@@ -1959,6 +1959,9 @@ function applyStoredLineEdits(root) {
     if (key && hiddenLineKeys.has(key)) {
       obj.visible = false;
     }
+    if (obj.type !== 'Line' && obj.type !== 'LineSegments') {
+      return;
+    }
     const posAttr = obj.geometry && obj.geometry.getAttribute('position');
     if (!posAttr) return;
     const array = posAttr.array;
@@ -1980,7 +1983,12 @@ function applyStoredLineEdits(root) {
         changed = true;
       }
     }
-    if (changed) posAttr.needsUpdate = true;
+    if (changed) {
+      posAttr.needsUpdate = true;
+      if (obj.userData && obj.userData.visibleMesh) {
+        rebuildConstellationMeshFromSegments(obj);
+      }
+    }
   });
 }
 

--- a/script.js
+++ b/script.js
@@ -383,7 +383,9 @@ function createMollweideBackground(R = 100, segments = 1024) {
   return mesh;
 }
 
-function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
+function createMollweideBorder(R = 100, thickness = 1, opacity = 1, segments = 1024) {
+  const clampedThickness = Math.max(0.1, thickness);
+  const clampedOpacity = Math.max(0, Math.min(1, opacity));
   const pts = [];
   let prev = null;
   for (let i = 0; i <= segments; i++) {
@@ -394,26 +396,28 @@ function createMollweideBorder(R = 100, thickness = 1, segments = 1024) {
     }
     prev = p;
   }
-  const geometry = buildWideLineGeometry(pts, thickness);
+  const geometry = buildWideLineGeometry(pts, clampedThickness);
   const material = new THREE.MeshBasicMaterial({
     color: 0xbbbbbb,
     side: THREE.DoubleSide,
     depthTest: false,
     depthWrite: false,
     transparent: true,
-    opacity: 1
+    opacity: clampedOpacity
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.renderOrder = 1001;
   mesh.userData = {
-    baseWidth: thickness,
+    baseWidth: clampedThickness,
     points: pts,
-    exportLineWidthFactor: 0.85,
+    exportLineWidthFactor: 1,
     baseRadius: R,
     segments,
     isMollweideBorder: true,
     baseColor: 0xbbbbbb,
-    exportColor: 0x888888
+    exportColor: 0x888888,
+    baseOpacity: clampedOpacity,
+    exportOpacityFactor: 1
   };
   return mesh;
 }
@@ -542,14 +546,21 @@ async function buildAndApplyFilters() {
     connectionFade,
     connectionLabelSize,
     constellationLineOpacity,
+    constellationLineWidth,
     constellationNameOpacity,
     planeOpacity,
+    mollweideBorderWidth,
+    mollweideBorderOpacity,
     showGalacticPlane,
     showEclipticPlane,
     showCelestialEquator,
     isolationOverlay: returnedIsolationOverlay,
     densityOverlay: returnedDensityOverlay
   } = filters;
+
+  const sanitizedConstellationLineWidth = Math.max(0.1, constellationLineWidth || 0.1);
+  const sanitizedBorderWidth = Math.max(0.1, mollweideBorderWidth || 0.1);
+  const sanitizedBorderOpacity = Math.max(0, Math.min(100, mollweideBorderOpacity));
 
   showConstellationBoundariesFlag = showConstellationBoundaries;
   showConstellationNamesFlag = showConstellationNames;
@@ -617,9 +628,15 @@ async function buildAndApplyFilters() {
   removeConstellationOverlayObjectsFromGlobe();
 
   if (showConstellationBoundaries) {
-    constellationLinesGlobe = createConstellationBoundariesForGlobe(constellationLineOpacity / 100);
+    constellationLinesGlobe = createConstellationBoundariesForGlobe(
+      constellationLineOpacity / 100,
+      sanitizedConstellationLineWidth
+    );
     constellationLinesGlobe.forEach(ln => globeMap.scene.add(ln));
-    constellationLinesMoll = createConstellationBoundariesForMollweide(constellationLineOpacity / 100);
+    constellationLinesMoll = createConstellationBoundariesForMollweide(
+      constellationLineOpacity / 100,
+      sanitizedConstellationLineWidth
+    );
     constellationLinesMoll.forEach(ln => { mollweideMap.scene.add(ln); applyStoredLineEdits(ln); });
   }
   if (showConstellationNames) {
@@ -638,6 +655,10 @@ async function buildAndApplyFilters() {
     constellationOverlayMoll.forEach(mesh => {
       mollweideMap.scene.add(mesh);
     });
+  }
+
+  if (mollweideMap && typeof mollweideMap.setMollweideBorderAppearance === 'function') {
+    mollweideMap.setMollweideBorderAppearance(sanitizedBorderWidth, sanitizedBorderOpacity / 100);
   }
 
   // --- Dust Clouds Overlay ---
@@ -986,6 +1007,7 @@ class MapManager {
       const mask = createMollweideMask(100);
       this.scene.add(mask);
       const border = createMollweideBorder(100);
+      this.mollweideBorder = border;
       this.scene.add(border);
     } else {
       this.controls = new ThreeDControls(this.camera, this.renderer.domElement);
@@ -1187,6 +1209,29 @@ class MapManager {
   setLabelOpacity(opacity) {
     this.labelOpacity = opacity;
     this.labelManager.setLabelOpacity(opacity);
+  }
+
+  setMollweideBorderAppearance(width, opacity) {
+    if (this.mapType !== 'Mollweide' || !this.mollweideBorder) return;
+    const border = this.mollweideBorder;
+    const sanitizedWidth = Math.max(0.1, width || 0);
+    const sanitizedOpacity = Math.max(0, Math.min(1, opacity !== undefined ? opacity : border.material.opacity));
+    if (Math.abs((border.userData.baseWidth || 0) - sanitizedWidth) > 1e-4) {
+      border.geometry.dispose();
+      border.geometry = buildWideLineGeometry(border.userData.points, sanitizedWidth);
+      border.userData.baseWidth = sanitizedWidth;
+      if (border.material) {
+        border.material.needsUpdate = true;
+      }
+    }
+    if (border.material) {
+      if (border.material.opacity !== sanitizedOpacity) {
+        border.material.opacity = sanitizedOpacity;
+        border.material.needsUpdate = true;
+      }
+    }
+    border.userData.baseOpacity = sanitizedOpacity;
+    if (window.requestRender) window.requestRender();
   }
 
   updateMap(stars, connectionObjs) {
@@ -1473,6 +1518,10 @@ function scaleMollweideSceneForExport(scale) {
       if (obj.userData.exportColor !== undefined && obj.material && obj.material.color) {
         obj.material.color.setHex(obj.userData.exportColor);
       }
+      if (obj.userData.baseOpacity !== undefined && obj.material) {
+        const opFactor = obj.userData.exportOpacityFactor || 1;
+        obj.material.opacity = Math.min(1, obj.userData.baseOpacity * opFactor);
+      }
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       let lwFactor = scale;
       if (obj.userData.exportLineWidthFactor) lwFactor *= obj.userData.exportLineWidthFactor;
@@ -1495,6 +1544,9 @@ function restoreMollweideScene(scale) {
       obj.geometry = buildWideLineGeometry(obj.userData.points, obj.userData.baseWidth);
       if (obj.userData.baseColor !== undefined && obj.material && obj.material.color) {
         obj.material.color.setHex(obj.userData.baseColor);
+      }
+      if (obj.userData.baseOpacity !== undefined && obj.material) {
+        obj.material.opacity = obj.userData.baseOpacity;
       }
     } else if (obj.userData && obj.userData.baseLineWidth !== undefined && obj.material && obj.material.linewidth !== undefined) {
       obj.material.linewidth = obj.userData.baseLineWidth;

--- a/ui/filterUI.js
+++ b/ui/filterUI.js
@@ -547,6 +547,29 @@ export function bindAdditionalOpacitySliders() {
     });
   }
 
+  const lineWidthSlider = document.getElementById('constellation-line-width-slider');
+  const lineWidthNumber = document.getElementById('constellation-line-width-number');
+  const lineWidthSpan = document.getElementById('constellation-line-width-value');
+  if (lineWidthSlider && lineWidthNumber && lineWidthSpan) {
+    const updateWidthDisplay = val => {
+      const clamped = Math.min(5, Math.max(0.1, val));
+      const display = clamped.toFixed(1);
+      lineWidthNumber.value = display;
+      lineWidthSpan.textContent = display;
+      return clamped;
+    };
+    lineWidthSlider.addEventListener('input', () => {
+      const current = parseFloat(lineWidthSlider.value);
+      const normalized = updateWidthDisplay(Number.isFinite(current) ? current : 1);
+      lineWidthSlider.value = normalized.toString();
+    });
+    lineWidthNumber.addEventListener('input', () => {
+      const current = parseFloat(lineWidthNumber.value);
+      const normalized = updateWidthDisplay(Number.isFinite(current) ? current : 1);
+      lineWidthSlider.value = normalized.toString();
+    });
+  }
+
   const nameOpSlider = document.getElementById('constellation-name-opacity-slider');
   const nameOpNumber = document.getElementById('constellation-name-opacity-number');
   const nameOpSpan = document.getElementById('constellation-name-opacity-value');
@@ -558,6 +581,43 @@ export function bindAdditionalOpacitySliders() {
     nameOpNumber.addEventListener('input', () => {
       nameOpSlider.value = nameOpNumber.value;
       nameOpSpan.textContent = nameOpNumber.value;
+    });
+  }
+
+  const borderWidthSlider = document.getElementById('mollweide-border-width-slider');
+  const borderWidthNumber = document.getElementById('mollweide-border-width-number');
+  const borderWidthSpan = document.getElementById('mollweide-border-width-value');
+  if (borderWidthSlider && borderWidthNumber && borderWidthSpan) {
+    const updateBorderWidthDisplay = val => {
+      const clamped = Math.min(10, Math.max(0.1, val));
+      const display = clamped.toFixed(1);
+      borderWidthNumber.value = display;
+      borderWidthSpan.textContent = display;
+      return clamped;
+    };
+    borderWidthSlider.addEventListener('input', () => {
+      const current = parseFloat(borderWidthSlider.value);
+      const normalized = updateBorderWidthDisplay(Number.isFinite(current) ? current : 1);
+      borderWidthSlider.value = normalized.toString();
+    });
+    borderWidthNumber.addEventListener('input', () => {
+      const current = parseFloat(borderWidthNumber.value);
+      const normalized = updateBorderWidthDisplay(Number.isFinite(current) ? current : 1);
+      borderWidthSlider.value = normalized.toString();
+    });
+  }
+
+  const borderOpacitySlider = document.getElementById('mollweide-border-opacity-slider');
+  const borderOpacityNumber = document.getElementById('mollweide-border-opacity-number');
+  const borderOpacitySpan = document.getElementById('mollweide-border-opacity-value');
+  if (borderOpacitySlider && borderOpacityNumber && borderOpacitySpan) {
+    borderOpacitySlider.addEventListener('input', () => {
+      borderOpacityNumber.value = borderOpacitySlider.value;
+      borderOpacitySpan.textContent = borderOpacitySlider.value;
+    });
+    borderOpacityNumber.addEventListener('input', () => {
+      borderOpacitySlider.value = borderOpacityNumber.value;
+      borderOpacitySpan.textContent = borderOpacityNumber.value;
     });
   }
 


### PR DESCRIPTION
## Summary
- add UI sliders to control constellation line width and Mollweide border opacity/width
- propagate constellation line opacity/width and border styling updates into the map and export pipeline
- clamp values and expose helpers so runtime and exports stay in sync with the new settings

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0be54b97c832a98dffaf1a8e9f3e7